### PR TITLE
feat: add lightweight sklearn comparison models

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -634,6 +634,7 @@ Best practice:
 - Keeps target-type validation at the model-entry seam.
 - Produces normalized direction scores from `predict_proba` for downstream ranking work.
 - Exposes a pure evaluation helper layer that derives classification, ranking, and downside diagnostics without changing model fitting.
+- The default comparison set now includes six sklearn-only classifiers: `logistic_regression`, `logistic_l1`, `random_forest`, `extra_trees`, `gradient_boosting`, and `hist_gradient_boosting`.
 
 Best practice:
 - Keep the registry lightweight and explicit.
@@ -772,6 +773,4 @@ Best practice:
 - Do not batch multiple strategies into a single `run_backtest(...)` call.
 - Do not redesign the current data layer just to support later model abstractions.
 - Preserve the local launcher and E2E runner as the default developer entrypoints.
-
-
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ Execution semantics:
 Non-default ML strategy variants are named explicitly in experiment outputs, for example `ml_logistic_regression__long_only` or `ml_random_forest__long_short__thr0p60__cash`.
 
 This PR changes execution strategy behavior only. `train-models` keeps the issue #19 and #20 evaluation surface unchanged, so the ranking, calibration, and threshold diagnostics remain score-review artifacts rather than execution-mode-aware strategy artifacts.
+
+## Lightweight Model Comparison Set
+
+The default weekly configs now compare six sklearn-only direction classifiers:
+
+- `logistic_regression`
+- `logistic_l1`
+- `random_forest`
+- `extra_trees`
+- `gradient_boosting`
+- `hist_gradient_boosting`
+
+This wave deliberately stays lightweight. It broadens the comparison baseline without adding external booster dependencies, model-specific pipeline branching, or tuning knobs.
 ## Environment
 
 - Python 3.12+

--- a/configs/experiment.weekly_rank.smoke.yaml
+++ b/configs/experiment.weekly_rank.smoke.yaml
@@ -39,8 +39,11 @@ baselines:
 
 models:
   - name: logistic_regression
+  - name: logistic_l1
   - name: random_forest
+  - name: extra_trees
   - name: gradient_boosting
+  - name: hist_gradient_boosting
 
 evaluation:
   walk_forward:
@@ -58,6 +61,4 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
-
-
 

--- a/configs/experiment.weekly_rank.yaml
+++ b/configs/experiment.weekly_rank.yaml
@@ -39,8 +39,11 @@ baselines:
 
 models:
   - name: logistic_regression
+  - name: logistic_l1
   - name: random_forest
+  - name: extra_trees
   - name: gradient_boosting
+  - name: hist_gradient_boosting
 
 evaluation:
   walk_forward:
@@ -58,6 +61,4 @@ artifacts:
   save_metrics_csv: true
   save_report_md: true
   save_plots: true
-
-
 

--- a/src/marketlab/models/registry.py
+++ b/src/marketlab/models/registry.py
@@ -5,7 +5,12 @@ from typing import Callable
 
 import pandas as pd
 from sklearn.base import ClassifierMixin
-from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    GradientBoostingClassifier,
+    HistGradientBoostingClassifier,
+    RandomForestClassifier,
+)
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
@@ -29,8 +34,28 @@ def _logistic_regression() -> ClassifierMixin:
     )
 
 
