### PR TITLE
feat: add optimizer input and covariance scaffolding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,10 @@ MarketLab is intentionally small and reviewable. Keep changes focused, documente
 
 1. Start from a fresh branch off `master`.
 2. Keep commits small and intentional.
-3. Run the local pre-push gate before opening or updating a PR:
-   - `python -m tox -e preflight`
+3. Run the local validation tiers before opening or updating a PR:
+   - normal iteration: the specific lane you touched
+   - normal pre-PR check: `py -3.12 -m tox -e preflight-fast`
+   - final local push gate: `py -3.12 -m tox -e preflight`
 4. Add tests for behavior changes.
 5. Ask for approval before pushing if the change is part of an agent-led workflow.
 
@@ -20,11 +22,46 @@ MarketLab is intentionally small and reviewable. Keep changes focused, documente
 ## Local Tools
 
 - `python scripts/run_marketlab.py ...` for repo-local execution
-- `python -m tox -e preflight` for the standard local validation gate
+- `py -3.12 -m tox -e lint` for lint-only changes
+- `py -3.12 -m tox -e docs` for docs-only changes
+- `py -3.12 -m tox -e py312` for the unit suite
+- `py -3.12 -m tox -e package` for packaging and installed-CLI checks
+- `py -3.12 -m tox -e integration` for pipeline, config, artifact, and report changes
+- `py -3.12 -m tox -e preflight-fast` for the standard fast local gate
+- `py -3.12 -m tox -e preflight-slow` for the slow packaging plus integration lanes
+- `py -3.12 -m tox -e preflight` for the full local pre-push gate
+- `py -3.12 scripts/profile_validation.py --env package --env integration` to profile the slow lanes directly
 - `powershell -ExecutionPolicy Bypass -File scripts/run-e2e.ps1` for real-data smoke validation when needed
+
+Observed local Windows budgets are currently:
+
+- `lint`: under `30s`
+- `docs`: under `30s`
+- `py312`: under `60s`
+- `package`: about `4-6m`
+- `integration`: about `8-10m`
+- `preflight`: about `14-16m`
+
+When `preflight` feels slow or unstable, diagnose it in this order:
+
+1. `py -3.12 -m tox -e lint`
+2. `py -3.12 -m tox -e docs`
+3. `py -3.12 -m tox -e py312`
+4. `py -3.12 -m tox -e package`
+5. `py -3.12 -m tox -e integration`
+6. `py -3.12 scripts/profile_validation.py --env package --env integration`
+7. `py -3.12 -m tox -e preflight`
+
+Interpret the result this way:
+
+- if only `package` is unstable or much slower than expected, inspect `scripts/check_package.py` and its scratch or virtualenv path handling next
+- if only `integration` dominates, profile that suite next, starting with pytest duration reporting inside the integration lane
+- if both are stable individually but `preflight` still feels killed, treat that as a tooling-timeout or UX problem rather than a MarketLab runtime failure
 
 ## Pull Requests
 
 - Describe the user-facing effect.
 - List the validation commands you ran.
 - Call out any follow-up work that is intentionally deferred.
+
+

--- a/README.md
+++ b/README.md
@@ -216,6 +216,31 @@ Allocation semantics:
 
 This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Optimizer methods, factor diagnostics, and broader scenario comparisons remain later work.
 
+## Optimizer Input Scaffold
+
+`backtest` and `run-experiment` now also accept a non-executable optimizer scaffold under `baselines.optimized`.
+
+Add to `baselines`:
+
+- `optimized.enabled`
+- `optimized.method`: `mean_variance`, `risk_parity`, or `black_litterman`
+- `optimized.lookback_days`
+- `optimized.rebalance_frequency`
+- `optimized.covariance_estimator`: `sample`, `ewma`, `diagonal_shrinkage`, or `external_csv`
+- `optimized.external_covariance_path`
+- `optimized.expected_return_source`: `historical_mean` or `external_csv`
+- `optimized.external_expected_returns_path`
+- `optimized.long_only`
+- `optimized.target_gross_exposure`
+
+This PR only adds the shared optimizer input seam and validates the external CSV contracts. It does not yet emit optimized strategy weights. If `baselines.optimized.enabled: true`, MarketLab now fails fast with a scaffold-only error instead of silently ignoring the config. The executable optimizer baselines remain later Phase 5 work.
+
+External input rules:
+
+- covariance CSVs must be square daily-return covariance matrices keyed by the configured symbols
+- expected-return CSVs must contain exactly `symbol,expected_return`, where `expected_return` is a daily decimal return
+- both loaders reorder to `data.symbols` and reject missing, extra, or non-numeric values
+
 ## Single-Symbol VOO Timing Example
 
 `configs/experiment.voo_long_only.ytd.yaml` is a tracked one-symbol directional timing example built around `VOO` from `2018-01-01` through `2026-04-03`. It currently compares five sklearn models, runs in `long_only` mode with `long_n: 1`, and lowers `min_test_rows` to `10` so quarterly test folds stay viable on a one-symbol weekly dataset.
@@ -277,15 +302,47 @@ powershell -ExecutionPolicy Bypass -File scripts/run-e2e.ps1
 
 ```bash
 python -m uv sync --group dev
-python -m uv run tox -e lint
-python -m uv run tox -e docs
-python -m uv run tox -e package
-python -m uv run tox -e py312
-python -m tox -e integration
-python -m tox -e preflight
+py -3.12 -m tox -e lint
+py -3.12 -m tox -e docs
+py -3.12 -m tox -e py312
+py -3.12 -m tox -e package
+py -3.12 -m tox -e integration
+py -3.12 -m tox -e preflight-fast
+py -3.12 -m tox -e preflight-slow
+py -3.12 -m tox -e preflight
+py -3.12 scripts/profile_validation.py --env package --env integration
 ```
 
-Use `python -m tox -e preflight` as the canonical local pre-push gate. It runs the same lint, docs, packaging, unit-test, and offline integration checks that Phase 3 CI expects through one local entrypoint after the dev dependencies are installed.
+Use `py -3.12 -m tox -e preflight` as the canonical local pre-push gate so local validation matches the Python version used in GitHub Actions. For normal iteration, prefer the specific lane you touched or `preflight-fast`; leave `preflight-slow` and the full `preflight` run for packaging, artifact, or final push checks.
+
+Current measured local Windows budgets are roughly:
+
+- `lint`: under `30s`
+- `docs`: under `30s`
+- `py312`: under `60s`
+- `package`: about `4-6m`
+- `integration`: about `8-10m`
+- `preflight`: about `14-16m`
+
+That makes `preflight` intentionally long because it is the sum of the expensive packaging and integration lanes, not because the fast lanes are slow. Use `scripts/profile_validation.py` when you need per-lane timings or need to confirm which component is driving a slow local run.
+
+## Investigating Slow Local Validation
+
+Use this sequence when `preflight` feels slow or unstable:
+
+1. `py -3.12 -m tox -e lint`
+2. `py -3.12 -m tox -e docs`
+3. `py -3.12 -m tox -e py312`
+4. `py -3.12 -m tox -e package`
+5. `py -3.12 -m tox -e integration`
+6. `py -3.12 scripts/profile_validation.py --env package --env integration`
+7. `py -3.12 -m tox -e preflight`
+
+Interpret the result this way:
+
+- if only `package` is unstable or much slower than expected, inspect `scripts/check_package.py` and its scratch or virtualenv path handling next
+- if only `integration` dominates, profile that suite next, starting with pytest duration reporting inside the integration lane
+- if both are stable individually but `preflight` still feels killed, treat that as a tooling-timeout or UX problem rather than a MarketLab runtime failure
 
 The MkDocs site now builds directly from the `docs/` directory, which is the canonical home for the public documentation set.
 
