### PR TITLE
chore: normalize tox work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 .codex/
 .tox/
 .tox-ci/
-.tox-phase3/
 build/
 dist/
 site/

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 env_list = lint, docs, py312, py313, py314, integration, package, preflight
 skip_missing_interpreters = true
 isolated_build = true
-work_dir = {tox_root}{/}.tox-phase3
+work_dir = {tox_root}{/}.tox
 
 [testenv]
 description = Run the fast deterministic unit suite through the bootstrapped Python environment


### PR DESCRIPTION
## Summary
- switch tox back to the stable `.tox` work directory instead of the phase-specific `.tox-phase3`
- remove the obsolete `.tox-phase3/` ignore entry so the repo only tracks the current tox convention
- keep this as a small prep change before the next Phase 4 feature work

## Validation
- `python -m tox -e preflight`
- `python -m tox -e lint`
- `python -m tox -e docs`