### PR TITLE
feat: add mean-variance optimizer baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MarketLab
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow: weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, shared out-of-sample experiments, and reviewable artifact summaries.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow: weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, an executable mean-variance baseline, shared out-of-sample experiments, and reviewable artifact summaries.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
@@ -20,7 +20,7 @@ python scripts/run_marketlab.py run-experiment --config configs/experiment.weekl
 ## What Each Command Does
 
 - `prepare-data`: build or reuse the cached prepared panel.
-- `backtest`: run the enabled baselines (`buy_hold`, `sma`, and optional config-defined allocation baselines) and write performance, analytics summaries, report, and plots.
+- `backtest`: run the enabled baselines (`buy_hold`, `sma`, optional config-defined allocation baselines, and the optional `mean_variance` optimized baseline) and write performance, analytics summaries, report, and plots.
 - `train-models`: fit the configured models across walk-forward folds and write raw training artifacts plus fold/model summaries, ranking diagnostics, calibration diagnostics, threshold diagnostics, and review plots.
 - `run-experiment`: run baselines and ML strategies together on the shared out-of-sample window and write the experiment outputs, analytics summaries, ranking-aware ML summary CSVs, calibration/threshold diagnostics, and review plots.
 
@@ -216,9 +216,9 @@ Allocation semantics:
 
 This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Optimizer methods, factor diagnostics, and broader scenario comparisons remain later work.
 
-## Optimizer Input Scaffold
+## Mean-Variance Optimizer Baseline
 
-`backtest` and `run-experiment` now also accept a non-executable optimizer scaffold under `baselines.optimized`.
+`backtest` and `run-experiment` now also support an executable long-only mean-variance baseline under `baselines.optimized`.
 
 Add to `baselines`:
 
@@ -232,8 +232,16 @@ Add to `baselines`:
 - `optimized.external_expected_returns_path`
 - `optimized.long_only`
 - `optimized.target_gross_exposure`
+- `optimized.risk_aversion`
 
-This PR only adds the shared optimizer input seam and validates the external CSV contracts. It does not yet emit optimized strategy weights. If `baselines.optimized.enabled: true`, MarketLab now fails fast with a scaffold-only error instead of silently ignoring the config. The executable optimizer baselines remain later Phase 5 work.
+Current Phase 5 behavior is intentionally narrow:
+
+- `mean_variance` is the only executable optimized method in this PR
+- `risk_parity` and `black_litterman` still fail fast with explicit not-implemented errors
+- the optimizer uses trailing daily adjusted-close returns ending on the `signal_date` and applies the weights on the next market open
+- no allocation is emitted before the first rebalance window with a full optimizer lookback
+- `target_gross_exposure < 1.0` leaves the undeployed exposure in cash
+- `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard long-only optimizer constraints
 
 External input rules:
 
@@ -268,6 +276,7 @@ This wave deliberately stays lightweight. It broadens the comparison baseline wi
   - `matplotlib`
   - `yfinance`
   - `scikit-learn`
+  - `scipy`
 
 ## Quickstart
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, an executable long-only mean-variance baseline, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -19,7 +19,7 @@ This document ties the current pieces together and records the working rules tha
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
-  - `buy_hold`, `sma`, config-defined allocation baselines, and optimizer input scaffolding for later optimized baselines
+  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance` optimized baseline, and optimizer input scaffolding for later optimized baselines
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
@@ -122,14 +122,16 @@ The required CI path stays offline and deterministic through tox. The Docker run
 - Cost-sensitivity reporting applies to `backtest` and `run-experiment`, but not to `train-models`.
 
 
-## Optimizer Scaffold Rules
+## Optimized Baseline Rules
 
-- `baselines.optimized` is a scaffold-only config surface in the current phase; it does not yet emit optimized strategy weights.
-- The scaffold exists to validate shared optimizer inputs, window timing, covariance estimation, and external file contracts before `mean_variance`, `risk_parity`, and `black_litterman` baselines land.
+- `baselines.optimized.method="mean_variance"` is the only executable optimized baseline in the current phase.
+- `risk_parity` and `black_litterman` remain scaffold-only and fail fast with explicit not-implemented errors.
 - Trailing return windows are built from adjusted close data only, and the latest included return must end on the `signal_date`.