@@ -293,7 +350,10 @@ The MkDocs site now builds directly from the `docs/` directory, which is the can
 
 - Branch from a refreshed `master` instead of working directly on the default branch.
 - Keep changes in small intentional commits so review scope stays clear.
-- Run `python -m tox -e preflight` before pushing.
+- Run `py -3.12 -m tox -e preflight-fast` during normal iteration.
+- Run `py -3.12 -m tox -e package` for packaging or installed-CLI work.
+- Run `py -3.12 -m tox -e integration` for pipeline, config, artifact, or report changes.
+- Run `py -3.12 -m tox -e preflight` before pushing.
 - Open a pull request for review instead of pushing directly to `master`.
 - Treat the `Docker Runner` workflow as an optional manual smoke path, not as a required pre-push step.
 - Keep Codex skills and other personal automation assets in the user-local Codex home rather than in the public repository or package surface.
@@ -341,6 +401,8 @@ Before the first automated public release:
 - create the GitHub Actions environment named `pypi`
 
 The first automated public release target remains `v0.1.0`.
+
+
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -19,7 +19,7 @@ This document ties the current pieces together and records the working rules tha
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
-  - `buy_hold`, `sma`, and config-defined allocation baselines
+  - `buy_hold`, `sma`, config-defined allocation baselines, and optimizer input scaffolding for later optimized baselines
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
@@ -121,6 +121,15 @@ The required CI path stays offline and deterministic through tox. The Docker run
 - The `0.0` bps rows are theoretical gross-return baselines, while the row at the configured trading cost should match the current net-return path already reported elsewhere.
 - Cost-sensitivity reporting applies to `backtest` and `run-experiment`, but not to `train-models`.
 
+
+## Optimizer Scaffold Rules
+
+- `baselines.optimized` is a scaffold-only config surface in the current phase; it does not yet emit optimized strategy weights.
+- The scaffold exists to validate shared optimizer inputs, window timing, covariance estimation, and external file contracts before `mean_variance`, `risk_parity`, and `black_litterman` baselines land.
+- Trailing return windows are built from adjusted close data only, and the latest included return must end on the `signal_date`.
+- External covariance inputs must be square daily-return covariance matrices keyed by the configured symbols.
+- External expected-return inputs must contain exactly `symbol,expected_return` in daily decimal units.
+- If `baselines.optimized.enabled` is set today, the pipeline fails fast with a scaffold-only runtime error instead of pretending an optimizer baseline exists.
 
 ## System Map
 
@@ -353,6 +362,7 @@ classDiagram
       +buy_hold: bool
       +sma: SMAConfig
       +allocation: AllocationConfig
+      +optimized: OptimizedConfig
     }
 
     class SMAConfig {
@@ -367,6 +377,19 @@ classDiagram
       +symbol_weights: dict[str, float]
       +group_weights: dict[str, float]
     }
+    class OptimizedConfig {
+      +enabled: bool
+      +method: str
+      +lookback_days: int
+      +rebalance_frequency: str
+      +covariance_estimator: str
+      +external_covariance_path: str
+      +expected_return_source: str
+      +external_expected_returns_path: str
+      +long_only: bool
+      +target_gross_exposure: float
+    }
+
     class EvaluationConfig {
       +walk_forward: WalkForwardConfig
     }
@@ -697,6 +720,18 @@ Best practice:
 - Reuses the shared rebalance cadence and emits full-symbol target rows on the first trading date and each later effective rebalance date.
 - Supports equal, exact symbol-weight, and group-sleeve allocation modes.
 
+### `src/marketlab/strategies/optimized.py`
+
+- Builds reusable optimizer input windows from the daily adjusted-close panel without introducing look-ahead.
+- Produces trailing common-date daily return matrices keyed by `signal_date` and `effective_date`.
+- Provides covariance helpers for `sample`, `ewma`, `diagonal_shrinkage`, and `external_csv` inputs.
+- Provides expected-return helpers for `historical_mean` and `external_csv` inputs.
+- Reorders and validates external covariance and expected-return files against `data.symbols`.
+
+Best practice:
+- Keep this module limited to optimizer inputs and estimators until actual optimized baselines land.
+- Use adjusted close returns ending on the signal date and reject malformed external files early.
+
 ### `src/marketlab/strategies/buy_hold.py`
 
 - Emits one equal-weight allocation on the first available date and then lets weights drift until the backtest engine sees another target row.
@@ -833,6 +868,9 @@ Best practice:
 - Do not batch multiple strategies into a single `run_backtest(...)` call.
 - Do not redesign the current data layer just to support later model abstractions.
 - Preserve the local launcher and E2E runner as the default developer entrypoints.
+
+
+
 
 
 

--- a/scripts/profile_validation.py
+++ b/scripts/profile_validation.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+VALID_ENVS = ("lint", "docs", "py312", "package", "integration")
+DEFAULT_ENVS = VALID_ENVS
+CI_PYTHON = (3, 12)
+
+
+@dataclass(slots=True)
+class LaneResult:
+    env: str
+    exit_code: int
+    elapsed_seconds: float
+
+
+def resolve_envs(envs: list[str] | None) -> list[str]:
+    if not envs:
+        return list(DEFAULT_ENVS)
+    return list(envs)
+
+
+def python_warning(version_info: tuple[int, int] | None = None) -> str | None:
+    major, minor = version_info or sys.version_info[:2]
+    if (major, minor) == CI_PYTHON:
+        return None
+    return (
+        f"Warning: current interpreter is Python {major}.{minor}. "
+        "Use `py -3.12 ...` to match the local CI defaults and GitHub Actions."
+    )
+
+
+def build_tox_command(env: str) -> list[str]:
+    return [sys.executable, "-m", "tox", "-e", env]
+
+
+def default_runner(command: list[str]) -> int:
+    completed = subprocess.run(command, check=False)
+    return completed.returncode
+
+
+def build_summary_table(results: list[LaneResult]) -> str:
+    lines = [
+        "Validation Summary",
+        f"{'env':<16}{'exit':>8}{'seconds':>12}",
+        f"{'-' * 16}{'-' * 8}{'-' * 12}",
+    ]
+    for result in results:
+        lines.append(
+            f"{result.env:<16}{result.exit_code:>8}{result.elapsed_seconds:>12.2f}"
+        )
+    if results:
+        total_seconds = sum(result.elapsed_seconds for result in results)
+        lines.append(f"{'total':<16}{'':>8}{total_seconds:>12.2f}")
+    return "\n".join(lines)
+
+
+def run_validation(
+    envs: list[str],
+    *,
+    runner: Callable[[list[str]], int] = default_runner,
+    out: Callable[[str], None] = print,
+    version_info: tuple[int, int] | None = None,
+) -> int:
+    warning = python_warning(version_info)
+    if warning is not None:
+        out(warning)
+
+    results: list[LaneResult] = []
+    first_failure = 0
+
+    for env in envs:
+        command = build_tox_command(env)
+        out(f"[start] {env}: {' '.join(command)}")
+        started_at = time.perf_counter()
+        exit_code = runner(command)
+        elapsed_seconds = time.perf_counter() - started_at
+        out(f"[finish] {env}: exit={exit_code} elapsed={elapsed_seconds:.2f}s")
+        results.append(
+            LaneResult(
+                env=env,
+                exit_code=exit_code,
+                elapsed_seconds=elapsed_seconds,
+            )
+        )
+        if exit_code != 0:
+            first_failure = exit_code
+            break
+
+    out(build_summary_table(results))
+    return first_failure
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Profile local validation lanes one tox environment at a time."
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        choices=VALID_ENVS,
+        dest="envs",
+        help="Run only the selected tox env. Repeat to run multiple envs in order.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    envs = resolve_envs(args.envs)
+    return run_validation(envs)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
@@ -8,6 +8,9 @@ from typing import Any
 import yaml
 
 ALLOCATION_MODES = {"equal", "group_weights", "symbol_weights"}
