### PR TITLE
feat: add benchmark-relative comparison reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Writes a timestamped folder under `artifacts/runs/<experiment_name>/` containing
 - `strategy_summary.csv`
 - `monthly_returns.csv`
 - `turnover_costs.csv`
+- `daily_exposure.csv`
+- optional `group_exposure.csv`
+- optional `benchmark_relative.csv`
 - `report.md`
 - `cumulative_returns.png`
 - `drawdown.png`
@@ -69,6 +72,9 @@ Writes a timestamped folder under `artifacts/runs/<experiment_name>/` containing
 - `strategy_summary.csv`
 - `monthly_returns.csv`
 - `turnover_costs.csv`
+- `daily_exposure.csv`
+- optional `group_exposure.csv`
+- optional `benchmark_relative.csv`
 - `report.md`
 - `cumulative_returns.png`
 - `drawdown.png`
@@ -147,7 +153,8 @@ Non-default ML strategy variants are named explicitly in experiment outputs, for
 
 These caps apply only after the current ranking strategy has already selected longs and shorts. MarketLab clips single-name exposure first, then clips group exposure separately for the long and short sleeves, then caps total long exposure, and finally caps total short exposure. Any removed exposure stays in cash; it is never renormalized back into the book.
 
-This remains a narrow structural-control step. The new caps do not change `buy_hold`, `sma`, or allocation baselines, and they do not add benchmark-relative reporting, optimizer methods, or broader portfolio analytics yet. Lower realized volatility or drawdown under a capped ranking strategy may simply reflect lower invested exposure or more cash, not better signal quality.
+This remains a narrow structural-control step. The new caps do not change `buy_hold`, `sma`, or allocation baselines, and they do not add optimizer methods, factor-model attribution, or broader scenario-pack work yet. Lower realized volatility or drawdown under a capped ranking strategy may simply reflect lower invested exposure or more cash, not better signal quality.
+
 ## Exposure-Aware Analytics
 
 `backtest` and `run-experiment` now also persist additive exposure analytics alongside the existing return and turnover artifacts.
@@ -159,6 +166,18 @@ This remains a narrow structural-control step. The new caps do not change `buy_h
 - `strategy_summary.csv` now appends average exposure, cash, active-position, and concentration fields, and `report.md` includes an `Exposure Summary` section.
 
 These analytics are interpretive, not predictive. Lower drawdown or volatility can simply reflect lower gross exposure or more cash, not better signal quality.
+
+
+## Benchmark-Relative Reporting
+
+`backtest` and `run-experiment` now also support optional benchmark-relative analytics under `evaluation.benchmark_strategy`.
+
+- The benchmark is an existing strategy name already present in the run, not a raw symbol.
+- When configured, MarketLab writes `benchmark_relative.csv` with daily strategy return, benchmark return, active return, and relative-equity paths on shared dates.
+- `strategy_summary.csv` now also appends benchmark-relative fields such as excess cumulative return, annualized excess return, tracking error, information ratio, correlation to benchmark, and up/down capture.
+- `report.md` includes a `Benchmark-Relative Summary` section when a benchmark is configured.
+
+These metrics are comparative, not causal. Higher absolute return and better benchmark-relative performance are separate questions, and lower active risk does not imply outperformance.
 
 ## Allocation Baselines And Symbol Groups
 
@@ -182,7 +201,7 @@ Allocation semantics:
 - `allocation_symbol_weights` rebalances back to exact configured symbol weights.
 - `allocation_group_weights` rebalances back to configured group sleeves and splits each sleeve equally across the symbols in that group.
 
-This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Risk caps, benchmark-relative reporting, and optimizer methods remain later work.
+This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Optimizer methods, factor diagnostics, and broader scenario comparisons remain later work.
 
 ## Single-Symbol VOO Timing Example
 
@@ -309,6 +328,7 @@ Before the first automated public release:
 - create the GitHub Actions environment named `pypi`
 
 The first automated public release target remains `v0.1.0`.
+
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -22,7 +22,7 @@ This document ties the current pieces together and records the working rules tha
   - `buy_hold`, `sma`, and config-defined allocation baselines
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
-  - metrics, exposure-aware strategy analytics CSVs, plots, and Markdown reporting
+  - metrics, exposure-aware and benchmark-relative strategy analytics CSVs, plots, and Markdown reporting
   - required PR CI for lint, docs, packaging, unit tests, and offline integration tests
   - Docker packaging for the installed CLI plus a manual GitHub Actions Docker runner
   - release automation with a monthly-batching Release PR and a PyPI publish path
@@ -105,6 +105,15 @@ The required CI path stays offline and deterministic through tox. The Docker run
 - `group_exposure.csv` is only written when `data.symbol_groups` covers the run universe, and it keeps long and short sleeves separate so concentration is not hidden by netting.
 - `strategy_summary.csv` appends average exposure, cash, active-position, and concentration fields without changing the existing leading performance columns.
 
+## Benchmark-Relative Reporting Rules
+
+- Benchmark-relative analytics are optional and only run when `evaluation.benchmark_strategy` is set.
+- The benchmark is an existing strategy name already present in the run, not a raw symbol or download instruction.
+- `benchmark_relative.csv` aligns each strategy to the benchmark on shared dates and stores daily active return plus relative equity.
+- `strategy_summary.csv` appends benchmark-relative fields such as excess cumulative return, tracking error, information ratio, correlation, and capture ratios without changing the existing leading columns.
+- Benchmark-relative reporting applies to `backtest` and `run-experiment`, but not to `train-models`.
+
+
 ## System Map
 
 ```mermaid
@@ -141,6 +150,7 @@ flowchart TD
     Summary --> ModelSummaryCsv[model_summary.csv]
     Summary --> FoldSummaryCsv[fold_summary.csv]
     Analytics --> StrategySummaryCsv[strategy_summary.csv]