+def _logistic_l1() -> ClassifierMixin:
+    return make_pipeline(
+        StandardScaler(),
+        LogisticRegression(
+            penalty="l1",
+            solver="liblinear",
+            max_iter=1000,
+            random_state=7,
+        ),
+    )
+
+
 def _random_forest() -> ClassifierMixin:
     return RandomForestClassifier(
+        n_estimators=200,
+        min_samples_leaf=3,
+        random_state=7,
+    )
+
+
+def _extra_trees() -> ClassifierMixin:
+    return ExtraTreesClassifier(
         n_estimators=200,
         min_samples_leaf=3,
         random_state=7,
@@ -41,7 +66,21 @@ def _gradient_boosting() -> ClassifierMixin:
     return GradientBoostingClassifier(random_state=7)
 
 
+def _hist_gradient_boosting() -> ClassifierMixin:
+    return HistGradientBoostingClassifier(random_state=7)
+
+
 MODEL_REGISTRY: dict[str, ModelDefinition] = {
+    "extra_trees": ModelDefinition(
+        name="extra_trees",
+        estimator_label="ExtraTreesClassifier",
+        builder=_extra_trees,
+    ),
+    "logistic_l1": ModelDefinition(
+        name="logistic_l1",
+        estimator_label="LogisticRegression",
+        builder=_logistic_l1,
+    ),
     "logistic_regression": ModelDefinition(
         name="logistic_regression",
         estimator_label="LogisticRegression",
@@ -56,6 +95,11 @@ MODEL_REGISTRY: dict[str, ModelDefinition] = {
         name="gradient_boosting",
         estimator_label="GradientBoostingClassifier",
         builder=_gradient_boosting,
+    ),
+    "hist_gradient_boosting": ModelDefinition(
+        name="hist_gradient_boosting",
+        estimator_label="HistGradientBoostingClassifier",
+        builder=_hist_gradient_boosting,
     ),
 }
 

--- a/src/marketlab/resources/config_templates/weekly_rank.yaml
+++ b/src/marketlab/resources/config_templates/weekly_rank.yaml
@@ -39,8 +39,11 @@ baselines:
 
 models:
   - name: logistic_regression
+  - name: logistic_l1
   - name: random_forest
+  - name: extra_trees
   - name: gradient_boosting
+  - name: hist_gradient_boosting
 
 evaluation:
   walk_forward:

--- a/src/marketlab/resources/config_templates/weekly_rank_smoke.yaml
+++ b/src/marketlab/resources/config_templates/weekly_rank_smoke.yaml
@@ -39,8 +39,11 @@ baselines:
 
 models:
   - name: logistic_regression
+  - name: logistic_l1
   - name: random_forest
+  - name: extra_trees
   - name: gradient_boosting
+  - name: hist_gradient_boosting
 
 evaluation:
   walk_forward:

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -44,6 +44,15 @@ PERFORMANCE_COLUMNS = [
     "equity",
 ]
 
+DEFAULT_MODEL_NAMES = {
+    "extra_trees",
+    "gradient_boosting",
+    "hist_gradient_boosting",
+    "logistic_l1",
+    "logistic_regression",
+    "random_forest",
+}
+
 
 def _write_run_experiment_config(
     tmp_path: Path,
@@ -117,7 +126,11 @@ def _write_run_experiment_config(
             },
             "models": [
                 {"name": "logistic_regression"},
+                {"name": "logistic_l1"},
                 {"name": "random_forest"},
+                {"name": "extra_trees"},
+                {"name": "gradient_boosting"},
+                {"name": "hist_gradient_boosting"},
             ],
             "evaluation": {
                 "walk_forward": walk_forward_payload,
@@ -224,7 +237,11 @@ def test_run_experiment_produces_baseline_and_ml_artifacts(tmp_path: Path) -> No
         "buy_hold",
         "sma",
         "ml_logistic_regression",
+        "ml_logistic_l1",
         "ml_random_forest",
+        "ml_extra_trees",
+        "ml_gradient_boosting",
+        "ml_hist_gradient_boosting",
     }
     assert list(metrics.columns) == EXPECTED_METRICS_COLUMNS
     assert list(performance.columns) == PERFORMANCE_COLUMNS
@@ -243,11 +260,11 @@ def test_run_experiment_produces_baseline_and_ml_artifacts(tmp_path: Path) -> No
     assert set(strategy_summary["strategy"]) == expected_strategies
     assert set(monthly_returns["strategy"]) == expected_strategies
     assert set(turnover_costs["strategy"]) == expected_strategies
-    assert set(model_summary["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(ranking_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(calibration_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(score_histograms["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(threshold_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
+    assert set(model_summary["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(ranking_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(calibration_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(score_histograms["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(threshold_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
     assert not fold_diagnostics.empty
     assert not ranking_diagnostics.empty
     assert not calibration_diagnostics.empty
@@ -282,6 +299,10 @@ def test_run_experiment_produces_baseline_and_ml_artifacts(tmp_path: Path) -> No
     assert "## Calibration And Threshold Diagnostics" in report_text
     assert "Phase 2 baseline plus ML experiment" in report_text
     assert "ml_logistic_regression" in report_text
+    assert "ml_logistic_l1" in report_text
+    assert "ml_extra_trees" in report_text
+    assert "ml_gradient_boosting" in report_text
+    assert "ml_hist_gradient_boosting" in report_text
     assert "- Used candidates:" in report_text
     assert "- Skipped candidates:" in report_text
     assert "- Best model by mean ROC AUC:" in report_text
@@ -388,12 +409,17 @@ def test_run_experiment_supports_long_only_strategy_variants(tmp_path: Path) -> 
         "buy_hold",
         "sma",
         "ml_logistic_regression__long_only",
+        "ml_logistic_l1__long_only",
         "ml_random_forest__long_only",
+        "ml_extra_trees__long_only",
+        "ml_gradient_boosting__long_only",
+        "ml_hist_gradient_boosting__long_only",
     }
     assert set(metrics["strategy"]) == expected_strategies
     assert set(performance["strategy"]) == expected_strategies
     assert set(strategy_summary["strategy"]) == expected_strategies
     assert "ml_logistic_regression__long_only" in report_text
+    assert "ml_logistic_l1__long_only" in report_text
 
 
 def test_run_experiment_supports_gated_cash_strategy_variants(tmp_path: Path) -> None:
@@ -420,9 +446,14 @@ def test_run_experiment_supports_gated_cash_strategy_variants(tmp_path: Path) ->
         "buy_hold",
         "sma",
         "ml_logistic_regression__long_short__thr0p99__cash",
+        "ml_logistic_l1__long_short__thr0p99__cash",
         "ml_random_forest__long_short__thr0p99__cash",
+        "ml_extra_trees__long_short__thr0p99__cash",
+        "ml_gradient_boosting__long_short__thr0p99__cash",
+        "ml_hist_gradient_boosting__long_short__thr0p99__cash",
     }
     assert set(metrics["strategy"]) == expected_strategies
     assert set(performance["strategy"]) == expected_strategies
     assert set(strategy_summary["strategy"]) == expected_strategies
     assert "ml_logistic_regression__long_short__thr0p99__cash" in report_text
+    assert "ml_logistic_l1__long_short__thr0p99__cash" in report_text

--- a/tests/integration/test_train_models.py
+++ b/tests/integration/test_train_models.py
@@ -43,6 +43,15 @@ PREDICTIONS_COLUMNS = [
     "predicted_target",
 ]
 
+DEFAULT_MODEL_NAMES = {
+    "extra_trees",
+    "gradient_boosting",
+    "hist_gradient_boosting",
+    "logistic_l1",
+    "logistic_regression",
+    "random_forest",
+}
+
 
 def _write_config(
     tmp_path: Path,
@@ -129,7 +138,11 @@ def test_train_models_writes_fold_metrics_manifest_predictions_and_summaries(tmp
         tmp_path,
         models=[
             {"name": "logistic_regression"},
+            {"name": "logistic_l1"},
             {"name": "random_forest"},
+            {"name": "extra_trees"},
+            {"name": "gradient_boosting"},
+            {"name": "hist_gradient_boosting"},
         ],
     )
 
@@ -192,14 +205,14 @@ def test_train_models_writes_fold_metrics_manifest_predictions_and_summaries(tmp
     assert "used" in set(fold_diagnostics["status"])
     assert set(ranking_diagnostics["bucket_status"]).issubset({"used", "underfilled"})
     assert set(threshold_diagnostics["threshold_status"]).issubset({"used", "empty"})
-    assert set(manifest["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(metrics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(predictions["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(ranking_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(calibration_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(score_histograms["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(threshold_diagnostics["model_name"]) == {"logistic_regression", "random_forest"}
-    assert set(model_summary["model_name"]) == {"logistic_regression", "random_forest"}
+    assert set(manifest["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(metrics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(predictions["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(ranking_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(calibration_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(score_histograms["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(threshold_diagnostics["model_name"]) == DEFAULT_MODEL_NAMES
+    assert set(model_summary["model_name"]) == DEFAULT_MODEL_NAMES
     assert set(fold_summary["fold_id"]) == set(folds["fold_id"])
     assert set(folds["fold_id"]) == set(
         fold_diagnostics.loc[fold_diagnostics["status"] == "used", "fold_id"].dropna().astype(int)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -18,9 +18,12 @@ FEATURES = pd.DataFrame(
 TARGET = pd.Series([0, 0, 0, 1, 1, 1], dtype=int)
 
 
-def test_supported_model_names_cover_phase_two_defaults() -> None:
+def test_supported_model_names_cover_lightweight_baseline_set() -> None:
     assert supported_model_names() == (
+        "extra_trees",
         "gradient_boosting",
+        "hist_gradient_boosting",
+        "logistic_l1",
         "logistic_regression",
         "random_forest",
     )


### PR DESCRIPTION
## Summary
- add `logistic_l1`, `extra_trees`, and `hist_gradient_boosting` to the sklearn model registry
- expand the shipped weekly configs and packaged templates to compare the six-model lightweight baseline set by default
- widen registry and pipeline coverage so the new models flow through existing training and experiment artifacts without schema changes

## Validation
- `python -m pytest -q tests/unit/test_models.py --basetemp .pytest_tmp_models_expand_escalated`
- `python -m pytest -q tests/unit/test_package_resources.py --basetemp .pytest_tmp_pkg_expand_escalated`
- `python -m pytest -q tests/integration/test_train_models.py --basetemp .pytest_tmp_train_expand_escalated`
- `python -m pytest -q tests/integration/test_run_experiment.py --basetemp .pytest_tmp_runexp_expand_escalated`
- `python -m tox -e preflight`

Closes #22