+OPTIMIZED_METHODS = {"black_litterman", "mean_variance", "risk_parity"}
+COVARIANCE_ESTIMATORS = {"diagonal_shrinkage", "ewma", "external_csv", "sample"}
+EXPECTED_RETURN_SOURCES = {"external_csv", "historical_mean"}
 WEIGHT_TOLERANCE = 1e-6
 
 
@@ -85,10 +88,25 @@ class AllocationConfig:
 
 
 @dataclass(slots=True)
+class OptimizedConfig:
+    enabled: bool = False
+    method: str = "mean_variance"
+    lookback_days: int = 252
+    rebalance_frequency: str = "W-FRI"
+    covariance_estimator: str = "sample"
+    external_covariance_path: str = ""
+    expected_return_source: str = "historical_mean"
+    external_expected_returns_path: str = ""
+    long_only: bool = True
+    target_gross_exposure: float = 1.0
+
+
+@dataclass(slots=True)
 class BaselinesConfig:
     buy_hold: bool = True
     sma: SMAConfig = field(default_factory=SMAConfig)
     allocation: AllocationConfig = field(default_factory=AllocationConfig)
+    optimized: OptimizedConfig = field(default_factory=OptimizedConfig)
 
 
 @dataclass(slots=True)
@@ -161,6 +179,20 @@ class ExperimentConfig:
     def output_dir(self) -> Path:
         return self.resolve_path(self.artifacts.output_dir)
 
+    @property
+    def optimized_external_covariance_path(self) -> Path | None:
+        path = self.baselines.optimized.external_covariance_path
+        if path == "":
+            return None
+        return self.resolve_path(path)
+
+    @property
+    def optimized_external_expected_returns_path(self) -> Path | None:
+        path = self.baselines.optimized.external_expected_returns_path
+        if path == "":
+            return None
+        return self.resolve_path(path)
+
 
 def _section(cls: type[Any], data: dict[str, Any] | None) -> Any:
     values = data or {}
@@ -188,6 +220,12 @@ def _normalize_mapping_sections(config: ExperimentConfig) -> None:
     if config.evaluation.cost_sensitivity_bps is None:
         config.evaluation.cost_sensitivity_bps = []
 
+    optimized = config.baselines.optimized
+    if optimized.external_covariance_path is None:
+        optimized.external_covariance_path = ""
+    if optimized.external_expected_returns_path is None:
+        optimized.external_expected_returns_path = ""
+
 
 def _validate_weights(label: str, weights: dict[str, float]) -> None:
     if any(value < 0.0 for value in weights.values()):
@@ -208,6 +246,11 @@ def _validate_non_negative_bps_list(label: str, values: list[float]) -> None:
     for value in values:
         if not math.isfinite(value) or value < 0.0:
             raise ValueError(f"{label} must contain only finite non-negative values.")
+
+
+def _validate_positive_float(label: str, value: float) -> None:
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{label} must be a finite positive value.")
 
 
 def _validate_config(config: ExperimentConfig) -> None:
@@ -244,6 +287,45 @@ def _validate_config(config: ExperimentConfig) -> None:
         "evaluation.cost_sensitivity_bps",
         config.evaluation.cost_sensitivity_bps,
     )
+
+    optimized = config.baselines.optimized
+    if optimized.method not in OPTIMIZED_METHODS:
+        allowed = ", ".join(sorted(OPTIMIZED_METHODS))
+        raise ValueError(f"baselines.optimized.method must be one of: {allowed}")
+    if optimized.covariance_estimator not in COVARIANCE_ESTIMATORS:
+        allowed = ", ".join(sorted(COVARIANCE_ESTIMATORS))
+        raise ValueError(f"baselines.optimized.covariance_estimator must be one of: {allowed}")
+    if optimized.expected_return_source not in EXPECTED_RETURN_SOURCES:
+        allowed = ", ".join(sorted(EXPECTED_RETURN_SOURCES))
+        raise ValueError(f"baselines.optimized.expected_return_source must be one of: {allowed}")
+    if optimized.lookback_days < 2:
+        raise ValueError("baselines.optimized.lookback_days must be at least 2.")
+    _validate_positive_float(
+        "baselines.optimized.target_gross_exposure",
+        optimized.target_gross_exposure,
+    )
+    if optimized.covariance_estimator == "external_csv":
+        if optimized.external_covariance_path == "":
+            raise ValueError(
+                "baselines.optimized.external_covariance_path is required when "
+                "baselines.optimized.covariance_estimator='external_csv'."
+            )
+    elif optimized.external_covariance_path != "":
+        raise ValueError(
+            "baselines.optimized.external_covariance_path must be empty unless "
+            "baselines.optimized.covariance_estimator='external_csv'."
+        )
+    if optimized.expected_return_source == "external_csv":
+        if optimized.external_expected_returns_path == "":
+            raise ValueError(
+                "baselines.optimized.external_expected_returns_path is required when "
+                "baselines.optimized.expected_return_source='external_csv'."
+            )
+    elif optimized.external_expected_returns_path != "":
+        raise ValueError(
+            "baselines.optimized.external_expected_returns_path must be empty unless "
+            "baselines.optimized.expected_return_source='external_csv'."
+        )
 
     allocation = config.baselines.allocation
     if allocation.mode not in ALLOCATION_MODES:
@@ -317,6 +399,10 @@ def load_config(path: str | Path) -> ExperimentConfig:
                 AllocationConfig,
                 (payload.get("baselines") or {}).get("allocation"),
             ),
+            optimized=_section(
+                OptimizedConfig,
+                (payload.get("baselines") or {}).get("optimized"),
+            ),
         ),
         models=[
             _section(ModelSpec, item)
@@ -336,5 +422,3 @@ def load_config(path: str | Path) -> ExperimentConfig:
     _normalize_mapping_sections(config)
     _validate_config(config)
     return config
-
-

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -350,6 +350,10 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
     )
 
     backtest_results: list[BacktestResult] = []