+- Mean-variance weights are applied on the next market open after the `signal_date`, and no allocation is emitted before the first full optimizer lookback window exists.
+- `target_gross_exposure` is a long-only invested-fraction request; any undeployed exposure remains cash in the backtest engine.
+- `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard optimizer constraints for the long-only mean-variance method.
 - External covariance inputs must be square daily-return covariance matrices keyed by the configured symbols.
 - External expected-return inputs must contain exactly `symbol,expected_return` in daily decimal units.
-- If `baselines.optimized.enabled` is set today, the pipeline fails fast with a scaffold-only runtime error instead of pretending an optimizer baseline exists.
 
 ## System Map
 
@@ -388,6 +390,7 @@ classDiagram
       +external_expected_returns_path: str
       +long_only: bool
       +target_gross_exposure: float
+      +risk_aversion: float
     }
 
     class EvaluationConfig {
@@ -727,10 +730,12 @@ Best practice:
 - Provides covariance helpers for `sample`, `ewma`, `diagonal_shrinkage`, and `external_csv` inputs.
 - Provides expected-return helpers for `historical_mean` and `external_csv` inputs.
 - Reorders and validates external covariance and expected-return files against `data.symbols`.
+- Executes the long-only `mean_variance` baseline with hard position and group constraints, while leaving later optimized methods scaffold-only.
 
 Best practice:
-- Keep this module limited to optimizer inputs and estimators until actual optimized baselines land.
-- Use adjusted close returns ending on the signal date and reject malformed external files early.
+- Keep adjusted-close return windows and optimizer timing leakage-safe: signal on the close, execute on the next open.
+- Keep hard constraints explicit inside the solver instead of post-solve clipping.
+- Reject malformed external files early and keep unsupported optimized methods on explicit errors until they are implemented.
 
 ### `src/marketlab/strategies/buy_hold.py`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "PyYAML>=6.0",
   "yfinance>=0.2",
   "scikit-learn>=1.4",
+  "scipy>=1.11",
 ]
 
 [project.optional-dependencies]

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -99,6 +99,7 @@ class OptimizedConfig:
     external_expected_returns_path: str = ""
     long_only: bool = True
     target_gross_exposure: float = 1.0
+    risk_aversion: float = 1.0
 
 
 @dataclass(slots=True)
@@ -304,6 +305,21 @@ def _validate_config(config: ExperimentConfig) -> None:
         "baselines.optimized.target_gross_exposure",
         optimized.target_gross_exposure,
     )
+    _validate_positive_float(
+        "baselines.optimized.risk_aversion",
+        optimized.risk_aversion,
+    )
+    if optimized.method == "mean_variance":
+        if not optimized.long_only:
+            raise ValueError(
+                "baselines.optimized.long_only must be true when "
+                "baselines.optimized.method='mean_variance'."
+            )
+        if optimized.target_gross_exposure > 1.0:
+            raise ValueError(
+                "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 "
+                "when baselines.optimized.method='mean_variance'."
+            )
     if optimized.covariance_estimator == "external_csv":
         if optimized.external_covariance_path == "":
             raise ValueError(

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -42,7 +42,12 @@ from marketlab.reports.plots import (
 from marketlab.reports.summary import build_fold_summary, build_model_summary
 from marketlab.strategies.allocation import generate_weights as allocation_weights
 from marketlab.strategies.buy_hold import generate_weights as buy_hold_weights
-from marketlab.strategies.optimized import generate_weights as optimized_weights
+from marketlab.strategies.optimized import (
+    MEAN_VARIANCE_STRATEGY_NAME,
+)
+from marketlab.strategies.optimized import (
+    generate_weights as optimized_weights,
+)
 from marketlab.strategies.ranking import generate_weights as ranking_weights
 from marketlab.strategies.sma import generate_weights as sma_weights
 from marketlab.targets.weekly import build_weekly_modeling_dataset
@@ -341,6 +346,22 @@ def _persist_experiment_outputs(
     )
 
 
+def _cash_only_weights(
+    *,
+    strategy_name: str,
+    effective_date: pd.Timestamp,
+    symbols: list[str],
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": strategy_name,
+            "effective_date": pd.Timestamp(effective_date),
+            "symbol": symbols,
+            "weight": [0.0] * len(symbols),
+        }
+    )
+
+
 def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResult:
     featured = add_feature_set(
         panel=panel,
@@ -397,6 +418,12 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
             max_position_weight=config.portfolio.risk.max_position_weight,
             max_group_weight=config.portfolio.risk.max_group_weight,
         )
+        if weights.empty and config.baselines.optimized.method == "mean_variance":
+            weights = _cash_only_weights(
+                strategy_name=MEAN_VARIANCE_STRATEGY_NAME,
+                effective_date=pd.Timestamp(featured["timestamp"].min()),
+                symbols=config.data.symbols,
+            )
         if not weights.empty:
             backtest_results.append(
                 run_backtest_detailed(

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -42,6 +42,7 @@ from marketlab.reports.plots import (
 from marketlab.reports.summary import build_fold_summary, build_model_summary
 from marketlab.strategies.allocation import generate_weights as allocation_weights
 from marketlab.strategies.buy_hold import generate_weights as buy_hold_weights
+from marketlab.strategies.optimized import generate_weights as optimized_weights
 from marketlab.strategies.ranking import generate_weights as ranking_weights
 from marketlab.strategies.sma import generate_weights as sma_weights
 from marketlab.targets.weekly import build_weekly_modeling_dataset
@@ -350,10 +351,6 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
     )
 
     backtest_results: list[BacktestResult] = []
-    if config.baselines.optimized.enabled:
-        raise RuntimeError(
-            "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
-        )
     if config.baselines.buy_hold:
         weights = buy_hold_weights(featured)
         backtest_results.append(
@@ -372,6 +369,33 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
             symbol_weights=config.baselines.allocation.symbol_weights,
             symbol_groups=config.data.symbol_groups,
             group_weights=config.baselines.allocation.group_weights,
+        )
+        if not weights.empty:
+            backtest_results.append(
+                run_backtest_detailed(
+                    panel=featured,
+                    weights=weights,
+                    cost_bps=config.portfolio.costs.bps_per_trade,
+                )
+            )
+
+    if config.baselines.optimized.enabled:
+        weights = optimized_weights(
+            panel=featured,
+            symbols=config.data.symbols,
+            method=config.baselines.optimized.method,
+            lookback_days=config.baselines.optimized.lookback_days,
+            frequency=config.baselines.optimized.rebalance_frequency,
+            covariance_estimator=config.baselines.optimized.covariance_estimator,
+            external_covariance_path=config.optimized_external_covariance_path,
+            expected_return_source=config.baselines.optimized.expected_return_source,
+            external_expected_returns_path=config.optimized_external_expected_returns_path,
+            long_only=config.baselines.optimized.long_only,
+            target_gross_exposure=config.baselines.optimized.target_gross_exposure,
+            risk_aversion=config.baselines.optimized.risk_aversion,
+            symbol_groups=config.data.symbol_groups,
+            max_position_weight=config.portfolio.risk.max_position_weight,
+            max_group_weight=config.portfolio.risk.max_group_weight,
         )
         if not weights.empty:
             backtest_results.append(
@@ -454,10 +478,6 @@ def _run_ml_strategies(
     predictions: pd.DataFrame,
 ) -> BacktestResult:
     backtest_results: list[BacktestResult] = []
-    if config.baselines.optimized.enabled:
-        raise RuntimeError(
-            "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
-        )
 
     for _, model_predictions in predictions.groupby("model_name", sort=True):
         weights = ranking_weights(

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from scipy.optimize import minimize
 
 from marketlab.rebalance import signal_effective_dates
 
@@ -12,7 +13,12 @@ COVARIANCE_ESTIMATORS = {"diagonal_shrinkage", "ewma", "external_csv", "sample"}
 EXPECTED_RETURN_SOURCES = {"external_csv", "historical_mean"}
 EWMA_LAMBDA = 0.94
 DIAGONAL_SHRINKAGE_WEIGHT = 0.10
+COVARIANCE_REGULARIZATION = 1e-8
+CONSTRAINT_TOLERANCE = 1e-6
+WEIGHT_EPSILON = 1e-12
 REQUIRED_PANEL_COLUMNS = {"adj_close", "symbol", "timestamp"}
+WEIGHTS_COLUMNS = ["strategy", "effective_date", "symbol", "weight"]
+MEAN_VARIANCE_STRATEGY_NAME = "mean_variance"
 
 
 @dataclass(slots=True)
@@ -31,6 +37,10 @@ class OptimizerInput:
     returns: pd.DataFrame
     covariance: pd.DataFrame
     expected_returns: pd.Series
+
+
+def _empty_weights_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=WEIGHTS_COLUMNS)
 
 
 def _require_columns(panel: pd.DataFrame) -> None:
@@ -313,3 +323,312 @@ def build_optimizer_inputs(
 
     return inputs
 
+
+def _unsupported_method_error(method: str) -> RuntimeError:
+    return RuntimeError(f"baselines.optimized.method='{method}' is not implemented yet.")
+
+
+def _validated_symbol_groups(
+    symbols: list[str],
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+) -> dict[str, str]:
+    if max_group_weight is None:
+        return {}
+
+    resolved_symbol_groups = symbol_groups or {}
+    missing_group_symbols = sorted(set(symbols) - set(resolved_symbol_groups))
+    if missing_group_symbols:
+        joined = ", ".join(missing_group_symbols)
+        raise ValueError(
+            "Optimized max_group_weight requires symbol_groups for all symbols: "
+            f"{joined}"
+        )
+    return {symbol: resolved_symbol_groups[symbol] for symbol in symbols}
+
+
+def _group_indices(symbols: list[str], symbol_groups: dict[str, str]) -> dict[str, np.ndarray]:
+    group_names = sorted(set(symbol_groups.values()))
+    return {
+        group_name: np.array(
+            [index for index, symbol in enumerate(symbols) if symbol_groups[symbol] == group_name],
+            dtype=int,
+        )
+        for group_name in group_names
+    }
+
+
+def _position_upper_bounds(
+    *,
+    symbols: list[str],
+    achieved_target_exposure: float,
+    max_position_weight: float | None,
+    max_group_weight: float | None,
+) -> np.ndarray:
+    upper_bounds: list[float] = []
+    for _symbol in symbols:
+        upper_bound = achieved_target_exposure
+        if max_position_weight is not None:
+            upper_bound = min(upper_bound, max_position_weight)
+        if max_group_weight is not None:
+            upper_bound = min(upper_bound, max_group_weight)
+        upper_bounds.append(float(upper_bound))
+    return np.asarray(upper_bounds, dtype=float)
+
+
+def _build_feasible_initializer(
+    *,
+    symbols: list[str],
+    target_gross_exposure: float,
+    max_position_weight: float | None,
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+) -> tuple[np.ndarray, float]:
+    resolved_symbol_groups = _validated_symbol_groups(symbols, symbol_groups, max_group_weight)
+    symbol_weights = {symbol: 0.0 for symbol in symbols}
+    position_remaining = {
+        symbol: min(target_gross_exposure, max_position_weight)
+        if max_position_weight is not None
+        else target_gross_exposure
+        for symbol in symbols
+    }
+    group_remaining = {
+        group_name: max_group_weight
+        for group_name in sorted(set(resolved_symbol_groups.values()))
+    }
+
+    remaining_exposure = float(target_gross_exposure)
+    while remaining_exposure > WEIGHT_EPSILON:
+        eligible_symbols: list[str] = []
+        for symbol in symbols:
+            symbol_capacity = position_remaining[symbol]
+            if max_group_weight is not None:
+                symbol_capacity = min(symbol_capacity, group_remaining[resolved_symbol_groups[symbol]])
+            if symbol_capacity > WEIGHT_EPSILON:
+                eligible_symbols.append(symbol)
+
+        if not eligible_symbols:
+            break
+
+        equal_slice = remaining_exposure / len(eligible_symbols)
+        deployed_exposure = 0.0
+        for symbol in eligible_symbols:
+            capacity = position_remaining[symbol]
+            if max_group_weight is not None:
+                capacity = min(capacity, group_remaining[resolved_symbol_groups[symbol]])
+            delta = min(equal_slice, capacity)
+            if delta <= WEIGHT_EPSILON:
+                continue
+            symbol_weights[symbol] += delta
+            position_remaining[symbol] -= delta
+            if max_group_weight is not None:
+                group_remaining[resolved_symbol_groups[symbol]] -= delta
+            deployed_exposure += delta
+
+        if deployed_exposure <= WEIGHT_EPSILON:
+            break
+        remaining_exposure -= deployed_exposure
+
+    weight_vector = np.asarray([symbol_weights[symbol] for symbol in symbols], dtype=float)
+    return weight_vector, float(weight_vector.sum())
+
+
+def _optimizer_failure(
+    *,
+    method: str,
+    signal_date: pd.Timestamp,
+    effective_date: pd.Timestamp,
+    message: str,
+) -> RuntimeError:
+    return RuntimeError(
+        "Optimized baseline failed "
+        f"for method='{method}' signal_date={signal_date.date()} "
+        f"effective_date={effective_date.date()}: {message}"
+    )
+
+
+def _solve_mean_variance_weights(
+    optimizer_input: OptimizerInput,
+    *,
+    target_gross_exposure: float,
+    risk_aversion: float,
+    max_position_weight: float | None,
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+) -> pd.Series:
+    symbols = optimizer_input.symbols
+    feasible_weights, achieved_target_exposure = _build_feasible_initializer(
+        symbols=symbols,
+        target_gross_exposure=target_gross_exposure,
+        max_position_weight=max_position_weight,
+        symbol_groups=symbol_groups,
+        max_group_weight=max_group_weight,
+    )
+    if achieved_target_exposure <= WEIGHT_EPSILON:
+        return pd.Series(0.0, index=symbols, dtype=float)
+
+    if len(symbols) == 1:
+        return pd.Series(feasible_weights, index=symbols, dtype=float)
+
+    covariance = optimizer_input.covariance.loc[symbols, symbols].to_numpy(dtype=float)
+    covariance = (covariance + covariance.T) / 2.0
+    covariance += np.eye(len(symbols), dtype=float) * COVARIANCE_REGULARIZATION
+    expected_returns = optimizer_input.expected_returns.loc[symbols].to_numpy(dtype=float)
+    upper_bounds = _position_upper_bounds(
+        symbols=symbols,
+        achieved_target_exposure=achieved_target_exposure,
+        max_position_weight=max_position_weight,
+        max_group_weight=max_group_weight,
+    )
+    resolved_symbol_groups = _validated_symbol_groups(symbols, symbol_groups, max_group_weight)
+    grouped_indices = _group_indices(symbols, resolved_symbol_groups)
+
+    def objective(weights: np.ndarray) -> float:
+        return float(0.5 * risk_aversion * (weights @ covariance @ weights) - (expected_returns @ weights))
+
+    constraints: list[dict[str, object]] = [
+        {
+            "type": "eq",
+            "fun": lambda weights: float(weights.sum() - achieved_target_exposure),
+        }
+    ]
+    for indices in grouped_indices.values():
+        constraints.append(
+            {
+                "type": "ineq",
+                "fun": lambda weights, idx=indices: float(max_group_weight - weights[idx].sum()),
+            }
+        )
+
+    result = minimize(
+        objective,
+        x0=feasible_weights,
+        method="SLSQP",
+        bounds=[(0.0, float(bound)) for bound in upper_bounds],
+        constraints=constraints,
+        options={"ftol": 1e-9, "maxiter": 500},
+    )
+    if not result.success:
+        raise _optimizer_failure(
+            method="mean_variance",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message=result.message,
+        )
+
+    weights = np.asarray(result.x, dtype=float)
+    if not np.isfinite(weights).all():
+        raise _optimizer_failure(
+            method="mean_variance",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned non-finite weights",
+        )
+
+    weights = np.clip(weights, 0.0, upper_bounds)
+    if abs(float(weights.sum()) - achieved_target_exposure) > CONSTRAINT_TOLERANCE:
+        raise _optimizer_failure(
+            method="mean_variance",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned weights that violate the target exposure constraint",
+        )
+    if (weights > upper_bounds + CONSTRAINT_TOLERANCE).any():
+        raise _optimizer_failure(
+            method="mean_variance",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned weights that violate the position cap constraint",
+        )
+    for group_name, indices in grouped_indices.items():
+        group_weight = float(weights[indices].sum())
+        if group_weight > max_group_weight + CONSTRAINT_TOLERANCE:
+            raise _optimizer_failure(
+                method="mean_variance",
+                signal_date=optimizer_input.signal_date,
+                effective_date=optimizer_input.effective_date,
+                message=(
+                    "solver returned weights that violate the group cap constraint "
+                    f"for group '{group_name}'"
+                ),
+            )
+
+    return pd.Series(weights, index=symbols, dtype=float)
+
+
+def _weights_to_frame(
+    strategy_name: str,
+    effective_date: pd.Timestamp,
+    symbols: list[str],
+    weights: pd.Series,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": strategy_name,
+            "effective_date": pd.Timestamp(effective_date),
+            "symbol": symbols,
+            "weight": [float(weights.loc[symbol]) for symbol in symbols],
+        }
+    )
+
+
+def generate_weights(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    method: str,
+    lookback_days: int,
+    frequency: str = "W-FRI",
+    covariance_estimator: str = "sample",
+    external_covariance_path: Path | str | None = None,
+    expected_return_source: str = "historical_mean",
+    external_expected_returns_path: Path | str | None = None,
+    long_only: bool = True,
+    target_gross_exposure: float = 1.0,
+    risk_aversion: float = 1.0,
+    symbol_groups: dict[str, str] | None = None,
+    max_position_weight: float | None = None,
+    max_group_weight: float | None = None,
+) -> pd.DataFrame:
+    if method != "mean_variance":
+        raise _unsupported_method_error(method)
+    if not long_only:
+        raise ValueError("Mean-variance optimized baseline currently supports long_only=True only.")
+    if panel.empty:
+        return _empty_weights_frame()
+
+    optimizer_inputs = build_optimizer_inputs(
+        panel,
+        symbols=list(symbols),
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+        expected_return_source=expected_return_source,
+        external_expected_returns_path=external_expected_returns_path,
+    )
+    if not optimizer_inputs:
+        return _empty_weights_frame()
+
+    weight_frames = []
+    for optimizer_input in optimizer_inputs:
+        weights = _solve_mean_variance_weights(
+            optimizer_input,
+            target_gross_exposure=target_gross_exposure,
+            risk_aversion=risk_aversion,
+            max_position_weight=max_position_weight,
+            symbol_groups=symbol_groups,
+            max_group_weight=max_group_weight,
+        )
+        weight_frames.append(
+            _weights_to_frame(
+                MEAN_VARIANCE_STRATEGY_NAME,
+                optimizer_input.effective_date,
+                optimizer_input.symbols,
+                weights,
+            )
+        )
+
+    return pd.concat(weight_frames, ignore_index=True).sort_values(
+        ["effective_date", "symbol"]
+    ).reset_index(drop=True)

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -26,12 +26,14 @@ def _write_backtest_config(
     tmp_path: Path,
     *,
     optimized: dict[str, object] | None = None,
+    buy_hold: bool = True,
+    sma_enabled: bool = True,
 ) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(load_fixture_panel(), cache_dir / "panel.csv")
     baselines_payload: dict[str, object] = {
-        "buy_hold": True,
-        "sma": {"enabled": True, "fast_window": 2, "slow_window": 3},
+        "buy_hold": buy_hold,
+        "sma": {"enabled": sma_enabled, "fast_window": 2, "slow_window": 3},
     }
     if optimized is not None:
         baselines_payload["optimized"] = optimized
@@ -171,6 +173,37 @@ def test_backtest_supports_mean_variance_optimized_baseline(tmp_path: Path) -> N
     assert mean_variance_row["avg_gross_exposure"] <= 0.6 + 1e-6
     assert "mean_variance" in report_text
 
+
+
+def test_backtest_keeps_mean_variance_as_cash_when_no_windows_exist(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "mean_variance",
+            "lookback_days": 10_000,
+            "target_gross_exposure": 0.6,
+            "risk_aversion": 1.0,
+        },
+        buy_hold=False,
+        sma_enabled=False,
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_backtest"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+
+    assert set(metrics["strategy"]) == {"mean_variance"}
+    assert set(strategy_summary["strategy"]) == {"mean_variance"}
+    mean_variance_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "mean_variance"
+    ].iloc[0]
+    assert mean_variance_row["avg_gross_exposure"] == 0.0
+    assert mean_variance_row["avg_cash_weight"] == 1.0
 
 
 def test_backtest_rejects_unimplemented_risk_parity_baseline(tmp_path: Path) -> None:

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
 from tests.integration import _cli_harness
 
 from marketlab.data.panel import save_panel_csv
 
 assert_command_ok = _cli_harness.assert_command_ok
 build_synthetic_panel = _cli_harness.build_synthetic_panel
+latest_run_dir = _cli_harness.latest_run_dir
 load_fixture_panel = _cli_harness.load_fixture_panel
 run_marketlab_cli = getattr(
     _cli_harness,
@@ -16,12 +18,23 @@ run_marketlab_cli = getattr(
 )
 write_yaml_config = _cli_harness.write_yaml_config
 
-ERROR_MESSAGE = "baselines.optimized is configured, but optimized baseline methods are not implemented yet."
+RISK_PARITY_ERROR = "baselines.optimized.method='risk_parity' is not implemented yet."
+BLACK_LITTERMAN_ERROR = "baselines.optimized.method='black_litterman' is not implemented yet."
 
 
-def _write_backtest_config(tmp_path: Path) -> Path:
+def _write_backtest_config(
+    tmp_path: Path,
+    *,
+    optimized: dict[str, object] | None = None,
+) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(load_fixture_panel(), cache_dir / "panel.csv")
+    baselines_payload: dict[str, object] = {
+        "buy_hold": True,
+        "sma": {"enabled": True, "fast_window": 2, "slow_window": 3},
+    }
+    if optimized is not None:
+        baselines_payload["optimized"] = optimized
     return write_yaml_config(
         tmp_path / "backtest.yaml",
         {
@@ -43,14 +56,7 @@ def _write_backtest_config(tmp_path: Path) -> Path:
             "portfolio": {
                 "costs": {"bps_per_trade": 10},
             },
-            "baselines": {
-                "buy_hold": True,
-                "sma": {"enabled": True, "fast_window": 2, "slow_window": 3},
-                "optimized": {
-                    "enabled": True,
-                    "method": "mean_variance",
-                },
-            },
+            "baselines": baselines_payload,
             "artifacts": {
                 "output_dir": str(tmp_path / "runs"),
                 "save_predictions": False,
@@ -62,7 +68,11 @@ def _write_backtest_config(tmp_path: Path) -> Path:
     )
 
 
-def _write_run_experiment_config(tmp_path: Path) -> Path:
+def _write_run_experiment_config(
+    tmp_path: Path,
+    *,
+    optimized: dict[str, object] | None = None,
+) -> Path:
     cache_dir = tmp_path / "cache"
     save_panel_csv(
         build_synthetic_panel(
@@ -72,6 +82,12 @@ def _write_run_experiment_config(tmp_path: Path) -> Path:
         ),
         cache_dir / "panel.csv",
     )
+    baselines_payload: dict[str, object] = {
+        "buy_hold": True,
+        "sma": {"enabled": True, "fast_window": 5, "slow_window": 10},
+    }
+    if optimized is not None:
+        baselines_payload["optimized"] = optimized
     return write_yaml_config(
         tmp_path / "integration.yaml",
         {
@@ -106,14 +122,7 @@ def _write_run_experiment_config(tmp_path: Path) -> Path:
                 },
                 "costs": {"bps_per_trade": 10},
             },
-            "baselines": {
-                "buy_hold": True,
-                "sma": {"enabled": True, "fast_window": 5, "slow_window": 10},
-                "optimized": {
-                    "enabled": True,
-                    "method": "mean_variance",
-                },
-            },
+            "baselines": baselines_payload,
             "models": [{"name": "logistic_regression"}],
             "evaluation": {
                 "walk_forward": {
@@ -133,24 +142,67 @@ def _write_run_experiment_config(tmp_path: Path) -> Path:
     )
 
 
-def test_backtest_rejects_unimplemented_optimized_baseline(tmp_path: Path) -> None:
-    config_path = _write_backtest_config(tmp_path)
+def test_backtest_supports_mean_variance_optimized_baseline(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "mean_variance",
+            "lookback_days": 3,
+            "target_gross_exposure": 0.6,
+            "risk_aversion": 1.0,
+        },
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_backtest"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert set(metrics["strategy"]) == {"buy_hold", "sma", "mean_variance"}
+    assert set(strategy_summary["strategy"]) == {"buy_hold", "sma", "mean_variance"}
+    mean_variance_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "mean_variance"
+    ].iloc[0]
+    assert mean_variance_row["avg_gross_exposure"] <= 0.6 + 1e-6
+    assert "mean_variance" in report_text
+
+
+
+def test_backtest_rejects_unimplemented_risk_parity_baseline(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "risk_parity",
+        },
+    )
 
     result = run_marketlab_cli("backtest", config_path)
 
     assert result.returncode != 0
     combined_output = f"{result.stdout}\n{result.stderr}"
-    assert ERROR_MESSAGE in combined_output
+    assert RISK_PARITY_ERROR in combined_output
     assert not (tmp_path / "runs" / "optimized_scaffold_backtest").exists()
 
 
 
-def test_run_experiment_rejects_unimplemented_optimized_baseline(tmp_path: Path) -> None:
-    config_path = _write_run_experiment_config(tmp_path)
+def test_run_experiment_rejects_unimplemented_black_litterman_baseline(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "black_litterman",
+        },
+    )
 
     result = run_marketlab_cli("run-experiment", config_path)
 
     assert result.returncode != 0
     combined_output = f"{result.stdout}\n{result.stderr}"
-    assert ERROR_MESSAGE in combined_output
+    assert BLACK_LITTERMAN_ERROR in combined_output
     assert not (tmp_path / "runs" / "optimized_scaffold_experiment").exists()

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -64,6 +64,7 @@ def _write_run_experiment_config(
     symbol_specs: tuple[tuple[str, float, float], ...] | None = None,
     symbol_groups: dict[str, str] | None = None,
     allocation: dict[str, object] | None = None,
+    optimized: dict[str, object] | None = None,
     models: list[dict[str, str]] | None = None,
     evaluation: dict[str, object] | None = None,
 ) -> Path:
@@ -118,6 +119,8 @@ def _write_run_experiment_config(
     }
     if allocation is not None:
         baselines_payload["allocation"] = allocation
+    if optimized is not None:
+        baselines_payload["optimized"] = optimized
 
     return write_yaml_config(
         tmp_path / "integration.yaml",
@@ -169,6 +172,7 @@ def _write_backtest_config(
     *,
     symbol_groups: dict[str, str] | None = None,
     allocation: dict[str, object] | None = None,
+    optimized: dict[str, object] | None = None,
     evaluation: dict[str, object] | None = None,
 ) -> Path:
     cache_dir = tmp_path / "cache"
@@ -180,6 +184,8 @@ def _write_backtest_config(
     }
     if allocation is not None:
         baselines_payload["allocation"] = allocation
+    if optimized is not None:
+        baselines_payload["optimized"] = optimized
 
     return write_yaml_config(
         tmp_path / "backtest.yaml",
@@ -461,6 +467,40 @@ def test_backtest_supports_config_defined_allocation_baseline(tmp_path: Path) ->
     )
     assert "allocation_equal" in report_text
 
+
+
+def test_run_experiment_supports_mean_variance_baseline(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        optimized={
+            "enabled": True,
+            "method": "mean_variance",
+            "lookback_days": 5,
+            "target_gross_exposure": 0.7,
+            "risk_aversion": 1.0,
+        },
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    performance = pd.read_csv(run_dir / "performance.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    expected_strategies = {"buy_hold", "sma", "mean_variance", "ml_logistic_regression"}
+    assert set(metrics["strategy"]) == expected_strategies
+    assert set(performance["strategy"]) == expected_strategies
+    assert set(strategy_summary["strategy"]) == expected_strategies
+    mean_variance_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "mean_variance"
+    ].iloc[0]
+    assert mean_variance_row["avg_gross_exposure"] <= 0.7 + 1e-6
+    assert "mean_variance" in report_text
 
 def test_run_experiment_supports_group_weight_allocation_baseline(tmp_path: Path) -> None:
     config_path = _write_run_experiment_config(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,6 +59,7 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
     assert config.baselines.optimized.external_expected_returns_path == ""
     assert config.baselines.optimized.long_only is True
     assert config.baselines.optimized.target_gross_exposure == pytest.approx(1.0)
+    assert config.baselines.optimized.risk_aversion == pytest.approx(1.0)
     assert config.optimized_external_covariance_path is None
     assert config.optimized_external_expected_returns_path is None
     assert config.portfolio.risk.max_position_weight is None
@@ -292,6 +293,18 @@ def test_load_config_rejects_invalid_cost_sensitivity_bps(
         (
             {"target_gross_exposure": 0.0},
             "baselines.optimized.target_gross_exposure must be a finite positive value",
+        ),
+        (
+            {"risk_aversion": 0.0},
+            "baselines.optimized.risk_aversion must be a finite positive value",
+        ),
+        (
+            {"method": "mean_variance", "long_only": False},
+            "baselines.optimized.long_only must be true when baselines.optimized.method='mean_variance'",
+        ),
+        (
+            {"method": "mean_variance", "target_gross_exposure": 1.2},
+            "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 when baselines.optimized.method='mean_variance'",
         ),
         (
             {"covariance_estimator": "external_csv"},

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -487,7 +487,8 @@ def test_generate_weights_respects_group_caps(tmp_path: Path) -> None:
 
     first_weights = _first_effective_weights(weights)
     assert float(first_weights.loc[["AAA", "BBB"]].sum()) == pytest.approx(0.4, abs=1e-5)
-    assert first_weights.loc["CCC"] == pytest.approx(0.6, abs=1e-5)
+    assert first_weights.loc["CCC"] == pytest.approx(0.4, abs=1e-5)
+    assert float(first_weights.sum()) == pytest.approx(0.8, abs=1e-5)
 
 
 def test_generate_weights_rejects_unimplemented_methods() -> None:

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -13,6 +13,7 @@ from marketlab.strategies.optimized import (
     build_optimizer_windows,
     estimate_covariance_matrix,
     estimate_expected_returns,
+    generate_weights,
     load_external_covariance,
     load_external_expected_returns,
 )
@@ -291,4 +292,211 @@ def test_build_optimizer_inputs_rejects_unused_external_paths() -> None:
             lookback_days=3,
             expected_return_source="historical_mean",
             external_expected_returns_path="expected.csv",
+        )
+
+def _build_optimizer_panel(
+    symbol_specs: tuple[tuple[str, float, float], ...],
+    *,
+    start_date: str = "2024-01-01",
+    end_date: str = "2024-01-26",
+) -> pd.DataFrame:
+    trading_dates = pd.bdate_range(start_date, end_date)
+    rows: list[dict[str, object]] = []
+    for symbol, base_price, daily_step in symbol_specs:
+        for index, timestamp in enumerate(trading_dates):
+            rows.append(
+                {
+                    "symbol": symbol,
+                    "timestamp": timestamp,
+                    "adj_close": base_price + (daily_step * index),
+                }
+            )
+
+    return pd.DataFrame(rows).sort_values(["symbol", "timestamp"]).reset_index(drop=True)
+
+
+def _write_external_covariance(path: Path, covariance: pd.DataFrame) -> None:
+    covariance.reset_index(names="symbol").to_csv(path, index=False)
+
+
+def _write_external_expected_returns(path: Path, expected_returns: pd.Series) -> None:
+    expected_returns.rename("expected_return").rename_axis("symbol").reset_index().to_csv(
+        path,
+        index=False,
+    )
+
+
+def _first_effective_weights(weights: pd.DataFrame) -> pd.Series:
+    first_effective_date = pd.to_datetime(weights["effective_date"]).min()
+    first_frame = weights.loc[pd.to_datetime(weights["effective_date"]) == first_effective_date]
+    return first_frame.set_index("symbol")["weight"].astype(float)
+
+
+def test_generate_weights_produces_symmetric_mean_variance_solution(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    expected_returns = pd.Series({"AAA": 0.01, "BBB": 0.01}, dtype=float)
+    covariance_path = tmp_path / "covariance.csv"
+    expected_returns_path = tmp_path / "expected.csv"
+    _write_external_covariance(covariance_path, covariance)
+    _write_external_expected_returns(expected_returns_path, expected_returns)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="mean_variance",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_returns_path,
+    )
+
+    assert set(weights["strategy"]) == {"mean_variance"}
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.5, abs=1e-6)
+    assert first_weights.loc["BBB"] == pytest.approx(0.5, abs=1e-6)
+
+
+def test_generate_weights_prefers_higher_expected_return_assets(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    expected_returns = pd.Series({"AAA": 0.03, "BBB": 0.01}, dtype=float)
+    covariance_path = tmp_path / "covariance.csv"
+    expected_returns_path = tmp_path / "expected.csv"
+    _write_external_covariance(covariance_path, covariance)
+    _write_external_expected_returns(expected_returns_path, expected_returns)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="mean_variance",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_returns_path,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.75, abs=1e-3)
+    assert first_weights.loc["BBB"] == pytest.approx(0.25, abs=1e-3)
+
+
+def test_generate_weights_respects_target_gross_exposure(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    expected_returns = pd.Series({"AAA": 0.01, "BBB": 0.01}, dtype=float)
+    covariance_path = tmp_path / "covariance.csv"
+    expected_returns_path = tmp_path / "expected.csv"
+    _write_external_covariance(covariance_path, covariance)
+    _write_external_expected_returns(expected_returns_path, expected_returns)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="mean_variance",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_returns_path,
+        target_gross_exposure=0.6,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert float(first_weights.sum()) == pytest.approx(0.6, abs=1e-6)
+    assert first_weights.loc["AAA"] == pytest.approx(0.3, abs=1e-6)
+    assert first_weights.loc["BBB"] == pytest.approx(0.3, abs=1e-6)
+
+
+def test_generate_weights_respects_position_caps(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    expected_returns = pd.Series({"AAA": 0.03, "BBB": 0.01}, dtype=float)
+    covariance_path = tmp_path / "covariance.csv"
+    expected_returns_path = tmp_path / "expected.csv"
+    _write_external_covariance(covariance_path, covariance)
+    _write_external_expected_returns(expected_returns_path, expected_returns)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="mean_variance",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_returns_path,
+        max_position_weight=0.6,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.6, abs=1e-5)
+    assert first_weights.loc["BBB"] == pytest.approx(0.4, abs=1e-5)
+
+
+def test_generate_weights_respects_group_caps(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel(
+        (("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0), ("CCC", 140.0, 1.0))
+    )
+    covariance = pd.DataFrame(
+        np.diag([0.04, 0.04, 0.04]),
+        index=["AAA", "BBB", "CCC"],
+        columns=["AAA", "BBB", "CCC"],
+        dtype=float,
+    )
+    expected_returns = pd.Series({"AAA": 0.03, "BBB": 0.03, "CCC": 0.0}, dtype=float)
+    covariance_path = tmp_path / "covariance.csv"
+    expected_returns_path = tmp_path / "expected.csv"
+    _write_external_covariance(covariance_path, covariance)
+    _write_external_expected_returns(expected_returns_path, expected_returns)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB", "CCC"],
+        method="mean_variance",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        expected_return_source="external_csv",
+        external_expected_returns_path=expected_returns_path,
+        symbol_groups={"AAA": "growth", "BBB": "growth", "CCC": "defensive"},
+        max_group_weight=0.4,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert float(first_weights.loc[["AAA", "BBB"]].sum()) == pytest.approx(0.4, abs=1e-5)
+    assert first_weights.loc["CCC"] == pytest.approx(0.6, abs=1e-5)
+
+
+def test_generate_weights_rejects_unimplemented_methods() -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+
+    with pytest.raises(RuntimeError, match="baselines.optimized.method='risk_parity' is not implemented yet"):
+        generate_weights(
+            panel,
+            symbols=["AAA", "BBB"],
+            method="risk_parity",
+            lookback_days=3,
         )


### PR DESCRIPTION
## Summary
- add the executable long-only mean_variance optimized baseline with a new isk_aversion knob
- wire mean_variance into acktest and un-experiment while keeping isk_parity and lack_litterman on explicit not-implemented errors
- cover config validation, solver constraints, integration behavior, and public docs

## Commit stack
- eat: add mean-variance optimizer config and solver
- eat: wire mean-variance baseline into experiment flows
- 	est: cover mean-variance baseline behavior and constraints
- docs: document the mean-variance baseline

## Validation
- python -m tox -e preflight (timed out locally after about 20 minutes on the current Windows/Python 3.14 environment)
- python -m ruff check src/marketlab/config.py src/marketlab/pipeline.py src/marketlab/strategies/optimized.py tests/unit/test_config.py tests/unit/test_optimized.py tests/integration/test_optimized_scaffold.py tests/integration/test_run_experiment.py
- python -m build --no-isolation
- python -m mkdocs build --strict
- manual command-path harnesses for config validation, solver math, cap behavior, acktest, un-experiment, and explicit unsupported-method failures

Closes #40