+    Analytics --> BenchmarkRelativeCsv[benchmark_relative.csv]
     Analytics --> MonthlyReturnsCsv[monthly_returns.csv]
     Analytics --> TurnoverCostsCsv[turnover_costs.csv]
     Pipeline --> Markdown[src/marketlab/reports/markdown.py]
@@ -213,7 +223,7 @@ sequenceDiagram
     B-->>P: metrics table
     P->>SUM: build_model_summary(...) and build_fold_summary(...)
     SUM-->>P: summary tables
-    P->>AN: build_strategy_summary(...) daily and grouped exposure monthly returns turnover costs
+    P->>AN: build_strategy_summary(...) daily and grouped exposure monthly returns turnover costs benchmark-relative comparisons
     AN-->>P: analytics tables
     P->>R: write_markdown_report(...)
     P->>R: plot_cumulative_returns(...)
@@ -383,6 +393,9 @@ classDiagram
       +strategy_summary_path: Path
       +monthly_returns_path: Path
       +turnover_costs_path: Path
+      +daily_exposure_path: Path
+      +group_exposure_path: Path | None
+      +benchmark_relative_path: Path | None
       +model_summary_path: Path | None
       +fold_diagnostics_path: Path | None
       +ranking_diagnostics_path: Path | None
@@ -811,6 +824,7 @@ Best practice:
 - Do not batch multiple strategies into a single `run_backtest(...)` call.
 - Do not redesign the current data layer just to support later model abstractions.
 - Preserve the local launcher and E2E runner as the default developer entrypoints.
+
 
 
 

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -110,6 +110,7 @@ class WalkForwardConfig:
 @dataclass(slots=True)
 class EvaluationConfig:
     walk_forward: WalkForwardConfig = field(default_factory=WalkForwardConfig)
+    benchmark_strategy: str = ""
 
 
 @dataclass(slots=True)
@@ -309,7 +310,8 @@ def load_config(path: str | Path) -> ExperimentConfig:
             walk_forward=_section(
                 WalkForwardConfig,
                 (payload.get("evaluation") or {}).get("walk_forward"),
-            )
+            ),
+            benchmark_strategy=(payload.get("evaluation") or {}).get("benchmark_strategy", ""),
         ),
         artifacts=_section(ArtifactsConfig, payload.get("artifacts")),
         base_dir=_config_base_dir(config_path),
@@ -317,3 +319,5 @@ def load_config(path: str | Path) -> ExperimentConfig:
     _normalize_mapping_sections(config)
     _validate_config(config)
     return config