+    if config.baselines.optimized.enabled:
+        raise RuntimeError(
+            "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
+        )
     if config.baselines.buy_hold:
         weights = buy_hold_weights(featured)
         backtest_results.append(
@@ -450,6 +454,10 @@ def _run_ml_strategies(
     predictions: pd.DataFrame,
 ) -> BacktestResult:
     backtest_results: list[BacktestResult] = []
+    if config.baselines.optimized.enabled:
+        raise RuntimeError(
+            "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
+        )
 
     for _, model_predictions in predictions.groupby("model_name", sort=True):
         weights = ranking_weights(
@@ -692,6 +700,8 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         score_histograms=training_outputs.score_histograms,
         threshold_diagnostics=training_outputs.threshold_diagnostics,
     )
+
+
 
 
 

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from marketlab.rebalance import signal_effective_dates
+
+COVARIANCE_ESTIMATORS = {"diagonal_shrinkage", "ewma", "external_csv", "sample"}
+EXPECTED_RETURN_SOURCES = {"external_csv", "historical_mean"}
+EWMA_LAMBDA = 0.94
+DIAGONAL_SHRINKAGE_WEIGHT = 0.10
+REQUIRED_PANEL_COLUMNS = {"adj_close", "symbol", "timestamp"}
+
+
+@dataclass(slots=True)
+class OptimizerWindow:
+    signal_date: pd.Timestamp
+    effective_date: pd.Timestamp
+    symbols: list[str]
+    returns: pd.DataFrame
+
+
+@dataclass(slots=True)
+class OptimizerInput:
+    signal_date: pd.Timestamp
+    effective_date: pd.Timestamp
+    symbols: list[str]
+    returns: pd.DataFrame
+    covariance: pd.DataFrame
+    expected_returns: pd.Series
+
+
+def _require_columns(panel: pd.DataFrame) -> None:
+    missing = REQUIRED_PANEL_COLUMNS - set(panel.columns)
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise ValueError(f"Panel is missing required columns for optimizer inputs: {joined}")
+
+
+def _normalized_panel(panel: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(panel)
+    if panel.empty:
+        return panel.copy()
+
+    return (
+        panel.loc[:, ["symbol", "timestamp", "adj_close"]]
+        .copy()
+        .assign(timestamp=lambda frame: pd.to_datetime(frame["timestamp"]))
+        .sort_values(["symbol", "timestamp"])
+        .reset_index(drop=True)
+    )
+
+
+def _validated_symbols(panel: pd.DataFrame, symbols: list[str]) -> list[str]:
+    missing_symbols = sorted(set(symbols) - set(panel["symbol"].unique()))
+    if missing_symbols:
+        joined = ", ".join(missing_symbols)
+        raise ValueError(f"Panel is missing symbols required for optimizer inputs: {joined}")
+    return list(symbols)
+
+
+def _common_daily_returns(panel: pd.DataFrame, symbols: list[str]) -> pd.DataFrame:
+    working = _normalized_panel(panel)
+    if working.empty:
+        return pd.DataFrame(columns=symbols, dtype=float)
+
+    ordered_symbols = _validated_symbols(working, symbols)
+    adj_close = (
+        working.loc[working["symbol"].isin(ordered_symbols)]
+        .pivot(index="timestamp", columns="symbol", values="adj_close")
+        .reindex(columns=ordered_symbols)
+        .sort_index()
+    )
+    daily_returns = adj_close.pct_change(fill_method=None).dropna(how="any")
+    return daily_returns.astype(float)
+
+
+def build_optimizer_windows(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    lookback_days: int,
+    frequency: str = "W-FRI",
+) -> list[OptimizerWindow]:
+    if lookback_days < 2:
+        raise ValueError("lookback_days must be at least 2.")
+
+    working = _normalized_panel(panel)
+    if working.empty:
+        return []
+
+    ordered_symbols = _validated_symbols(working, symbols)
+    effective_dates = signal_effective_dates(working, frequency)
+    common_returns = _common_daily_returns(working, ordered_symbols)
+    windows: list[OptimizerWindow] = []
+
+    for signal_date, effective_date in effective_dates.items():
+        signal_timestamp = pd.Timestamp(signal_date)
+        if signal_timestamp not in common_returns.index:
+            continue
+
+        trailing_returns = common_returns.loc[common_returns.index <= signal_timestamp].tail(lookback_days)
+        if len(trailing_returns) < lookback_days:
+            continue
+        if pd.Timestamp(trailing_returns.index[-1]) != signal_timestamp:
+            continue
+
+        windows.append(
+            OptimizerWindow(
+                signal_date=signal_timestamp,
+                effective_date=pd.Timestamp(effective_date),
+                symbols=ordered_symbols,
+                returns=trailing_returns.loc[:, ordered_symbols].copy(),
+            )
+        )
+
+    return windows
+
+
+def load_external_covariance(path: Path | str, *, symbols: list[str]) -> pd.DataFrame:
+    covariance = pd.read_csv(Path(path), index_col=0)
+    if covariance.shape[0] != covariance.shape[1]:
+        raise ValueError("External covariance CSV must be a square matrix.")
+
+    covariance.index = covariance.index.map(str)
+    covariance.columns = covariance.columns.map(str)
+    ordered_symbols = list(symbols)
+    symbol_set = set(ordered_symbols)
+    if set(covariance.index) != symbol_set or set(covariance.columns) != symbol_set:
+        raise ValueError("External covariance CSV must contain exactly the configured symbols.")
+
+    covariance = covariance.loc[ordered_symbols, ordered_symbols]
+    covariance = covariance.apply(pd.to_numeric, errors="raise")
+    if not np.isfinite(covariance.to_numpy(dtype=float)).all():
+        raise ValueError("External covariance CSV must contain only finite numeric values.")
+    return covariance.astype(float)
+
+
+def estimate_covariance_matrix(
+    returns: pd.DataFrame,
+    *,
+    method: str = "sample",
+    external_path: Path | str | None = None,
+) -> pd.DataFrame:
+    ordered_symbols = list(returns.columns)
+    if method not in COVARIANCE_ESTIMATORS:
+        allowed = ", ".join(sorted(COVARIANCE_ESTIMATORS))
+        raise ValueError(f"Unsupported covariance estimator: {method}. Expected one of: {allowed}")
+
+    if method == "external_csv":
+        if external_path is None:
+            raise ValueError("external_path is required when method='external_csv'.")
+        return load_external_covariance(external_path, symbols=ordered_symbols)
+
+    if external_path is not None:
+        raise ValueError("external_path must be omitted unless method='external_csv'.")
+
+    if returns.empty:
+        return pd.DataFrame(index=ordered_symbols, columns=ordered_symbols, dtype=float)
+
+    if method == "sample":
+        return returns.cov().loc[ordered_symbols, ordered_symbols].astype(float)
+
+    if method == "ewma":
+        values = returns.loc[:, ordered_symbols].to_numpy(dtype=float)
+        row_count = len(values)
+        weights = (1.0 - EWMA_LAMBDA) * (EWMA_LAMBDA ** np.arange(row_count - 1, -1, -1))
+        weights = weights / weights.sum()
+        mean = np.average(values, axis=0, weights=weights)
+        centered = values - mean
+        covariance = centered.T @ (centered * weights[:, None])
+        return pd.DataFrame(covariance, index=ordered_symbols, columns=ordered_symbols, dtype=float)
+
+    sample_covariance = returns.cov().loc[ordered_symbols, ordered_symbols].astype(float)
+    diagonal_covariance = pd.DataFrame(
+        np.diag(np.diag(sample_covariance.to_numpy(dtype=float))),
+        index=ordered_symbols,
+        columns=ordered_symbols,
+        dtype=float,
+    )
+    return ((1.0 - DIAGONAL_SHRINKAGE_WEIGHT) * sample_covariance) + (
+        DIAGONAL_SHRINKAGE_WEIGHT * diagonal_covariance
+    )
+
+
+def load_external_expected_returns(path: Path | str, *, symbols: list[str]) -> pd.Series:
+    expected_returns = pd.read_csv(Path(path))
+    expected_columns = ["symbol", "expected_return"]
+    if list(expected_returns.columns) != expected_columns:
+        raise ValueError(
+            "External expected returns CSV must have exactly these columns: symbol, expected_return."
+        )
+
+    expected_returns["symbol"] = expected_returns["symbol"].astype(str)
+    ordered_symbols = list(symbols)
+    symbol_set = set(ordered_symbols)
+    if set(expected_returns["symbol"]) != symbol_set:
+        raise ValueError("External expected returns CSV must contain exactly the configured symbols.")
+    if expected_returns["symbol"].duplicated().any():
+        raise ValueError("External expected returns CSV must contain one row per symbol.")
+
+    series = pd.to_numeric(
+        expected_returns.set_index("symbol").loc[ordered_symbols, "expected_return"],
+        errors="raise",
+    )
+    if not np.isfinite(series.to_numpy(dtype=float)).all():
+        raise ValueError("External expected returns CSV must contain only finite numeric values.")
+    series.name = "expected_return"
+    return series.astype(float)
+
+
+def estimate_expected_returns(
+    returns: pd.DataFrame,
+    *,
+    source: str = "historical_mean",
+    external_path: Path | str | None = None,
+) -> pd.Series:
+    ordered_symbols = list(returns.columns)
+    if source not in EXPECTED_RETURN_SOURCES:
+        allowed = ", ".join(sorted(EXPECTED_RETURN_SOURCES))
+        raise ValueError(f"Unsupported expected return source: {source}. Expected one of: {allowed}")
+
+    if source == "external_csv":
+        if external_path is None:
+            raise ValueError("external_path is required when source='external_csv'.")
+        return load_external_expected_returns(external_path, symbols=ordered_symbols)
+
+    if external_path is not None:
+        raise ValueError("external_path must be omitted unless source='external_csv'.")
+
+    return returns.loc[:, ordered_symbols].mean(axis=0).astype(float).rename("expected_return")
+
+
+def build_optimizer_inputs(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    lookback_days: int,
+    frequency: str = "W-FRI",
+    covariance_estimator: str = "sample",
+    external_covariance_path: Path | str | None = None,
+    expected_return_source: str = "historical_mean",
+    external_expected_returns_path: Path | str | None = None,
+) -> list[OptimizerInput]:
+    windows = build_optimizer_windows(
+        panel,
+        symbols=symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+    )
+    if not windows:
+        return []
+
+    shared_covariance: pd.DataFrame | None = None
+    if covariance_estimator == "external_csv":
+        if external_covariance_path is None:
+            raise ValueError("external_covariance_path is required when covariance_estimator='external_csv'.")
+        shared_covariance = load_external_covariance(
+            external_covariance_path,
+            symbols=windows[0].symbols,
+        )
+
+    shared_expected_returns: pd.Series | None = None
+    if expected_return_source == "external_csv":
+        if external_expected_returns_path is None:
+            raise ValueError(
+                "external_expected_returns_path is required when expected_return_source='external_csv'."
+            )
+        shared_expected_returns = load_external_expected_returns(
+            external_expected_returns_path,
+            symbols=windows[0].symbols,
+        )
+
+    inputs: list[OptimizerInput] = []
+    for window in windows:
+        covariance = (
+            shared_covariance.copy()
+            if shared_covariance is not None
+            else estimate_covariance_matrix(window.returns, method=covariance_estimator)
+        )
+        expected_returns = (
+            shared_expected_returns.copy()
+            if shared_expected_returns is not None
+            else estimate_expected_returns(window.returns, source=expected_return_source)
+        )
+        inputs.append(
+            OptimizerInput(
+                signal_date=window.signal_date,
+                effective_date=window.effective_date,
+                symbols=window.symbols,
+                returns=window.returns.copy(),
+                covariance=covariance.loc[window.symbols, window.symbols].copy(),
+                expected_returns=expected_returns.loc[window.symbols].copy(),
+            )
+        )
+
+    return inputs
+

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -245,14 +245,7 @@ def build_optimizer_inputs(
     expected_return_source: str = "historical_mean",
     external_expected_returns_path: Path | str | None = None,
 ) -> list[OptimizerInput]:
-    windows = build_optimizer_windows(
-        panel,
-        symbols=symbols,
-        lookback_days=lookback_days,
-        frequency=frequency,
-    )
-    if not windows:
-        return []
+    ordered_symbols = list(symbols)
 
     shared_covariance: pd.DataFrame | None = None
     if covariance_estimator == "external_csv":
@@ -260,7 +253,13 @@ def build_optimizer_inputs(
             raise ValueError("external_covariance_path is required when covariance_estimator='external_csv'.")
         shared_covariance = load_external_covariance(
             external_covariance_path,
-            symbols=windows[0].symbols,
+            symbols=ordered_symbols,
+        )
+    else:
+        estimate_covariance_matrix(
+            pd.DataFrame(columns=ordered_symbols, dtype=float),
+            method=covariance_estimator,
+            external_path=external_covariance_path,
         )
 
     shared_expected_returns: pd.Series | None = None
@@ -271,8 +270,23 @@ def build_optimizer_inputs(
             )
         shared_expected_returns = load_external_expected_returns(
             external_expected_returns_path,
-            symbols=windows[0].symbols,
+            symbols=ordered_symbols,
         )
+    else:
+        estimate_expected_returns(
+            pd.DataFrame(columns=ordered_symbols, dtype=float),
+            source=expected_return_source,
+            external_path=external_expected_returns_path,
+        )
+
+    windows = build_optimizer_windows(
+        panel,
+        symbols=ordered_symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+    )
+    if not windows:
+        return []
 
     inputs: list[OptimizerInput] = []
     for window in windows:

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.integration import _cli_harness
+
+from marketlab.data.panel import save_panel_csv
+
+assert_command_ok = _cli_harness.assert_command_ok
+build_synthetic_panel = _cli_harness.build_synthetic_panel
+load_fixture_panel = _cli_harness.load_fixture_panel
+run_marketlab_cli = getattr(
+    _cli_harness,
+    "run_marketlab_cli",
+    _cli_harness.run_launcher_command,
+)
+write_yaml_config = _cli_harness.write_yaml_config
+
+ERROR_MESSAGE = "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
+
+
+def _write_backtest_config(tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    save_panel_csv(load_fixture_panel(), cache_dir / "panel.csv")
+    return write_yaml_config(
+        tmp_path / "backtest.yaml",
+        {
+            "experiment_name": "optimized_scaffold_backtest",
+            "data": {
+                "symbols": ["VOO", "QQQ", "SMH", "XLV", "IEMG"],
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+                "interval": "1d",
+                "cache_dir": str(cache_dir),
+                "prepared_panel_filename": "panel.csv",
+            },
+            "features": {
+                "return_windows": [2, 3],
+                "ma_windows": [2, 3],
+                "vol_windows": [2],
+                "momentum_window": 2,
+            },
+            "portfolio": {
+                "costs": {"bps_per_trade": 10},
+            },
+            "baselines": {
+                "buy_hold": True,
+                "sma": {"enabled": True, "fast_window": 2, "slow_window": 3},
+                "optimized": {
+                    "enabled": True,
+                    "method": "mean_variance",
+                },
+            },
+            "artifacts": {
+                "output_dir": str(tmp_path / "runs"),
+                "save_predictions": False,
+                "save_metrics_csv": True,
+                "save_report_md": True,
+                "save_plots": True,
+            },
+        },
+    )
+
+
+def _write_run_experiment_config(tmp_path: Path) -> Path:
+    cache_dir = tmp_path / "cache"
+    save_panel_csv(
+        build_synthetic_panel(
+            (("AAA", 100.0, 0.45), ("BBB", 130.0, 0.40), ("CCC", 160.0, 0.35), ("DDD", 190.0, 0.30)),
+            start_date="2020-01-01",
+            end_date="2024-12-31",
+        ),
+        cache_dir / "panel.csv",
+    )
+    return write_yaml_config(
+        tmp_path / "integration.yaml",
+        {
+            "experiment_name": "optimized_scaffold_experiment",
+            "data": {
+                "symbols": ["AAA", "BBB", "CCC", "DDD"],
+                "start_date": "2020-01-01",
+                "end_date": "2024-12-31",
+                "interval": "1d",
+                "cache_dir": str(cache_dir),
+                "prepared_panel_filename": "panel.csv",
+            },
+            "features": {
+                "return_windows": [5, 10],
+                "ma_windows": [5, 10],
+                "vol_windows": [5],
+                "momentum_window": 10,
+            },
+            "target": {
+                "horizon_days": 5,
+                "type": "direction",
+            },
+            "portfolio": {
+                "ranking": {
+                    "long_n": 2,
+                    "short_n": 2,
+                    "rebalance_frequency": "W-FRI",
+                    "weighting": "equal",
+                    "mode": "long_short",
+                    "min_score_threshold": 0.0,
+                    "cash_when_underfilled": False,
+                },
+                "costs": {"bps_per_trade": 10},
+            },
+            "baselines": {
+                "buy_hold": True,
+                "sma": {"enabled": True, "fast_window": 5, "slow_window": 10},
+                "optimized": {
+                    "enabled": True,
+                    "method": "mean_variance",
+                },
+            },
+            "models": [{"name": "logistic_regression"}],
+            "evaluation": {
+                "walk_forward": {
+                    "train_years": 1,
+                    "test_months": 2,
+                    "step_months": 2,
+                },
+            },
+            "artifacts": {
+                "output_dir": str(tmp_path / "runs"),
+                "save_predictions": True,
+                "save_metrics_csv": True,
+                "save_report_md": True,
+                "save_plots": True,
+            },
+        },
+    )
+
+
+def test_backtest_rejects_unimplemented_optimized_baseline(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(tmp_path)
+
+    result = run_marketlab_cli("backtest", config_path)
+
+    assert result.returncode != 0
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert ERROR_MESSAGE in combined_output
+    assert not (tmp_path / "runs" / "optimized_scaffold_backtest").exists()
+
+
+
+def test_run_experiment_rejects_unimplemented_optimized_baseline(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(tmp_path)
+
+    result = run_marketlab_cli("run-experiment", config_path)
+
+    assert result.returncode != 0
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert ERROR_MESSAGE in combined_output
+    assert not (tmp_path / "runs" / "optimized_scaffold_experiment").exists()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -49,6 +49,18 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
     assert config.baselines.allocation.mode == "equal"
     assert config.baselines.allocation.symbol_weights == {}
     assert config.baselines.allocation.group_weights == {}
+    assert config.baselines.optimized.enabled is False
+    assert config.baselines.optimized.method == "mean_variance"
+    assert config.baselines.optimized.lookback_days == 252
+    assert config.baselines.optimized.rebalance_frequency == "W-FRI"
+    assert config.baselines.optimized.covariance_estimator == "sample"
+    assert config.baselines.optimized.external_covariance_path == ""
+    assert config.baselines.optimized.expected_return_source == "historical_mean"
+    assert config.baselines.optimized.external_expected_returns_path == ""
+    assert config.baselines.optimized.long_only is True
+    assert config.baselines.optimized.target_gross_exposure == pytest.approx(1.0)
+    assert config.optimized_external_covariance_path is None
+    assert config.optimized_external_expected_returns_path is None
     assert config.portfolio.risk.max_position_weight is None
     assert config.portfolio.risk.max_group_weight is None
     assert config.portfolio.risk.max_long_exposure is None
@@ -65,7 +77,11 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
                 "enabled": False,
                 "symbol_weights": None,
                 "group_weights": None,
-            }
+            },
+            "optimized": {
+                "external_covariance_path": None,
+                "external_expected_returns_path": None,
+            },
         },
         evaluation={"cost_sensitivity_bps": None},
     )
@@ -75,6 +91,8 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
     assert config.data.symbol_groups == {}
     assert config.baselines.allocation.symbol_weights == {}
     assert config.baselines.allocation.group_weights == {}
+    assert config.baselines.optimized.external_covariance_path == ""
+    assert config.baselines.optimized.external_expected_returns_path == ""
     assert config.evaluation.cost_sensitivity_bps == []
 
 
@@ -251,3 +269,78 @@ def test_load_config_rejects_invalid_cost_sensitivity_bps(
     ):
         load_config(config_path)
 
+
+@pytest.mark.parametrize(
+    ("optimized", "message"),
+    [
+        (
+            {"method": "unknown"},
+            "baselines.optimized.method must be one of",
+        ),
+        (
+            {"covariance_estimator": "unknown"},
+            "baselines.optimized.covariance_estimator must be one of",
+        ),
+        (
+            {"expected_return_source": "unknown"},
+            "baselines.optimized.expected_return_source must be one of",
+        ),
+        (
+            {"lookback_days": 1},
+            "baselines.optimized.lookback_days must be at least 2",
+        ),
+        (
+            {"target_gross_exposure": 0.0},
+            "baselines.optimized.target_gross_exposure must be a finite positive value",
+        ),
+        (
+            {"covariance_estimator": "external_csv"},
+            "baselines.optimized.external_covariance_path is required when baselines.optimized.covariance_estimator='external_csv'",
+        ),
+        (
+            {"covariance_estimator": "sample", "external_covariance_path": "cov.csv"},
+            "baselines.optimized.external_covariance_path must be empty unless baselines.optimized.covariance_estimator='external_csv'",
+        ),
+        (
+            {"expected_return_source": "external_csv"},
+            "baselines.optimized.external_expected_returns_path is required when baselines.optimized.expected_return_source='external_csv'",
+        ),
+        (
+            {"expected_return_source": "historical_mean", "external_expected_returns_path": "expected.csv"},
+            "baselines.optimized.external_expected_returns_path must be empty unless baselines.optimized.expected_return_source='external_csv'",
+        ),
+    ],
+)
+def test_load_config_rejects_invalid_optimized_scaffold_settings(
+    tmp_path: Path,
+    optimized: dict[str, object],
+    message: str,
+) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        baselines={"optimized": optimized},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_config(config_path)
+
+
+def test_load_config_resolves_relative_optimized_external_paths(tmp_path: Path) -> None:
+    config_dir = tmp_path / "nested"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = _write_config(
+        config_dir / "config.yaml",
+        baselines={
+            "optimized": {
+                "covariance_estimator": "external_csv",
+                "external_covariance_path": "inputs/covariance.csv",
+                "expected_return_source": "external_csv",
+                "external_expected_returns_path": "inputs/expected.csv",
+            }
+        },
+    )
+
+    config = load_config(config_path)
+
+    assert config.optimized_external_covariance_path == (config_dir / "inputs" / "covariance.csv").resolve()
+    assert config.optimized_external_expected_returns_path == (config_dir / "inputs" / "expected.csv").resolve()

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marketlab.strategies.optimized import (
+    DIAGONAL_SHRINKAGE_WEIGHT,
+    EWMA_LAMBDA,
+    build_optimizer_inputs,
+    build_optimizer_windows,
+    estimate_covariance_matrix,
+    estimate_expected_returns,
+    load_external_covariance,
+    load_external_expected_returns,
+)
+
+
+def _build_panel(*, missing_bbb_on: str | None = None) -> pd.DataFrame:
+    trading_dates = pd.bdate_range("2024-01-01", "2024-01-19")
+    rows: list[dict[str, object]] = []
+    for symbol, base_price, daily_step in (
+        ("AAA", 100.0, 1.0),
+        ("BBB", 120.0, 0.5),
+    ):
+        for index, timestamp in enumerate(trading_dates):
+            if symbol == "BBB" and missing_bbb_on is not None and timestamp == pd.Timestamp(missing_bbb_on):
+                continue
+            close_price = base_price + (daily_step * index)
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "timestamp": timestamp,
+                    "adj_close": close_price,
+                }
+            )
+
+    return pd.DataFrame(rows).sort_values(["symbol", "timestamp"]).reset_index(drop=True)
+
+
+def test_build_optimizer_windows_uses_signal_dates_and_common_history() -> None:
+    windows = build_optimizer_windows(
+        _build_panel(),
+        symbols=["AAA", "BBB"],
+        lookback_days=3,
+        frequency="W-FRI",
+    )
+
+    assert len(windows) >= 2
+    first_window = windows[0]
+    assert first_window.signal_date == pd.Timestamp("2024-01-05")
+    assert first_window.effective_date == pd.Timestamp("2024-01-08")
+    assert first_window.symbols == ["AAA", "BBB"]
+    assert list(first_window.returns.columns) == ["AAA", "BBB"]
+    assert len(first_window.returns) == 3
+    assert first_window.returns.index.min() == pd.Timestamp("2024-01-03")
+    assert first_window.returns.index.max() == pd.Timestamp("2024-01-05")
+
+
+def test_build_optimizer_windows_skips_signal_dates_without_common_signal_return() -> None:
+    windows = build_optimizer_windows(
+        _build_panel(missing_bbb_on="2024-01-05"),
+        symbols=["AAA", "BBB"],
+        lookback_days=3,
+        frequency="W-FRI",
+    )
+
+    assert [window.signal_date for window in windows] == [pd.Timestamp("2024-01-12")]
+
+
+def test_estimate_covariance_matrix_sample_matches_pandas_covariance() -> None:
+    returns = pd.DataFrame(
+        {
+            "AAA": [0.01, 0.02, -0.01],
+            "BBB": [0.00, 0.01, 0.03],
+        }
+    )
+
+    covariance = estimate_covariance_matrix(returns, method="sample")
+
+    pd.testing.assert_frame_equal(covariance, returns.cov())
+
+
+def test_estimate_covariance_matrix_ewma_matches_weighted_formula() -> None:
+    returns = pd.DataFrame(
+        {
+            "AAA": [0.01, 0.02, -0.01],
+            "BBB": [0.00, 0.01, 0.03],
+        }
+    )
+
+    covariance = estimate_covariance_matrix(returns, method="ewma")
+
+    values = returns.to_numpy(dtype=float)
+    weights = (1.0 - EWMA_LAMBDA) * (EWMA_LAMBDA ** np.arange(len(values) - 1, -1, -1))
+    weights = weights / weights.sum()
+    mean = np.average(values, axis=0, weights=weights)
+    centered = values - mean
+    expected = centered.T @ (centered * weights[:, None])
+    expected_frame = pd.DataFrame(expected, index=returns.columns, columns=returns.columns)
+
+    pd.testing.assert_frame_equal(covariance, expected_frame)
+
+
+def test_estimate_covariance_matrix_diagonal_shrinkage_blends_sample_and_diagonal() -> None:
+    returns = pd.DataFrame(
+        {
+            "AAA": [0.01, 0.02, -0.01],
+            "BBB": [0.00, 0.01, 0.03],
+        }
+    )
+
+    covariance = estimate_covariance_matrix(returns, method="diagonal_shrinkage")
+    sample_covariance = returns.cov()
+    diagonal_only = pd.DataFrame(
+        np.diag(np.diag(sample_covariance.to_numpy(dtype=float))),
+        index=returns.columns,
+        columns=returns.columns,
+        dtype=float,
+    )
+    expected = ((1.0 - DIAGONAL_SHRINKAGE_WEIGHT) * sample_covariance) + (
+        DIAGONAL_SHRINKAGE_WEIGHT * diagonal_only
+    )
+
+    pd.testing.assert_frame_equal(covariance, expected)
+
+
+def test_load_external_covariance_reorders_symbols_and_rejects_mismatches(tmp_path: Path) -> None:
+    covariance_path = tmp_path / "covariance.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["BBB", "AAA"],
+            "BBB": [0.04, 0.01],
+            "AAA": [0.01, 0.09],
+        }
+    ).to_csv(covariance_path, index=False)
+
+    covariance = load_external_covariance(covariance_path, symbols=["AAA", "BBB"])
+
+    assert list(covariance.index) == ["AAA", "BBB"]
+    assert list(covariance.columns) == ["AAA", "BBB"]
+    assert covariance.loc["AAA", "BBB"] == pytest.approx(0.01)
+
+    mismatch_path = tmp_path / "covariance_bad.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "CCC"],
+            "AAA": [0.09, 0.01],
+            "CCC": [0.01, 0.04],
+        }
+    ).to_csv(mismatch_path, index=False)
+
+    with pytest.raises(ValueError, match="External covariance CSV must contain exactly the configured symbols"):
+        load_external_covariance(mismatch_path, symbols=["AAA", "BBB"])
+
+
+def test_load_external_covariance_rejects_non_square_files(tmp_path: Path) -> None:
+    covariance_path = tmp_path / "covariance_nonsquare.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "AAA": [0.09, 0.01],
+            "BBB": [0.01, 0.04],
+            "CCC": [0.00, 0.00],
+        }
+    ).to_csv(covariance_path, index=False)
+
+    with pytest.raises(ValueError, match="External covariance CSV must be a square matrix"):
+        load_external_covariance(covariance_path, symbols=["AAA", "BBB"])
+
+
+def test_estimate_expected_returns_historical_mean_and_external_loader(tmp_path: Path) -> None:
+    returns = pd.DataFrame(
+        {
+            "AAA": [0.01, 0.02, -0.01],
+            "BBB": [0.00, 0.01, 0.03],
+        }
+    )
+
+    historical = estimate_expected_returns(returns, source="historical_mean")
+    pd.testing.assert_series_equal(
+        historical,
+        returns.mean(axis=0).rename("expected_return"),
+    )
+
+    expected_path = tmp_path / "expected.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["BBB", "AAA"],
+            "expected_return": [0.02, 0.01],
+        }
+    ).to_csv(expected_path, index=False)
+
+    expected_returns = load_external_expected_returns(expected_path, symbols=["AAA", "BBB"])
+
+    assert list(expected_returns.index) == ["AAA", "BBB"]
+    assert expected_returns.loc["AAA"] == pytest.approx(0.01)
+    assert expected_returns.loc["BBB"] == pytest.approx(0.02)
+
+    invalid_path = tmp_path / "expected_invalid.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "expected": [0.01, 0.02],
+        }
+    ).to_csv(invalid_path, index=False)
+
+    with pytest.raises(
+        ValueError,
+        match="External expected returns CSV must have exactly these columns: symbol, expected_return",
+    ):
+        load_external_expected_returns(invalid_path, symbols=["AAA", "BBB"])
+
+
+def test_build_optimizer_inputs_supports_external_sources(tmp_path: Path) -> None:
+    panel = _build_panel()
+    covariance_path = tmp_path / "covariance.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "AAA": [0.09, 0.01],
+            "BBB": [0.01, 0.04],
+        }
+    ).to_csv(covariance_path, index=False)
+    expected_path = tmp_path / "expected.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "expected_return": [0.01, 0.02],
+        }
+    ).to_csv(expected_path, index=False)
+
+    optimizer_inputs = build_optimizer_inputs(
+        panel,
+        symbols=["AAA", "BBB"],
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_path,
+    )
+
+    assert len(optimizer_inputs) >= 1
+    first_input = optimizer_inputs[0]
+    assert first_input.signal_date == pd.Timestamp("2024-01-05")
+    assert first_input.effective_date == pd.Timestamp("2024-01-08")
+    assert list(first_input.covariance.index) == ["AAA", "BBB"]
+    assert list(first_input.expected_returns.index) == ["AAA", "BBB"]
+    assert first_input.expected_returns.loc["AAA"] == pytest.approx(0.01)
+    assert first_input.covariance.loc["BBB", "BBB"] == pytest.approx(0.04)
+
+

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -251,4 +251,44 @@ def test_build_optimizer_inputs_supports_external_sources(tmp_path: Path) -> Non
     assert first_input.expected_returns.loc["AAA"] == pytest.approx(0.01)
     assert first_input.covariance.loc["BBB", "BBB"] == pytest.approx(0.04)
 
