### PR TITLE
feat: add long-only and confidence-gated ranking strategy modes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ This document ties the current pieces together and records the working rules tha
   - walk-forward fold generation with additive guardrails, embargo controls, and skipped-fold diagnostics
   - model registry for configured estimators
   - walk-forward `train-models` execution and artifact generation
-  - score-to-weight ranking strategy for ML portfolios
+  - score-to-weight ranking strategies for ML portfolios, including long-short, long-only, and confidence-gated cash-underfilled variants
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
@@ -302,6 +302,9 @@ classDiagram
       +short_n: int
       +rebalance_frequency: str
       +weighting: str
+      +mode: str
+      +min_score_threshold: float
+      +cash_when_underfilled: bool
     }
 
     class CostsConfig {
@@ -653,13 +656,14 @@ Best practice:
 ### `src/marketlab/strategies/ranking.py`
 
 - Turns one model's fold predictions into a canonical `WeightsFrame`.
-- Ranks longs from the highest scores and shorts from the lowest scores with `symbol` as the deterministic tie-breaker.
-- Emits full-symbol weight rows with explicit zeros for non-selected names.
+- Supports `long_short` and `long_only` execution modes plus additive score-threshold gating.
+- Uses `symbol` as the deterministic tie-breaker for both long and short candidate ranking.
+- Emits full-symbol weight rows with explicit zeros for non-selected names and can either zero the full basket or leave missing exposure in cash when the basket is underfilled.
 - Adds zero-weight boundary rows at the next rebalance `effective_date` when a later fold does not already begin there.
 
 Best practice:
 - Keep ranking prediction-only; do not derive scores from the panel in this layer.
-- Keep the exposure policy explicit: `+0.5` total long, `-0.5` total short, gross exposure `1.0`.
+- Keep the exposure policy explicit: default `long_short` uses `+0.5` total long and `-0.5` total short, while `long_only` uses `+1.0` total long exposure with any missing slots left in cash only when configured.
 
 ### `src/marketlab/backtest/engine.py`
 
@@ -768,5 +772,6 @@ Best practice:
 - Do not batch multiple strategies into a single `run_backtest(...)` call.
 - Do not redesign the current data layer just to support later model abstractions.
 - Preserve the local launcher and E2E runner as the default developer entrypoints.
+
 
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ Calibration review is also additive to the existing evaluation surface. `calibra
 
 `model_metrics.csv` now adds fold-level `ece` and `max_calibration_gap`, while `model_summary.csv` and `fold_summary.csv` add `mean_ece` and `mean_max_calibration_gap`. When plots are enabled, `train-models` and `run-experiment` also write `calibration_curves.png`, `score_histograms.png`, and `threshold_sweeps.png`, and the experiment report includes a `Calibration And Threshold Diagnostics` section with compact calibration and threshold highlight tables. This PR remains evaluation-only: it does not recalibrate probabilities or change any strategy controls.
 
+## Ranking Strategy Modes
+
+`run-experiment` now supports additive execution controls under `portfolio.ranking`:
+
+- `mode`: `long_short` or `long_only`
+- `min_score_threshold`: minimum score required for long selection; in `long_short`, shorts require `score <= 1 - min_score_threshold`
+- `cash_when_underfilled`: when `true`, keep fixed per-slot weights for the names that pass and leave the missing exposure in cash instead of zeroing the whole basket
+
+Defaults remain backward-compatible:
+
+- `mode: long_short`
+- `min_score_threshold: 0.0`
+- `cash_when_underfilled: false`
+
+Execution semantics:
+
+- `long_short` keeps the existing equal-weight market-neutral construction with `+0.5` total long exposure and `-0.5` total short exposure when the basket is fully populated.
+- `long_only` allocates `+1.0 / long_n` per selected long and leaves all other names at `0.0`.
+- With `cash_when_underfilled: false`, any underfilled basket still falls back to an all-zero allocation for that rebalance.
+- With `cash_when_underfilled: true`, missing slots stay in cash and the selected names keep their fixed per-slot weights instead of being renormalized.
+
+Non-default ML strategy variants are named explicitly in experiment outputs, for example `ml_logistic_regression__long_only` or `ml_random_forest__long_short__thr0p60__cash`.
+
+This PR changes execution strategy behavior only. `train-models` keeps the issue #19 and #20 evaluation surface unchanged, so the ranking, calibration, and threshold diagnostics remain score-review artifacts rather than execution-mode-aware strategy artifacts.
 ## Environment
 
 - Python 3.12+
@@ -216,3 +240,4 @@ Before the first automated public release:
 - create the GitHub Actions environment named `pypi`
 
 The first automated public release target remains `v0.1.0`.
+

--- a/configs/experiment.weekly_rank.smoke.yaml
+++ b/configs/experiment.weekly_rank.smoke.yaml
@@ -24,6 +24,9 @@ portfolio:
     short_n: 2
     rebalance_frequency: "W-FRI"
     weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
   costs:
     bps_per_trade: 10
 
@@ -55,5 +58,6 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
+
 
 

--- a/configs/experiment.weekly_rank.yaml
+++ b/configs/experiment.weekly_rank.yaml
@@ -24,6 +24,9 @@ portfolio:
     short_n: 2
     rebalance_frequency: "W-FRI"
     weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
   costs:
     bps_per_trade: 10
 
@@ -55,5 +58,6 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
+
 
 

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,6 +39,9 @@ class RankingConfig:
     short_n: int = 2
     rebalance_frequency: str = "W-FRI"
     weighting: str = "equal"
+    mode: str = "long_short"
+    min_score_threshold: float = 0.0
+    cash_when_underfilled: bool = False
 
 
 @dataclass(slots=True)
@@ -184,4 +187,5 @@ def load_config(path: str | Path) -> ExperimentConfig:
         base_dir=_config_base_dir(config_path),
     )
     return config
+
 

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -374,6 +374,9 @@ def _run_ml_strategies(
             short_n=config.portfolio.ranking.short_n,
             frequency=config.portfolio.ranking.rebalance_frequency,
             weighting=config.portfolio.ranking.weighting,
+            mode=config.portfolio.ranking.mode,
+            min_score_threshold=config.portfolio.ranking.min_score_threshold,
+            cash_when_underfilled=config.portfolio.ranking.cash_when_underfilled,
         )
         performance_frames.append(
             run_backtest(
@@ -595,3 +598,4 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         score_histograms=training_outputs.score_histograms,
         threshold_diagnostics=training_outputs.threshold_diagnostics,
     )
+

--- a/src/marketlab/resources/config_templates/weekly_rank.yaml
+++ b/src/marketlab/resources/config_templates/weekly_rank.yaml
@@ -24,6 +24,9 @@ portfolio:
     short_n: 2
     rebalance_frequency: "W-FRI"
     weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
   costs:
     bps_per_trade: 10
 
@@ -55,3 +58,4 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
+

--- a/src/marketlab/resources/config_templates/weekly_rank_smoke.yaml
+++ b/src/marketlab/resources/config_templates/weekly_rank_smoke.yaml
@@ -24,6 +24,9 @@ portfolio:
     short_n: 2
     rebalance_frequency: "W-FRI"
     weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
   costs:
     bps_per_trade: 10
 
@@ -55,3 +58,4 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
+

--- a/src/marketlab/strategies/ranking.py
+++ b/src/marketlab/strategies/ranking.py
@@ -14,6 +14,7 @@ REQUIRED_PREDICTION_COLUMNS = {
 }
 REQUIRED_PANEL_COLUMNS = {"symbol", "timestamp"}
 WEIGHTS_COLUMNS = ["strategy", "effective_date", "symbol", "weight"]
+VALID_MODES = {"long_only", "long_short"}
 
 
 def _validate_predictions(predictions: pd.DataFrame) -> pd.DataFrame:
@@ -53,6 +54,48 @@ def _validate_panel(panel: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
     return working, sorted(working["symbol"].drop_duplicates().tolist())
 
 
+def _validate_mode(mode: str) -> str:
+    if mode not in VALID_MODES:
+        joined = ", ".join(sorted(VALID_MODES))
+        raise ValueError(f"Ranking mode must be one of: {joined}.")
+    return mode
+
+
+def _validate_threshold(min_score_threshold: float) -> float:
+    if not 0.0 <= min_score_threshold <= 1.0:
+        raise ValueError("Ranking min_score_threshold must be between 0.0 and 1.0.")
+    return float(min_score_threshold)
+
+
+def _strategy_threshold_token(min_score_threshold: float) -> str:
+    threshold_text = f"{min_score_threshold:.6f}".rstrip("0")
+    if threshold_text.endswith("."):
+        threshold_text += "0"
+    if "." in threshold_text and len(threshold_text.split(".", maxsplit=1)[1]) == 1:
+        threshold_text += "0"
+    if "." not in threshold_text:
+        threshold_text += ".00"
+    return threshold_text.replace(".", "p")
+
+
+def _strategy_name(
+    model_name: str,
+    mode: str,
+    min_score_threshold: float,
+    cash_when_underfilled: bool,
+) -> str:
+    base_name = f"ml_{model_name}"
+    if mode == "long_short" and min_score_threshold == 0.0 and not cash_when_underfilled:
+        return base_name
+
+    parts = [base_name, mode]
+    if min_score_threshold > 0.0:
+        parts.append(f"thr{_strategy_threshold_token(min_score_threshold)}")
+    if cash_when_underfilled:
+        parts.append("cash")
+    return "__".join(parts)
+
+
 def _zero_weight_frame(
     strategy_name: str,
     effective_date: pd.Timestamp,
@@ -68,28 +111,36 @@ def _zero_weight_frame(
     )
 
 
-def _rank_signal_rows(
-    signal_rows: pd.DataFrame,
+def _weight_frame(
     strategy_name: str,
+    effective_date: pd.Timestamp,
     symbols: list[str],
+    long_symbols: list[str],
+    short_symbols: list[str],
+    *,
+    mode: str,
     long_n: int,
     short_n: int,
+    cash_when_underfilled: bool,
 ) -> pd.DataFrame:
-    effective_dates = signal_rows["effective_date"].drop_duplicates().tolist()
-    if len(effective_dates) != 1:
-        raise ValueError("Ranking predictions must map each signal date to exactly one effective date.")
-    effective_date = pd.Timestamp(effective_dates[0])
+    if mode == "long_only":
+        if len(long_symbols) != long_n and not cash_when_underfilled:
+            return _zero_weight_frame(strategy_name, effective_date, symbols)
 
-    long_candidates = signal_rows.sort_values(["score", "symbol"], ascending=[False, True])
-    long_symbols = long_candidates["symbol"].head(long_n).tolist()
+        weights = {symbol: 0.0 for symbol in symbols}
+        long_weight = 1.0 / float(long_n)
+        for symbol in long_symbols:
+            weights[symbol] = long_weight
+        return pd.DataFrame(
+            {
+                "strategy": strategy_name,
+                "effective_date": effective_date,
+                "symbol": symbols,
+                "weight": [weights[symbol] for symbol in symbols],
+            }
+        )
 
-    short_candidates = signal_rows.loc[~signal_rows["symbol"].isin(long_symbols)].sort_values(
-        ["score", "symbol"],
-        ascending=[True, True],
-    )
-    short_symbols = short_candidates["symbol"].head(short_n).tolist()
-
-    if len(long_symbols) != long_n or len(short_symbols) != short_n:
+    if (len(long_symbols) != long_n or len(short_symbols) != short_n) and not cash_when_underfilled:
         return _zero_weight_frame(strategy_name, effective_date, symbols)
 
     weights = {symbol: 0.0 for symbol in symbols}
@@ -107,6 +158,63 @@ def _rank_signal_rows(
             "symbol": symbols,
             "weight": [weights[symbol] for symbol in symbols],
         }
+    )
+
+
+def _rank_signal_rows(
+    signal_rows: pd.DataFrame,
+    strategy_name: str,
+    symbols: list[str],
+    long_n: int,
+    short_n: int,
+    *,
+    mode: str,
+    min_score_threshold: float,
+    cash_when_underfilled: bool,
+) -> pd.DataFrame:
+    effective_dates = signal_rows["effective_date"].drop_duplicates().tolist()
+    if len(effective_dates) != 1:
+        raise ValueError("Ranking predictions must map each signal date to exactly one effective date.")
+    effective_date = pd.Timestamp(effective_dates[0])
+
+    long_candidates = signal_rows.loc[signal_rows["score"] >= min_score_threshold].sort_values(
+        ["score", "symbol"],
+        ascending=[False, True],
+    )
+    long_symbols = long_candidates["symbol"].head(long_n).tolist()
+
+    if mode == "long_only":
+        return _weight_frame(
+            strategy_name,
+            effective_date,
+            symbols,
+            long_symbols,
+            [],
+            mode=mode,
+            long_n=long_n,
+            short_n=short_n,
+            cash_when_underfilled=cash_when_underfilled,
+        )
+
+    short_threshold = 1.0 - min_score_threshold
+    short_candidates = signal_rows.loc[
+        (~signal_rows["symbol"].isin(long_symbols)) & (signal_rows["score"] <= short_threshold)
+    ].sort_values(
+        ["score", "symbol"],
+        ascending=[True, True],
+    )
+    short_symbols = short_candidates["symbol"].head(short_n).tolist()
+
+    return _weight_frame(
+        strategy_name,
+        effective_date,
+        symbols,
+        long_symbols,
+        short_symbols,
+        mode=mode,
+        long_n=long_n,
+        short_n=short_n,
+        cash_when_underfilled=cash_when_underfilled,
     )
 
 
@@ -145,9 +253,16 @@ def generate_weights(
     short_n: int,
     frequency: str = "W-FRI",
     weighting: str = "equal",
+    mode: str = "long_short",
+    min_score_threshold: float = 0.0,
+    cash_when_underfilled: bool = False,
 ) -> pd.DataFrame:
-    if long_n < 1 or short_n < 1:
-        raise ValueError("long_n and short_n must both be at least 1.")
+    mode = _validate_mode(mode)
+    min_score_threshold = _validate_threshold(min_score_threshold)
+    if long_n < 1:
+        raise ValueError("long_n must be at least 1.")
+    if mode == "long_short" and short_n < 1:
+        raise ValueError("short_n must be at least 1 for long_short mode.")
     if weighting != "equal":
         raise ValueError("Ranking weighting='equal' only in Phase 2.")
     if predictions.empty:
@@ -158,7 +273,12 @@ def generate_weights(
     if not symbols:
         return pd.DataFrame(columns=WEIGHTS_COLUMNS)
 
-    strategy_name = f"ml_{working_predictions['model_name'].iat[0]}"
+    strategy_name = _strategy_name(
+        model_name=str(working_predictions["model_name"].iat[0]),
+        mode=mode,
+        min_score_threshold=min_score_threshold,
+        cash_when_underfilled=cash_when_underfilled,
+    )
     weight_frames = [
         _rank_signal_rows(
             signal_rows=signal_rows,
@@ -166,6 +286,9 @@ def generate_weights(
             symbols=symbols,
             long_n=long_n,
             short_n=short_n,
+            mode=mode,
+            min_score_threshold=min_score_threshold,
+            cash_when_underfilled=cash_when_underfilled,
         )
         for (_, _), signal_rows in working_predictions.groupby(["signal_date", "effective_date"], sort=True)
     ]

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -49,6 +49,7 @@ def _write_run_experiment_config(
     tmp_path: Path,
     *,
     walk_forward: dict[str, int | float] | None = None,
+    ranking: dict[str, object] | None = None,
 ) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(
@@ -73,6 +74,17 @@ def _write_run_experiment_config(
     if walk_forward is not None:
         walk_forward_payload.update(walk_forward)
 
+    ranking_payload: dict[str, object] = {
+        "long_n": 2,
+        "short_n": 2,
+        "rebalance_frequency": "W-FRI",
+        "weighting": "equal",
+        "mode": "long_short",
+        "min_score_threshold": 0.0,
+        "cash_when_underfilled": False,
+    }
+    if ranking is not None:
+        ranking_payload.update(ranking)
     return write_yaml_config(
         tmp_path / "integration.yaml",
         {
@@ -96,12 +108,7 @@ def _write_run_experiment_config(
                 "type": "direction",
             },
             "portfolio": {
-                "ranking": {
-                    "long_n": 2,
-                    "short_n": 2,
-                    "rebalance_frequency": "W-FRI",
-                    "weighting": "equal",
-                },
+                "ranking": ranking_payload,
                 "costs": {"bps_per_trade": 10},
             },
             "baselines": {
@@ -359,3 +366,63 @@ def test_backtest_remains_baseline_only(tmp_path: Path) -> None:
     assert not (run_dir / "calibration_curves.png").exists()
     assert not (run_dir / "score_histograms.png").exists()
     assert not (run_dir / "threshold_sweeps.png").exists()
+
+
+def test_run_experiment_supports_long_only_strategy_variants(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        ranking={"mode": "long_only"},
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    performance = pd.read_csv(run_dir / "performance.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    expected_strategies = {
+        "buy_hold",
+        "sma",
+        "ml_logistic_regression__long_only",
+        "ml_random_forest__long_only",
+    }
+    assert set(metrics["strategy"]) == expected_strategies
+    assert set(performance["strategy"]) == expected_strategies
+    assert set(strategy_summary["strategy"]) == expected_strategies
+    assert "ml_logistic_regression__long_only" in report_text
+
+
+def test_run_experiment_supports_gated_cash_strategy_variants(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        ranking={
+            "mode": "long_short",
+            "min_score_threshold": 0.99,
+            "cash_when_underfilled": True,
+        },
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    performance = pd.read_csv(run_dir / "performance.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    expected_strategies = {
+        "buy_hold",
+        "sma",
+        "ml_logistic_regression__long_short__thr0p99__cash",
+        "ml_random_forest__long_short__thr0p99__cash",
+    }
+    assert set(metrics["strategy"]) == expected_strategies
+    assert set(performance["strategy"]) == expected_strategies
+    assert set(strategy_summary["strategy"]) == expected_strategies
+    assert "ml_logistic_regression__long_short__thr0p99__cash" in report_text

--- a/tests/integration/test_train_models.py
+++ b/tests/integration/test_train_models.py
@@ -49,6 +49,7 @@ def _write_config(
     *,
     models: list[dict[str, str]],
     walk_forward: dict[str, int | float] | None = None,
+    ranking: dict[str, object] | None = None,
 ) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(
@@ -72,6 +73,17 @@ def _write_config(
     if walk_forward is not None:
         walk_forward_payload.update(walk_forward)
 
+    ranking_payload: dict[str, object] = {
+        "long_n": 2,
+        "short_n": 2,
+        "rebalance_frequency": "W-FRI",
+        "weighting": "equal",
+        "mode": "long_short",
+        "min_score_threshold": 0.0,
+        "cash_when_underfilled": False,
+    }
+    if ranking is not None:
+        ranking_payload.update(ranking)
     return write_yaml_config(
         tmp_path / "train_models.yaml",
         {
@@ -95,9 +107,7 @@ def _write_config(
                 "type": "direction",
             },
             "portfolio": {
-                "ranking": {
-                    "rebalance_frequency": "W-FRI",
-                }
+                "ranking": ranking_payload,
             },
             "models": models,
             "evaluation": {
@@ -251,3 +261,28 @@ def test_train_models_surfaces_unsupported_model_name(tmp_path: Path) -> None:
     assert result.returncode != 0
     combined_output = f"{result.stdout}\n{result.stderr}"
     assert "Unsupported model 'not_real'" in combined_output
+
+
+def test_train_models_keeps_existing_artifact_contract_with_strategy_mode_fields(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        ranking={
+            "mode": "long_only",
+            "min_score_threshold": 0.8,
+            "cash_when_underfilled": True,
+        },
+    )
+
+    result = run_marketlab_cli("train-models", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_train_models"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "model_metrics.csv")
+    ranking_diagnostics = pd.read_csv(run_dir / "ranking_diagnostics.csv")
+    model_summary = pd.read_csv(run_dir / "model_summary.csv")
+
+    assert list(metrics.columns) == MODEL_METRICS_COLUMNS
+    assert list(model_summary.columns) == MODEL_SUMMARY_COLUMNS
+    assert set(ranking_diagnostics["model_name"]) == {"logistic_regression"}

--- a/tests/unit/test_ranking.py
+++ b/tests/unit/test_ranking.py
@@ -16,18 +16,34 @@ def _panel(symbols: list[str]) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def test_ranking_generates_market_neutral_weights_with_symbol_tiebreaks() -> None:
-    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
-    predictions = pd.DataFrame(
+def _predictions(
+    symbols: list[str],
+    scores: list[float],
+    *,
+    fold_ids: list[int] | None = None,
+    signal_dates: list[pd.Timestamp] | None = None,
+    effective_dates: list[pd.Timestamp] | None = None,
+) -> pd.DataFrame:
+    row_count = len(symbols)
+    return pd.DataFrame(
         {
-            "model_name": ["logistic_regression"] * 4,
-            "fold_id": [0] * 4,
-            "signal_date": [pd.Timestamp("2024-01-05")] * 4,
-            "effective_date": [pd.Timestamp("2024-01-08")] * 4,
-            "symbol": ["AAA", "BBB", "CCC", "DDD"],
-            "score": [0.9, 0.9, 0.1, 0.2],
+            "model_name": ["logistic_regression"] * row_count,
+            "fold_id": fold_ids or ([0] * row_count),
+            "signal_date": signal_dates or ([pd.Timestamp("2024-01-05")] * row_count),
+            "effective_date": effective_dates or ([pd.Timestamp("2024-01-08")] * row_count),
+            "symbol": symbols,
+            "score": scores,
         }
     )
+
+
+def _rebalance(weights: pd.DataFrame, effective_date: str) -> pd.DataFrame:
+    return weights.loc[weights["effective_date"] == pd.Timestamp(effective_date)].reset_index(drop=True)
+
+
+def test_ranking_generates_default_market_neutral_weights_with_symbol_tiebreaks() -> None:
+    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
+    predictions = _predictions(["AAA", "BBB", "CCC", "DDD"], [0.9, 0.9, 0.1, 0.2])
 
     weights = generate_weights(
         predictions=predictions,
@@ -36,7 +52,9 @@ def test_ranking_generates_market_neutral_weights_with_symbol_tiebreaks() -> Non
         short_n=2,
     )
 
-    rebalance = weights.loc[weights["effective_date"] == pd.Timestamp("2024-01-08")]
+    rebalance = _rebalance(weights, "2024-01-08")
+    assert rebalance["strategy"].nunique() == 1
+    assert rebalance["strategy"].iat[0] == "ml_logistic_regression"
     assert rebalance["symbol"].tolist() == ["AAA", "BBB", "CCC", "DDD"]
     assert rebalance.loc[rebalance["symbol"].isin(["AAA", "BBB"]), "weight"].tolist() == [
         pytest.approx(0.25),
@@ -49,42 +67,106 @@ def test_ranking_generates_market_neutral_weights_with_symbol_tiebreaks() -> Non
     assert rebalance["weight"].sum() == pytest.approx(0.0)
 
 
-def test_ranking_falls_back_to_zero_weights_when_sides_cannot_be_filled() -> None:
-    panel = _panel(["AAA", "BBB", "CCC"])
-    predictions = pd.DataFrame(
-        {
-            "model_name": ["logistic_regression"] * 3,
-            "fold_id": [0] * 3,
-            "signal_date": [pd.Timestamp("2024-01-05")] * 3,
-            "effective_date": [pd.Timestamp("2024-01-08")] * 3,
-            "symbol": ["AAA", "BBB", "CCC"],
-            "score": [0.9, 0.8, 0.1],
-        }
-    )
+def test_ranking_generates_long_only_weights() -> None:
+    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
+    predictions = _predictions(["AAA", "BBB", "CCC", "DDD"], [0.95, 0.85, 0.3, 0.2])
 
     weights = generate_weights(
         predictions=predictions,
         panel=panel,
         long_n=2,
         short_n=2,
+        mode="long_only",
     )
 
-    assert weights["weight"].eq(0.0).all()
+    rebalance = _rebalance(weights, "2024-01-08")
+    assert rebalance["strategy"].iat[0] == "ml_logistic_regression__long_only"
+    assert rebalance.loc[rebalance["symbol"].isin(["AAA", "BBB"]), "weight"].tolist() == [
+        pytest.approx(0.5),
+        pytest.approx(0.5),
+    ]
+    assert rebalance.loc[rebalance["symbol"].isin(["CCC", "DDD"]), "weight"].tolist() == [
+        pytest.approx(0.0),
+        pytest.approx(0.0),
+    ]
+    assert rebalance["weight"].sum() == pytest.approx(1.0)
+
+
+def test_ranking_applies_symmetric_threshold_gating_in_long_short_mode() -> None:
+    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
+    predictions = _predictions(["AAA", "BBB", "CCC", "DDD"], [0.95, 0.85, 0.15, 0.05])
+
+    weights = generate_weights(
+        predictions=predictions,
+        panel=panel,
+        long_n=1,
+        short_n=1,
+        mode="long_short",
+        min_score_threshold=0.9,
+    )
+
+    rebalance = _rebalance(weights, "2024-01-08")
+    assert rebalance["strategy"].iat[0] == "ml_logistic_regression__long_short__thr0p90"
+    assert rebalance.loc[rebalance["symbol"] == "AAA", "weight"].iat[0] == pytest.approx(0.5)
+    assert rebalance.loc[rebalance["symbol"] == "DDD", "weight"].iat[0] == pytest.approx(-0.5)
+    assert rebalance.loc[rebalance["symbol"].isin(["BBB", "CCC"]), "weight"].tolist() == [
+        pytest.approx(0.0),
+        pytest.approx(0.0),
+    ]
+
+
+def test_ranking_preserves_partial_book_as_cash_when_enabled() -> None:
+    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
+    predictions = _predictions(["AAA", "BBB", "CCC", "DDD"], [0.95, 0.85, 0.45, 0.35])
+
+    weights = generate_weights(
+        predictions=predictions,
+        panel=panel,
+        long_n=2,
+        short_n=2,
+        mode="long_short",
+        min_score_threshold=0.8,
+        cash_when_underfilled=True,
+    )
+
+    rebalance = _rebalance(weights, "2024-01-08")
+    assert rebalance["strategy"].iat[0] == "ml_logistic_regression__long_short__thr0p80__cash"
+    assert rebalance.loc[rebalance["symbol"].isin(["AAA", "BBB"]), "weight"].tolist() == [
+        pytest.approx(0.25),
+        pytest.approx(0.25),
+    ]
+    assert rebalance.loc[rebalance["symbol"].isin(["CCC", "DDD"]), "weight"].tolist() == [
+        pytest.approx(0.0),
+        pytest.approx(0.0),
+    ]
+    assert rebalance["weight"].sum() == pytest.approx(0.5)
+
+
+def test_ranking_falls_back_to_zero_weights_when_underfilled_cash_is_disabled() -> None:
+    panel = _panel(["AAA", "BBB", "CCC", "DDD"])
+    predictions = _predictions(["AAA", "BBB", "CCC", "DDD"], [0.95, 0.85, 0.45, 0.35])
+
+    weights = generate_weights(
+        predictions=predictions,
+        panel=panel,
+        long_n=2,
+        short_n=2,
+        mode="long_short",
+        min_score_threshold=0.8,
+        cash_when_underfilled=False,
+    )
+
+    rebalance = _rebalance(weights, "2024-01-08")
+    assert rebalance["weight"].eq(0.0).all()
 
 
 def test_ranking_adds_zero_boundary_rows_at_next_rebalance_effective_date() -> None:
     panel = _panel(["AAA", "BBB", "CCC", "DDD"])
-    predictions = pd.DataFrame(
-        {
-            "model_name": ["logistic_regression"] * 8,
-            "fold_id": [0] * 8,
-            "signal_date": [pd.Timestamp("2024-01-05")] * 4
-            + [pd.Timestamp("2024-01-12")] * 4,
-            "effective_date": [pd.Timestamp("2024-01-08")] * 4
-            + [pd.Timestamp("2024-01-15")] * 4,
-            "symbol": ["AAA", "BBB", "CCC", "DDD"] * 2,
-            "score": [0.9, 0.8, 0.2, 0.1] * 2,
-        }
+    predictions = _predictions(
+        ["AAA", "BBB", "CCC", "DDD"] * 2,
+        [0.9, 0.8, 0.2, 0.1] * 2,
+        signal_dates=[pd.Timestamp("2024-01-05")] * 4 + [pd.Timestamp("2024-01-12")] * 4,
+        effective_dates=[pd.Timestamp("2024-01-08")] * 4 + [pd.Timestamp("2024-01-15")] * 4,
     )
 
     weights = generate_weights(
@@ -95,27 +177,23 @@ def test_ranking_adds_zero_boundary_rows_at_next_rebalance_effective_date() -> N
     )
 
     assert pd.Timestamp("2024-01-16") not in set(weights["effective_date"])
-    boundary = weights.loc[weights["effective_date"] == pd.Timestamp("2024-01-22")]
+    boundary = _rebalance(weights, "2024-01-22")
     assert len(boundary) == 4
     assert boundary["weight"].eq(0.0).all()
 
 
-
 def test_ranking_skips_boundary_zero_rows_when_next_fold_starts_there() -> None:
     panel = _panel(["AAA", "BBB", "CCC", "DDD"])
-    predictions = pd.DataFrame(
-        {
-            "model_name": ["logistic_regression"] * 12,
-            "fold_id": [0] * 8 + [1] * 4,
-            "signal_date": [pd.Timestamp("2024-01-05")] * 4
-            + [pd.Timestamp("2024-01-12")] * 4
-            + [pd.Timestamp("2024-01-19")] * 4,
-            "effective_date": [pd.Timestamp("2024-01-08")] * 4
-            + [pd.Timestamp("2024-01-15")] * 4
-            + [pd.Timestamp("2024-01-22")] * 4,
-            "symbol": ["AAA", "BBB", "CCC", "DDD"] * 3,
-            "score": [0.9, 0.8, 0.2, 0.1] * 3,
-        }
+    predictions = _predictions(
+        ["AAA", "BBB", "CCC", "DDD"] * 3,
+        [0.9, 0.8, 0.2, 0.1] * 3,
+        fold_ids=[0] * 8 + [1] * 4,
+        signal_dates=[pd.Timestamp("2024-01-05")] * 4
+        + [pd.Timestamp("2024-01-12")] * 4
+        + [pd.Timestamp("2024-01-19")] * 4,
+        effective_dates=[pd.Timestamp("2024-01-08")] * 4
+        + [pd.Timestamp("2024-01-15")] * 4
+        + [pd.Timestamp("2024-01-22")] * 4,
     )
 
     weights = generate_weights(
@@ -126,6 +204,6 @@ def test_ranking_skips_boundary_zero_rows_when_next_fold_starts_there() -> None:
     )
 
     assert not weights.duplicated(subset=["effective_date", "symbol"]).any()
-    jan_22 = weights.loc[weights["effective_date"] == pd.Timestamp("2024-01-22")]
+    jan_22 = _rebalance(weights, "2024-01-22")
     assert not jan_22.empty
     assert not jan_22["weight"].eq(0.0).all()


### PR DESCRIPTION
## Summary
- add `portfolio.ranking` controls for `mode`, `min_score_threshold`, and `cash_when_underfilled`
- support long-only and confidence-gated ranking weights while preserving the default long-short path
- keep the `train-models` evaluation artifact surface unchanged and carry variant strategy names through `run-experiment` outputs

## Validation
- `python -m tox -e preflight`

Closes #21