+
+

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
@@ -22,6 +22,7 @@ from marketlab.features.engineering import add_feature_set
 from marketlab.models import train_direction_models_on_folds
 from marketlab.rebalance import next_rebalance_effective_date
 from marketlab.reports.analytics import (
+    build_benchmark_relative,
     build_daily_exposure,
     build_group_exposure,
     build_monthly_returns,
@@ -58,6 +59,7 @@ class ExperimentArtifacts:
     turnover_costs_path: Path
     daily_exposure_path: Path
     group_exposure_path: Path | None
+    benchmark_relative_path: Path | None
     report_path: Path | None
     cumulative_plot_path: Path | None
     drawdown_plot_path: Path | None
@@ -171,10 +173,16 @@ def _persist_experiment_outputs(
     metrics = compute_strategy_metrics(performance)
     daily_exposure = build_daily_exposure(daily_holdings, daily_cash)
     group_exposure = build_group_exposure(daily_holdings, symbol_groups)
+    benchmark_relative = build_benchmark_relative(
+        performance,
+        config.evaluation.benchmark_strategy,
+    )
     strategy_summary = build_strategy_summary(
         performance,
         daily_exposure=daily_exposure,
         group_exposure=group_exposure,
+        benchmark_relative=benchmark_relative,
+        benchmark_strategy=config.evaluation.benchmark_strategy,
     )
     monthly_returns = build_monthly_returns(performance)
     turnover_costs = build_turnover_costs(performance)
@@ -196,6 +204,11 @@ def _persist_experiment_outputs(
     if not group_exposure.empty:
         group_exposure_path = artifact_run_dir / "group_exposure.csv"
         group_exposure.to_csv(group_exposure_path, index=False)
+
+    benchmark_relative_path: Path | None = None
+    if not benchmark_relative.empty:
+        benchmark_relative_path = artifact_run_dir / "benchmark_relative.csv"
+        benchmark_relative.to_csv(benchmark_relative_path, index=False)
 
     persisted_fold_diagnostics_path = fold_diagnostics_path
     if fold_diagnostics is not None and persisted_fold_diagnostics_path is None:
@@ -298,6 +311,7 @@ def _persist_experiment_outputs(
         turnover_costs_path=turnover_costs_path,
         daily_exposure_path=daily_exposure_path,
         group_exposure_path=group_exposure_path,
+        benchmark_relative_path=benchmark_relative_path,
         report_path=report_path,
         cumulative_plot_path=cumulative_plot_path,
         drawdown_plot_path=drawdown_plot_path,
@@ -667,4 +681,9 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         score_histograms=training_outputs.score_histograms,
         threshold_diagnostics=training_outputs.threshold_diagnostics,
     )
+
+
+
+
+
 

--- a/src/marketlab/reports/analytics.py
+++ b/src/marketlab/reports/analytics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import pandas as pd
 
 from marketlab.backtest.engine import WEIGHT_EPSILON
@@ -33,6 +35,14 @@ STRATEGY_SUMMARY_COLUMNS = [
     "avg_active_positions",
     "max_position_weight",
     "max_group_weight",
+    "benchmark_strategy",
+    "excess_cumulative_return",
+    "annualized_excess_return",
+    "tracking_error",
+    "information_ratio",
+    "correlation_to_benchmark",
+    "up_capture",
+    "down_capture",
 ]
 
 MONTHLY_RETURNS_COLUMNS = [
@@ -72,6 +82,18 @@ GROUP_EXPOSURE_COLUMNS = [
     "short_exposure",
     "gross_exposure",
     "net_exposure",
+]
+
+BENCHMARK_RELATIVE_COLUMNS = [
+    "date",
+    "strategy",
+    "benchmark_strategy",
+    "strategy_net_return",
+    "benchmark_net_return",
+    "excess_return",
+    "strategy_equity",
+    "benchmark_equity",
+    "relative_equity",
 ]
 
 
@@ -163,6 +185,23 @@ def _normalized_group_exposure(group_exposure: pd.DataFrame) -> pd.DataFrame:
         group_exposure.copy()
         .assign(date=lambda frame: pd.to_datetime(frame["date"]))
         .sort_values(["strategy", "date", "group_name"])
+        .reset_index(drop=True)
+    )
+
+
+def _normalized_benchmark_relative(benchmark_relative: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        benchmark_relative,
+        set(BENCHMARK_RELATIVE_COLUMNS),
+        "Benchmark-relative frame",
+    )
+    if benchmark_relative.empty:
+        return benchmark_relative.copy()
+
+    return (
+        benchmark_relative.copy()
+        .assign(date=lambda frame: pd.to_datetime(frame["date"]))
+        .sort_values(["strategy", "date"])
         .reset_index(drop=True)
     )
 
@@ -269,10 +308,84 @@ def build_group_exposure(
     return grouped.loc[:, GROUP_EXPOSURE_COLUMNS]
 
 
+def build_benchmark_relative(
+    performance: pd.DataFrame,
+    benchmark_strategy: str,
+) -> pd.DataFrame:
+    working = _normalized_performance(performance)
+    if working.empty or benchmark_strategy == "":
+        return pd.DataFrame(columns=BENCHMARK_RELATIVE_COLUMNS)
+
+    strategies = working["strategy"].drop_duplicates().tolist()
+    if benchmark_strategy not in set(strategies):
+        available = ", ".join(sorted(strategies))
+        raise ValueError(
+            "evaluation.benchmark_strategy='"
+            f"{benchmark_strategy}' is not present in run strategies. Available strategies: {available}"
+        )
+
+    benchmark_frame = (
+        working.loc[working["strategy"] == benchmark_strategy, ["date", "net_return", "equity"]]
+        .rename(
+            columns={
+                "net_return": "benchmark_net_return",
+                "equity": "benchmark_equity",
+            }
+        )
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+
+    benchmark_relative = (
+        working.loc[:, ["date", "strategy", "net_return", "equity"]]
+        .rename(
+            columns={
+                "net_return": "strategy_net_return",
+                "equity": "strategy_equity",
+            }
+        )
+        .merge(
+            benchmark_frame,
+            on="date",
+            how="inner",
+            validate="many_to_one",
+        )
+        .sort_values(["strategy", "date"])
+        .reset_index(drop=True)
+    )
+    benchmark_relative["benchmark_strategy"] = benchmark_strategy
+    benchmark_relative["excess_return"] = (
+        benchmark_relative["strategy_net_return"] - benchmark_relative["benchmark_net_return"]
+    )
+    benchmark_relative["relative_equity"] = (
+        benchmark_relative["strategy_equity"] / benchmark_relative["benchmark_equity"]
+    )
+    return benchmark_relative.loc[:, BENCHMARK_RELATIVE_COLUMNS]
+
+
+def _capture_ratio(frame: pd.DataFrame, *, direction: str) -> float:
+    if direction == "up":
+        subset = frame.loc[frame["benchmark_net_return"] > 0.0]
+    else:
+        subset = frame.loc[frame["benchmark_net_return"] < 0.0]
+
+    if subset.empty:
+        return float("nan")
+
+    benchmark_return = float((1.0 + subset["benchmark_net_return"]).prod() - 1.0)
+    if abs(benchmark_return) <= WEIGHT_EPSILON:
+        return float("nan")
+
+    strategy_return = float((1.0 + subset["strategy_net_return"]).prod() - 1.0)
+    return strategy_return / benchmark_return
+
+
 def build_strategy_summary(
     performance: pd.DataFrame,
     daily_exposure: pd.DataFrame | None = None,
     group_exposure: pd.DataFrame | None = None,
+    benchmark_relative: pd.DataFrame | None = None,
+    benchmark_strategy: str = "",
 ) -> pd.DataFrame:
     working = _normalized_performance(performance)
     if working.empty:
@@ -375,9 +488,63 @@ def build_strategy_summary(
             .reset_index(drop=True)
         )
 
+    if benchmark_strategy == "" or benchmark_relative is None or benchmark_relative.empty:
+        benchmark_summary = pd.DataFrame(
+            {
+                "strategy": summary["strategy"],
+                "benchmark_strategy": "",
+                "excess_cumulative_return": float("nan"),
+                "annualized_excess_return": float("nan"),
+                "tracking_error": float("nan"),
+                "information_ratio": float("nan"),
+                "correlation_to_benchmark": float("nan"),
+                "up_capture": float("nan"),
+                "down_capture": float("nan"),
+            }
+        )
+    else:
+        normalized_benchmark_relative = _normalized_benchmark_relative(benchmark_relative)
+
+        def _benchmark_summary_row(frame: pd.DataFrame) -> pd.Series:
+            frame = frame.sort_values("date").reset_index(drop=True)
+            trading_days = len(frame)
+            relative_equity = float(frame["relative_equity"].iloc[-1]) if trading_days else float("nan")
+            tracking_error = float(frame["excess_return"].std(ddof=0) * math.sqrt(252.0))
+            information_ratio = float("nan")
+            if tracking_error > WEIGHT_EPSILON:
+                information_ratio = float(frame["excess_return"].mean() * 252.0 / tracking_error)
+
+            return pd.Series(
+                {
+                    "benchmark_strategy": str(frame["benchmark_strategy"].iat[0]),
+                    "excess_cumulative_return": relative_equity - 1.0,
+                    "annualized_excess_return": (
+                        float((relative_equity ** (252.0 / trading_days)) - 1.0)
+                        if trading_days and relative_equity > 0.0
+                        else float("nan")
+                    ),
+                    "tracking_error": tracking_error,
+                    "information_ratio": information_ratio,
+                    "correlation_to_benchmark": float(
+                        frame["strategy_net_return"].corr(frame["benchmark_net_return"])
+                    ),
+                    "up_capture": _capture_ratio(frame, direction="up"),
+                    "down_capture": _capture_ratio(frame, direction="down"),
+                }
+            )
+
+        benchmark_summary = (
+            normalized_benchmark_relative.groupby("strategy", sort=False)
+            .apply(_benchmark_summary_row, include_groups=False)
+            .reset_index()
+            .sort_values("strategy")
+            .reset_index(drop=True)
+        )
+
     summary = (
         summary.merge(exposure_summary, on="strategy", how="left", validate="one_to_one")
         .merge(group_summary, on="strategy", how="left", validate="one_to_one")
+        .merge(benchmark_summary, on="strategy", how="left", validate="one_to_one")
         .sort_values("strategy")
         .reset_index(drop=True)
     )

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -20,6 +20,18 @@ EXPOSURE_SUMMARY_COLUMNS = [
     "max_group_weight",
 ]
 
+BENCHMARK_SUMMARY_COLUMNS = [
+    "strategy",
+    "benchmark_strategy",
+    "excess_cumulative_return",
+    "annualized_excess_return",
+    "tracking_error",
+    "information_ratio",
+    "correlation_to_benchmark",
+    "up_capture",
+    "down_capture",
+]
+
 
 def _markdown_table(frame: pd.DataFrame) -> str:
     columns = list(frame.columns)
@@ -51,16 +63,24 @@ def _headline_lines(
         return []
 
     lines: list[str] = []
-    best_strategy = metrics.sort_values(["cumulative_return", "strategy"], ascending=[False, True]).iloc[0]
+    best_strategy = metrics.sort_values(
+        ["cumulative_return", "strategy"],
+        ascending=[False, True],
+    ).iloc[0]
     lines.append(
-        f"- Best overall strategy by cumulative return: `{best_strategy['strategy']}` ({best_strategy['cumulative_return']:.6f})"
+        "- Best overall strategy by cumulative return: "
+        f"`{best_strategy['strategy']}` ({best_strategy['cumulative_return']:.6f})"
     )
 
     ml_metrics = metrics.loc[metrics["strategy"].astype(str).str.startswith("ml_")]
     if not ml_metrics.empty:
-        best_ml = ml_metrics.sort_values(["cumulative_return", "strategy"], ascending=[False, True]).iloc[0]
+        best_ml = ml_metrics.sort_values(
+            ["cumulative_return", "strategy"],
+            ascending=[False, True],
+        ).iloc[0]
         lines.append(
-            f"- Best ML strategy by cumulative return: `{best_ml['strategy']}` ({best_ml['cumulative_return']:.6f})"
+            "- Best ML strategy by cumulative return: "
+            f"`{best_ml['strategy']}` ({best_ml['cumulative_return']:.6f})"
         )
 
     if model_summary is not None and not model_summary.empty:
@@ -74,11 +94,14 @@ def _headline_lines(
             else:
                 best_model = ranked_models.iloc[0]
                 lines.append(
-                    f"- Best model by mean ROC AUC: `{best_model['model_name']}` ({best_model['mean_roc_auc']:.6f})"
+                    "- Best model by mean ROC AUC: "
+                    f"`{best_model['model_name']}` ({best_model['mean_roc_auc']:.6f})"
                 )
 
         if {"model_name", "mean_top_bucket_return"}.issubset(model_summary.columns):
-            ranked_top_bucket = model_summary.dropna(subset=["mean_top_bucket_return"]).sort_values(
+            ranked_top_bucket = model_summary.dropna(
+                subset=["mean_top_bucket_return"]
+            ).sort_values(
                 ["mean_top_bucket_return", "model_name"],
                 ascending=[False, True],
             )
@@ -87,11 +110,14 @@ def _headline_lines(
             else:
                 best_top_bucket = ranked_top_bucket.iloc[0]
                 lines.append(
-                    f"- Best model by mean top-bucket return: `{best_top_bucket['model_name']}` ({best_top_bucket['mean_top_bucket_return']:.6f})"
+                    "- Best model by mean top-bucket return: "
+                    f"`{best_top_bucket['model_name']}` ({best_top_bucket['mean_top_bucket_return']:.6f})"
                 )
 
         if {"model_name", "mean_top_bottom_spread"}.issubset(model_summary.columns):
-            ranked_spread = model_summary.dropna(subset=["mean_top_bottom_spread"]).sort_values(
+            ranked_spread = model_summary.dropna(
+                subset=["mean_top_bottom_spread"]
+            ).sort_values(
                 ["mean_top_bottom_spread", "model_name"],
                 ascending=[False, True],
             )
@@ -100,7 +126,8 @@ def _headline_lines(
             else:
                 best_spread = ranked_spread.iloc[0]
                 lines.append(
-                    f"- Best model by mean top-bottom spread: `{best_spread['model_name']}` ({best_spread['mean_top_bottom_spread']:.6f})"
+                    "- Best model by mean top-bottom spread: "
+                    f"`{best_spread['model_name']}` ({best_spread['mean_top_bottom_spread']:.6f})"
                 )
 
     return lines
@@ -181,7 +208,10 @@ def _threshold_highlights(threshold_diagnostics: pd.DataFrame) -> pd.DataFrame:
             .sort_values("threshold")
             .reset_index(drop=True)
         )
-        best_f1 = aggregated.sort_values(["mean_f1", "threshold"], ascending=[False, True]).iloc[0]
+        best_f1 = aggregated.sort_values(
+            ["mean_f1", "threshold"],
+            ascending=[False, True],
+        ).iloc[0]
         best_balanced = aggregated.sort_values(
             ["mean_balanced_accuracy", "threshold"],
             ascending=[False, True],
@@ -215,7 +245,9 @@ def _exposure_summary_lines(strategy_summary: pd.DataFrame) -> list[str]:
     if not set(EXPOSURE_SUMMARY_COLUMNS).issubset(strategy_summary.columns):
         return []
 
-    lines = [_markdown_table(_display_frame(strategy_summary.loc[:, EXPOSURE_SUMMARY_COLUMNS]))]
+    lines = [
+        _markdown_table(_display_frame(strategy_summary.loc[:, EXPOSURE_SUMMARY_COLUMNS]))
+    ]
     lines.extend(
         [
             "",
@@ -225,6 +257,26 @@ def _exposure_summary_lines(strategy_summary: pd.DataFrame) -> list[str]:
     )
     if strategy_summary["max_group_weight"].notna().any():
         lines.append("- Group concentration details are also persisted in `group_exposure.csv`.")
+    return lines
+
+
+def _benchmark_summary_lines(strategy_summary: pd.DataFrame) -> list[str]:
+    if not set(BENCHMARK_SUMMARY_COLUMNS).issubset(strategy_summary.columns):
+        return []
+    if not strategy_summary["benchmark_strategy"].astype(str).str.len().gt(0).any():
+        return []
+
+    lines = [
+        _markdown_table(_display_frame(strategy_summary.loc[:, BENCHMARK_SUMMARY_COLUMNS]))
+    ]
+    lines.extend(
+        [
+            "",
+            "- Benchmark-relative metrics separate absolute return from active return and active risk.",
+            "- Lower tracking error does not imply outperformance; it only means the strategy stayed closer to the benchmark path.",
+            "- Daily active return and relative equity are also persisted in `benchmark_relative.csv`.",
+        ]
+    )
     return lines
 
 
@@ -280,16 +332,25 @@ def write_markdown_report(
     content_lines.extend(_section("Strategy Metrics", [metrics_table]))
 
     if strategy_summary is not None and not strategy_summary.empty:
-        content_lines.extend(_section("Strategy Summary", [_markdown_table(_display_frame(strategy_summary))]))
+        content_lines.extend(
+            _section("Strategy Summary", [_markdown_table(_display_frame(strategy_summary))])
+        )
         exposure_lines = _exposure_summary_lines(strategy_summary)
         if exposure_lines:
             content_lines.extend(_section("Exposure Summary", exposure_lines))
+        benchmark_lines = _benchmark_summary_lines(strategy_summary)
+        if benchmark_lines:
+            content_lines.extend(_section("Benchmark-Relative Summary", benchmark_lines))
 
     if monthly_returns is not None and not monthly_returns.empty:
-        content_lines.extend(_section("Monthly Net Returns", [_monthly_returns_table(monthly_returns)]))
+        content_lines.extend(
+            _section("Monthly Net Returns", [_monthly_returns_table(monthly_returns)])
+        )
 
     if turnover_costs is not None and not turnover_costs.empty:
-        content_lines.extend(_section("Turnover And Costs", [_turnover_costs_table(turnover_costs)]))
+        content_lines.extend(
+            _section("Turnover And Costs", [_turnover_costs_table(turnover_costs)])
+        )
 
     if fold_diagnostics is not None and not fold_diagnostics.empty:
         content_lines.extend(
@@ -300,10 +361,14 @@ def write_markdown_report(
         )
 
     if model_summary is not None and not model_summary.empty:
-        content_lines.extend(_section("Model Summary", [_markdown_table(_display_frame(model_summary))]))
+        content_lines.extend(
+            _section("Model Summary", [_markdown_table(_display_frame(model_summary))])
+        )
 
     if fold_summary is not None and not fold_summary.empty:
-        content_lines.extend(_section("Fold Summary", [_markdown_table(_display_frame(fold_summary))]))
+        content_lines.extend(
+            _section("Fold Summary", [_markdown_table(_display_frame(fold_summary))])
+        )
 
     show_calibration_section = (
         model_summary is not None
@@ -313,18 +378,24 @@ def write_markdown_report(
     if show_calibration_section:
         calibration_lines = [_calibration_summary_table(model_summary)]
         if threshold_diagnostics is not None and not threshold_diagnostics.empty:
-            calibration_lines.extend([
-                "",
-                _markdown_table(_display_frame(_threshold_highlights(threshold_diagnostics))),
-            ])
+            calibration_lines.extend(
+                [
+                    "",
+                    _markdown_table(_display_frame(_threshold_highlights(threshold_diagnostics))),
+                ]
+            )
         for alt_text, plot_path in [
             ("Calibration Curves", calibration_curves_plot_path),
             ("Score Histograms", score_histograms_plot_path),
             ("Threshold Sweeps", threshold_sweeps_plot_path),
         ]:
             if plot_path is not None and plot_path.exists():
-                calibration_lines.extend(["", _relative_image_line(output_path, plot_path, alt_text)])
-        content_lines.extend(_section("Calibration And Threshold Diagnostics", calibration_lines))
+                calibration_lines.extend(
+                    ["", _relative_image_line(output_path, plot_path, alt_text)]
+                )
+        content_lines.extend(
+            _section("Calibration And Threshold Diagnostics", calibration_lines)
+        )
 
     output_path.write_text("\n".join(content_lines).rstrip() + "\n", encoding="utf-8")
     return output_path

--- a/tests/integration/_cli_harness.py
+++ b/tests/integration/_cli_harness.py
@@ -24,6 +24,9 @@ from marketlab.models.evaluation import (
     THRESHOLD_DIAGNOSTICS_COLUMNS as _THRESHOLD_DIAGNOSTICS_COLUMNS,
 )
 from marketlab.reports.analytics import (
+    BENCHMARK_RELATIVE_COLUMNS as _BENCHMARK_RELATIVE_COLUMNS,
+)
+from marketlab.reports.analytics import (
     DAILY_EXPOSURE_COLUMNS as _DAILY_EXPOSURE_COLUMNS,
 )
 from marketlab.reports.analytics import (
@@ -56,6 +59,7 @@ RANKING_DIAGNOSTICS_COLUMNS = list(_RANKING_DIAGNOSTICS_COLUMNS)
 CALIBRATION_DIAGNOSTICS_COLUMNS = list(_CALIBRATION_DIAGNOSTICS_COLUMNS)
 SCORE_HISTOGRAM_COLUMNS = list(_SCORE_HISTOGRAM_COLUMNS)
 THRESHOLD_DIAGNOSTICS_COLUMNS = list(_THRESHOLD_DIAGNOSTICS_COLUMNS)
+BENCHMARK_RELATIVE_COLUMNS = list(_BENCHMARK_RELATIVE_COLUMNS)
 DAILY_EXPOSURE_COLUMNS = list(_DAILY_EXPOSURE_COLUMNS)
 GROUP_EXPOSURE_COLUMNS = list(_GROUP_EXPOSURE_COLUMNS)
 MONTHLY_RETURNS_COLUMNS = list(_MONTHLY_RETURNS_COLUMNS)
@@ -217,3 +221,4 @@ def latest_run_dir(run_root: Path) -> Path:
     run_dirs = sorted(path for path in run_root.iterdir() if path.is_dir())
     assert run_dirs, f"No run directories exist under {run_root}"
     return run_dirs[-1]
+

--- a/tests/integration/test_benchmark_reporting.py
+++ b/tests/integration/test_benchmark_reporting.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from tests.integration import _cli_harness
+from tests.integration.test_run_experiment import (
+    _write_backtest_config,
+    _write_run_experiment_config,
+    assert_command_ok,
+    latest_run_dir,
+    run_marketlab_cli,
+    stdout_path,
+)
+
+BENCHMARK_RELATIVE_COLUMNS = _cli_harness.BENCHMARK_RELATIVE_COLUMNS
+STRATEGY_SUMMARY_COLUMNS = _cli_harness.STRATEGY_SUMMARY_COLUMNS
+
+
+
+def test_backtest_writes_benchmark_relative_artifacts(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        evaluation={"benchmark_strategy": "buy_hold"},
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_backtest_fixture"
+    run_dir = latest_run_dir(run_root)
+    benchmark_relative_path = run_dir / "benchmark_relative.csv"
+    strategy_summary_path = run_dir / "strategy_summary.csv"
+    report_path = run_dir / "report.md"
+
+    assert stdout_path(result) == run_dir.resolve()
+    assert benchmark_relative_path.exists()
+
+    benchmark_relative = pd.read_csv(benchmark_relative_path)
+    strategy_summary = pd.read_csv(strategy_summary_path)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert list(benchmark_relative.columns) == BENCHMARK_RELATIVE_COLUMNS
+    assert list(strategy_summary.columns) == STRATEGY_SUMMARY_COLUMNS
+    assert set(benchmark_relative["strategy"]) == {"buy_hold", "sma"}
+    assert benchmark_relative["benchmark_strategy"].eq("buy_hold").all()
+    assert strategy_summary["benchmark_strategy"].eq("buy_hold").all()
+    assert "## Benchmark-Relative Summary" in report_text
+    assert "benchmark_relative.csv" in report_text
+
+
+
+def test_run_experiment_writes_benchmark_relative_artifacts(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        evaluation={"benchmark_strategy": "buy_hold"},
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    benchmark_relative_path = run_dir / "benchmark_relative.csv"
+    strategy_summary_path = run_dir / "strategy_summary.csv"
+    report_path = run_dir / "report.md"
+
+    assert benchmark_relative_path.exists()
+
+    benchmark_relative = pd.read_csv(benchmark_relative_path)
+    strategy_summary = pd.read_csv(strategy_summary_path)
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert list(benchmark_relative.columns) == BENCHMARK_RELATIVE_COLUMNS
+    assert list(strategy_summary.columns) == STRATEGY_SUMMARY_COLUMNS
+    assert set(strategy_summary["strategy"]) == {
+        "buy_hold",
+        "sma",
+        "ml_logistic_regression",
+    }
+    assert set(benchmark_relative["strategy"]) == {
+        "buy_hold",
+        "sma",
+        "ml_logistic_regression",
+    }
+    assert benchmark_relative["benchmark_strategy"].eq("buy_hold").all()
+    assert strategy_summary["benchmark_strategy"].eq("buy_hold").all()
+    assert "## Benchmark-Relative Summary" in report_text
+
+
+
+def test_backtest_rejects_unknown_benchmark_strategy(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        evaluation={"benchmark_strategy": "missing"},
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+
+    assert result.returncode != 0
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert "evaluation.benchmark_strategy='missing'" in combined_output
+    assert "Available strategies: buy_hold, sma" in combined_output

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 from pathlib import Path
 
@@ -64,6 +64,7 @@ def _write_run_experiment_config(
     symbol_groups: dict[str, str] | None = None,
     allocation: dict[str, object] | None = None,
     models: list[dict[str, str]] | None = None,
+    evaluation: dict[str, object] | None = None,
 ) -> Path:
     cache_dir = tmp_path / "cache"
     resolved_symbol_specs = symbol_specs or (
@@ -149,6 +150,7 @@ def _write_run_experiment_config(
             "models": resolved_models,
             "evaluation": {
                 "walk_forward": walk_forward_payload,
+                **(evaluation or {}),
             },
             "artifacts": {
                 "output_dir": str(tmp_path / "runs"),
@@ -166,6 +168,7 @@ def _write_backtest_config(
     *,
     symbol_groups: dict[str, str] | None = None,
     allocation: dict[str, object] | None = None,
+    evaluation: dict[str, object] | None = None,
 ) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(load_fixture_panel(), cache_dir / "panel.csv")
@@ -200,6 +203,7 @@ def _write_backtest_config(
                 "costs": {"bps_per_trade": 10},
             },
             "baselines": baselines_payload,
+            "evaluation": evaluation or {},
             "artifacts": {
                 "output_dir": str(tmp_path / "runs"),
                 "save_predictions": False,
@@ -209,7 +213,6 @@ def _write_backtest_config(
             },
         },
     )
-
 def test_run_experiment_produces_baseline_and_ml_artifacts(tmp_path: Path) -> None:
     config_path = _write_run_experiment_config(tmp_path)
 
@@ -674,4 +677,9 @@ def test_run_experiment_supports_gated_cash_strategy_variants(tmp_path: Path) ->
     assert set(strategy_summary["strategy"]) == expected_strategies
     assert "ml_logistic_regression__long_short__thr0p99__cash" in report_text
     assert "ml_logistic_l1__long_short__thr0p99__cash" in report_text
+
+
+
+
+
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -4,11 +4,13 @@ import pandas as pd
 import pytest
 
 from marketlab.reports.analytics import (
+    BENCHMARK_RELATIVE_COLUMNS,
     DAILY_EXPOSURE_COLUMNS,
     GROUP_EXPOSURE_COLUMNS,
     MONTHLY_RETURNS_COLUMNS,
     STRATEGY_SUMMARY_COLUMNS,
     TURNOVER_COSTS_COLUMNS,
+    build_benchmark_relative,
     build_daily_exposure,
     build_group_exposure,
     build_monthly_returns,
@@ -228,3 +230,92 @@ def test_build_strategy_summary_aggregates_one_row_per_strategy(
     assert beta_row["avg_engine_cash_weight"] == pytest.approx((1.0 + 0.98 + 1.02) / 3.0)
     assert beta_row["max_position_weight"] == pytest.approx(0.60)
     assert beta_row["max_group_weight"] == pytest.approx(0.60)
+
+
+def test_build_benchmark_relative_requires_present_benchmark(performance: pd.DataFrame) -> None:
+    with pytest.raises(
+        ValueError,
+        match="evaluation.benchmark_strategy='missing' is not present in run strategies",
+    ):
+        build_benchmark_relative(performance, "missing")
+
+
+def test_build_benchmark_relative_aligns_daily_paths(performance: pd.DataFrame) -> None:
+    benchmark_relative = build_benchmark_relative(performance, "beta")
+
+    assert list(benchmark_relative.columns) == BENCHMARK_RELATIVE_COLUMNS
+    assert set(benchmark_relative["strategy"]) == {"alpha", "beta"}
+    assert benchmark_relative["benchmark_strategy"].eq("beta").all()
+
+    alpha_last = benchmark_relative.loc[
+        benchmark_relative["strategy"] == "alpha"
+    ].sort_values("date").iloc[-1]
+    assert alpha_last["excess_return"] == pytest.approx(-0.03)
+    assert alpha_last["relative_equity"] == pytest.approx(
+        1.015863218 / 1.0327977695
+    )
+
+    beta_rows = benchmark_relative.loc[
+        benchmark_relative["strategy"] == "beta"
+    ].sort_values("date")
+    assert beta_rows["excess_return"].tolist() == pytest.approx([0.0, 0.0, 0.0])
+    assert beta_rows["relative_equity"].tolist() == pytest.approx([1.0, 1.0, 1.0])
+
+
+def test_build_strategy_summary_appends_benchmark_relative_metrics(
+    performance: pd.DataFrame,
+    daily_holdings: pd.DataFrame,
+    daily_cash: pd.DataFrame,
+) -> None:
+    daily_exposure = build_daily_exposure(daily_holdings, daily_cash)
+    group_exposure = build_group_exposure(
+        daily_holdings,
+        {"AAA": "growth", "BBB": "defensive"},
+    )
+    benchmark_relative = build_benchmark_relative(performance, "beta")
+    summary = build_strategy_summary(
+        performance,
+        daily_exposure=daily_exposure,
+        group_exposure=group_exposure,
+        benchmark_relative=benchmark_relative,
+        benchmark_strategy="beta",
+    )
+
+    assert list(summary.columns) == STRATEGY_SUMMARY_COLUMNS
+
+    alpha_rows = performance.loc[performance["strategy"] == "alpha"].sort_values("date")
+    beta_rows = performance.loc[performance["strategy"] == "beta"].sort_values("date")
+    alpha_excess = alpha_rows["net_return"].reset_index(drop=True) - beta_rows["net_return"].reset_index(drop=True)
+    relative_equity = alpha_rows["equity"].iloc[-1] / beta_rows["equity"].iloc[-1]
+    tracking_error = float(alpha_excess.std(ddof=0) * (252.0 ** 0.5))
+    information_ratio = float(alpha_excess.mean() * 252.0 / tracking_error)
+    up_capture = float(
+        (((1.0 + alpha_rows["net_return"]).prod()) - 1.0)
+        / (((1.0 + beta_rows["net_return"]).prod()) - 1.0)
+    )
+
+    alpha_row = summary.loc[summary["strategy"] == "alpha"].iloc[0]
+    assert alpha_row["benchmark_strategy"] == "beta"
+    assert alpha_row["excess_cumulative_return"] == pytest.approx(relative_equity - 1.0)
+    assert alpha_row["annualized_excess_return"] == pytest.approx(
+        (relative_equity ** (252.0 / 3.0)) - 1.0
+    )
+    assert alpha_row["tracking_error"] == pytest.approx(tracking_error)
+    assert alpha_row["information_ratio"] == pytest.approx(information_ratio)
+    assert alpha_row["correlation_to_benchmark"] == pytest.approx(
+        alpha_rows["net_return"].reset_index(drop=True).corr(
+            beta_rows["net_return"].reset_index(drop=True)
+        )
+    )
+    assert alpha_row["up_capture"] == pytest.approx(up_capture)
+    assert pd.isna(alpha_row["down_capture"])
+
+    beta_row = summary.loc[summary["strategy"] == "beta"].iloc[0]
+    assert beta_row["benchmark_strategy"] == "beta"
+    assert beta_row["excess_cumulative_return"] == pytest.approx(0.0)
+    assert beta_row["tracking_error"] == pytest.approx(0.0)
+    assert pd.isna(beta_row["information_ratio"])
+    assert beta_row["correlation_to_benchmark"] == pytest.approx(1.0)
+    assert beta_row["up_capture"] == pytest.approx(1.0)
+    assert pd.isna(beta_row["down_capture"])
+

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -216,3 +216,4 @@ def test_load_config_accepts_valid_risk_caps(tmp_path: Path) -> None:
     assert config.portfolio.risk.max_group_weight == pytest.approx(0.40)
     assert config.portfolio.risk.max_long_exposure == pytest.approx(0.60)
     assert config.portfolio.risk.max_short_exposure == pytest.approx(0.45)
+

--- a/tests/unit/test_markdown_report.py
+++ b/tests/unit/test_markdown_report.py
@@ -67,6 +67,14 @@ def _strategy_summary() -> pd.DataFrame:
             "avg_active_positions": [3.0],
             "max_position_weight": [0.40],
             "max_group_weight": [0.55],
+            "benchmark_strategy": [""],
+            "excess_cumulative_return": [float("nan")],
+            "annualized_excess_return": [float("nan")],
+            "tracking_error": [float("nan")],
+            "information_ratio": [float("nan")],
+            "correlation_to_benchmark": [float("nan")],
+            "up_capture": [float("nan")],
+            "down_capture": [float("nan")],
         }
     )
 
@@ -240,3 +248,37 @@ def test_write_markdown_report_adds_calibration_section_and_plot_links(tmp_path:
     assert "![Calibration Curves](calibration_curves.png)" in report_text
     assert "![Score Histograms](score_histograms.png)" in report_text
     assert "![Threshold Sweeps](threshold_sweeps.png)" in report_text
+
+
+
+def test_write_markdown_report_adds_benchmark_relative_summary_section(
+    tmp_path: Path,
+) -> None:
+    config = ExperimentConfig(experiment_name="markdown_fixture")
+    strategy_summary = _strategy_summary()
+    strategy_summary.loc[:, "benchmark_strategy"] = "buy_hold"
+    strategy_summary.loc[:, "excess_cumulative_return"] = 0.02
+    strategy_summary.loc[:, "annualized_excess_return"] = 0.15
+    strategy_summary.loc[:, "tracking_error"] = 0.08
+    strategy_summary.loc[:, "information_ratio"] = 0.75
+    strategy_summary.loc[:, "correlation_to_benchmark"] = 0.92
+    strategy_summary.loc[:, "up_capture"] = 0.88
+    strategy_summary.loc[:, "down_capture"] = 0.70
+
+    report_path = write_markdown_report(
+        config=config,
+        metrics=_base_metrics(),
+        performance=_base_performance(),
+        path=tmp_path / "report.md",
+        strategy_summary=strategy_summary,
+    )
+
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert "## Benchmark-Relative Summary" in report_text
+    assert (
+        "| strategy | benchmark_strategy | excess_cumulative_return | annualized_excess_return | tracking_error | information_ratio | correlation_to_benchmark | up_capture | down_capture |"
+        in report_text
+    )
+    assert "benchmark_relative.csv" in report_text
+    assert "active risk" in report_text


### PR DESCRIPTION
## Summary
- add optional benchmark-relative reporting under evaluation.benchmark_strategy
- persist enchmark_relative.csv for acktest and un-experiment
- append benchmark-relative fields to strategy_summary.csv
- add markdown, unit, and integration coverage for benchmark reporting

## Validation
- python -m tox -e preflight (timed out locally on this Windows machine)
- python -m ruff check .
- python -m mkdocs build --strict
- python -m build --no-isolation
- python -m pytest -q tests/unit/test_config.py tests/unit/test_analytics.py tests/unit/test_markdown_report.py tests/integration/test_benchmark_reporting.py --basetemp .pytest_tmp_pr37_focus
- python -m pytest -q tests/integration/test_run_experiment.py::test_backtest_remains_baseline_only tests/integration/test_run_experiment.py::test_run_experiment_produces_baseline_and_ml_artifacts tests/integration/test_run_experiment.py::test_run_experiment_supports_group_weight_allocation_baseline tests/integration/test_benchmark_reporting.py --basetemp .pytest_tmp_pr37_targeted