+def test_build_optimizer_inputs_validates_external_requirements_before_window_generation() -> None:
+    empty_panel = pd.DataFrame(columns=["symbol", "timestamp", "adj_close"])
 
+    with pytest.raises(
+        ValueError,
+        match="external_covariance_path is required when covariance_estimator='external_csv'",
+    ):
+        build_optimizer_inputs(
+            empty_panel,
+            symbols=["AAA", "BBB"],
+            lookback_days=3,
+            covariance_estimator="external_csv",
+        )
+
+
+def test_build_optimizer_inputs_rejects_unused_external_paths() -> None:
+    empty_panel = pd.DataFrame(columns=["symbol", "timestamp", "adj_close"])
+
+    with pytest.raises(
+        ValueError,
+        match="external_path must be omitted unless method='external_csv'",
+    ):
+        build_optimizer_inputs(
+            empty_panel,
+            symbols=["AAA", "BBB"],
+            lookback_days=3,
+            covariance_estimator="sample",
+            external_covariance_path="covariance.csv",
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="external_path must be omitted unless source='external_csv'",
+    ):
+        build_optimizer_inputs(
+            empty_panel,
+            symbols=["AAA", "BBB"],
+            lookback_days=3,
+            expected_return_source="historical_mean",
+            external_expected_returns_path="expected.csv",
+        )

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import configparser
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "profile_validation.py"
+TOX_INI_PATH = Path(__file__).resolve().parents[2] / "tox.ini"
+
+
+def _load_module():
+    module_name = "profile_validation"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_envs_defaults_to_ci_matching_lanes() -> None:
+    module = _load_module()
+
+    assert module.resolve_envs(None) == ["lint", "docs", "py312", "package", "integration"]
+    assert module.resolve_envs([]) == ["lint", "docs", "py312", "package", "integration"]
+
+
+def test_resolve_envs_preserves_requested_order() -> None:
+    module = _load_module()
+
+    assert module.resolve_envs(["package", "integration"]) == ["package", "integration"]
+
+
+def test_build_summary_table_formats_results() -> None:
+    module = _load_module()
+    results = [
+        module.LaneResult(env="lint", exit_code=0, elapsed_seconds=1.25),
+        module.LaneResult(env="docs", exit_code=3, elapsed_seconds=2.5),
+    ]
+
+    summary = module.build_summary_table(results)
+
+    assert "Validation Summary" in summary
+    assert "lint" in summary
+    assert "docs" in summary
+    assert "1.25" in summary
+    assert "2.50" in summary
+    assert "total" in summary
+    assert "3.75" in summary
+
+
+def test_run_validation_warns_when_not_on_python_312() -> None:
+    module = _load_module()
+    messages: list[str] = []
+
+    exit_code = module.run_validation(
+        ["lint"],
+        runner=lambda command: 0,
+        out=messages.append,
+        version_info=(3, 14),
+    )
+
+    assert exit_code == 0
+    assert any("current interpreter is Python 3.14" in message for message in messages)
+    assert any(message.startswith("[start] lint:") for message in messages)
+    assert any(message.startswith("[finish] lint:") for message in messages)
+    assert any("Validation Summary" in message for message in messages)
+
+
+def test_run_validation_returns_first_failure_exit_code_and_stops() -> None:
+    module = _load_module()
+    calls: list[str] = []
+    exit_codes = {"lint": 0, "docs": 7, "py312": 0}
+
+    def fake_runner(command: list[str]) -> int:
+        env_name = command[-1]
+        calls.append(env_name)
+        return exit_codes[env_name]
+
+    exit_code = module.run_validation(
+        ["lint", "docs", "py312"],
+        runner=fake_runner,
+        out=lambda message: None,
+        version_info=(3, 12),
+    )
+
+    assert exit_code == 7
+    assert calls == ["lint", "docs"]
+
+
+def test_parse_args_collects_repeated_env_flags() -> None:
+    module = _load_module()
+
+    args = module.parse_args(["--env", "lint", "--env", "package"])
+
+    assert args.envs == ["lint", "package"]
+
+
+def test_tox_preflight_tiers_match_expected_commands() -> None:
+    parser = configparser.ConfigParser()
+    parser.read(TOX_INI_PATH, encoding="utf-8")
+
+    assert "preflight-fast" in parser["tox"]["env_list"]
+    assert "preflight-slow" in parser["tox"]["env_list"]
+
+    for env_name in ("lint", "docs", "package", "integration"):
+        assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
+
+    assert parser["testenv:preflight-fast"]["basepython"] == "py312"
+    assert parser["testenv:preflight-fast"]["commands"].strip() == "{envpython} -m tox -e lint,docs,py312"
+
+    assert parser["testenv:preflight-slow"]["basepython"] == "py312"
+    assert parser["testenv:preflight-slow"]["commands"].strip() == "{envpython} -m tox -e package,integration"
+
+    assert parser["testenv:preflight"]["basepython"] == "py312"
+    assert parser["testenv:preflight"]["commands"].strip() == "{envpython} -m tox -e lint,docs,package,py312,integration"
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = lint, docs, py312, py313, py314, integration, package, preflight
+env_list = lint, docs, py312, py313, py314, integration, package, preflight-fast, preflight-slow, preflight
 skip_missing_interpreters = true
 isolated_build = true
 work_dir = {tox_root}{/}.tox
@@ -14,6 +14,7 @@ commands =
 
 [testenv:integration]
 description = Run the offline integration test suite through the bootstrapped Python environment
+basepython = py312
 package = editable
 deps =
     pytest>=8.0
@@ -22,6 +23,7 @@ commands =
 
 [testenv:lint]
 description = Run Ruff across the repository
+basepython = py312
 skip_install = true
 deps =
     ruff>=0.11
@@ -30,6 +32,7 @@ commands =
 
 [testenv:docs]
 description = Build the MkDocs site with strict warnings
+basepython = py312
 skip_install = true
 deps =
     mkdocs>=1.6
@@ -38,6 +41,7 @@ commands =
 
 [testenv:package]
 description = Build source and wheel distributions
+basepython = py312
 skip_install = true
 deps =
     build>=1.2
@@ -51,8 +55,29 @@ commands =
     {envpython} -m build --no-isolation
     {envpython} scripts/check_package.py
 
+[testenv:preflight-fast]
+description = Run the fast local validation gate through the CI-aligned tox envs
+basepython = py312
+skip_install = true
+env_dir = {work_dir}{/}.preflight-fast-local
+deps =
+    tox>=4.0
+commands =
+    {envpython} -m tox -e lint,docs,py312
+
+[testenv:preflight-slow]
+description = Run the slow local validation gate through the CI-aligned tox envs
+basepython = py312
+skip_install = true
+env_dir = {work_dir}{/}.preflight-slow-local
+deps =
+    tox>=4.0
+commands =
+    {envpython} -m tox -e package,integration
+
 [testenv:preflight]
 description = Run the local pre-push CI check set through the CI tox envs
+basepython = py312
 skip_install = true
 env_dir = {work_dir}{/}.preflight-local
 deps =


### PR DESCRIPTION
Closes #39

## Summary
- add the `baselines.optimized` scaffold, reusable optimizer input windows, covariance helpers, and external CSV validators for later optimized baselines
- fail fast when optimized baselines are enabled before the executable methods land
- add local validation tiers and a small profiling script so slow preflight runs can be diagnosed by lane instead of treated as one opaque timeout

## Commit Stack
- `feat: add optimized baseline input scaffolding`
- `test: cover optimizer scaffold inputs`
- `chore: add local validation tiers and diagnostics`

## Validation
- `python -m ruff check src/marketlab/config.py src/marketlab/pipeline.py src/marketlab/strategies/optimized.py tests/unit/test_config.py tests/unit/test_optimized.py tests/integration/test_optimized_scaffold.py README.md docs/architecture.md`
- `python -m build --no-isolation`
- `python -m pytest -q tests/unit/test_profile_validation.py --basetemp .pytest_tmp_profile_validation_2`
- `python -m ruff check scripts/profile_validation.py tests/unit/test_profile_validation.py README.md CONTRIBUTING.md`
- `python -m mkdocs build --strict`

Note: per request, I did not rerun the full `preflight` gate before opening this PR.