### PR TITLE
feat: add risk parity optimizer baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MarketLab
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow: weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, an executable mean-variance baseline, shared out-of-sample experiments, and reviewable artifact summaries.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow: weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, and reviewable artifact summaries.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
@@ -20,7 +20,7 @@ python scripts/run_marketlab.py run-experiment --config configs/experiment.weekl
 ## What Each Command Does
 
 - `prepare-data`: build or reuse the cached prepared panel.
-- `backtest`: run the enabled baselines (`buy_hold`, `sma`, optional config-defined allocation baselines, and the optional `mean_variance` optimized baseline) and write performance, analytics summaries, report, and plots.
+- `backtest`: run the enabled baselines (`buy_hold`, `sma`, optional config-defined allocation baselines, and the optional executable optimized baseline) and write performance, analytics summaries, report, and plots.
 - `train-models`: fit the configured models across walk-forward folds and write raw training artifacts plus fold/model summaries, ranking diagnostics, calibration diagnostics, threshold diagnostics, and review plots.
 - `run-experiment`: run baselines and ML strategies together on the shared out-of-sample window and write the experiment outputs, analytics summaries, ranking-aware ML summary CSVs, calibration/threshold diagnostics, and review plots.
 
@@ -216,9 +216,9 @@ Allocation semantics:
 
 This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Optimizer methods, factor diagnostics, and broader scenario comparisons remain later work.
 
-## Mean-Variance Optimizer Baseline
+## Optimized Baselines
 
-`backtest` and `run-experiment` now also support an executable long-only mean-variance baseline under `baselines.optimized`.
+`backtest` and `run-experiment` now also support executable long-only optimized baselines under `baselines.optimized`.
 
 Add to `baselines`:
 
@@ -236,12 +236,15 @@ Add to `baselines`:
 
 Current Phase 5 behavior is intentionally narrow:
 
-- `mean_variance` is the only executable optimized method in this PR
-- `risk_parity` and `black_litterman` still fail fast with explicit not-implemented errors
+- `mean_variance` and `risk_parity` are executable optimized methods
+- `black_litterman` still fails fast with an explicit not-implemented error
 - the optimizer uses trailing daily adjusted-close returns ending on the `signal_date` and applies the weights on the next market open
 - no allocation is emitted before the first rebalance window with a full optimizer lookback
 - `target_gross_exposure < 1.0` leaves the undeployed exposure in cash
 - `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard long-only optimizer constraints
+- `risk_aversion` only applies to `mean_variance`
+- `risk_parity` uses only the configured covariance estimator and does not consume expected-return inputs
+- capped `risk_parity` portfolios are the best feasible approximation to equal risk contributions, not exact parity under binding caps
 
 External input rules:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, an executable long-only mean-variance baseline, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance and risk-parity baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -19,7 +19,7 @@ This document ties the current pieces together and records the working rules tha
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
-  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance` optimized baseline, and optimizer input scaffolding for later optimized baselines
+  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance` and `risk_parity` optimized baselines, and optimizer input scaffolding for later optimized baselines
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
@@ -124,12 +124,15 @@ The required CI path stays offline and deterministic through tox. The Docker run
 
 ## Optimized Baseline Rules
 
-- `baselines.optimized.method="mean_variance"` is the only executable optimized baseline in the current phase.
-- `risk_parity` and `black_litterman` remain scaffold-only and fail fast with explicit not-implemented errors.
+- `baselines.optimized.method="mean_variance"` and `baselines.optimized.method="risk_parity"` are executable optimized baselines in the current phase.
+- `black_litterman` remains scaffold-only and fails fast with an explicit not-implemented error.
 - Trailing return windows are built from adjusted close data only, and the latest included return must end on the `signal_date`.
-- Mean-variance weights are applied on the next market open after the `signal_date`, and no allocation is emitted before the first full optimizer lookback window exists.
+- Optimized weights are applied on the next market open after the `signal_date`, and no allocation is emitted before the first full optimizer lookback window exists.
 - `target_gross_exposure` is a long-only invested-fraction request; any undeployed exposure remains cash in the backtest engine.
-- `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard optimizer constraints for the long-only mean-variance method.
+- `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard optimizer constraints for the long-only optimized methods.
+- `risk_aversion` applies only to `mean_variance`.
+- `risk_parity` uses only the configured covariance estimator and does not consume expected-return inputs.
+- Binding position or group caps turn `risk_parity` into the best feasible approximation to equal risk contributions rather than exact parity.
 - External covariance inputs must be square daily-return covariance matrices keyed by the configured symbols.
 - External expected-return inputs must contain exactly `symbol,expected_return` in daily decimal units.
 
@@ -730,7 +733,7 @@ Best practice:
 - Provides covariance helpers for `sample`, `ewma`, `diagonal_shrinkage`, and `external_csv` inputs.
 - Provides expected-return helpers for `historical_mean` and `external_csv` inputs.
 - Reorders and validates external covariance and expected-return files against `data.symbols`.
-- Executes the long-only `mean_variance` baseline with hard position and group constraints, while leaving later optimized methods scaffold-only.
+- Executes the long-only `mean_variance` and `risk_parity` baselines with hard position and group constraints, while leaving `black_litterman` scaffold-only.
 
 Best practice:
 - Keep adjusted-close return windows and optimizer timing leakage-safe: signal on the close, execute on the next open.

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -320,6 +320,27 @@ def _validate_config(config: ExperimentConfig) -> None:
                 "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 "
                 "when baselines.optimized.method='mean_variance'."
             )
+    if optimized.method == "risk_parity":
+        if not optimized.long_only:
+            raise ValueError(
+                "baselines.optimized.long_only must be true when "
+                "baselines.optimized.method='risk_parity'."
+            )
+        if optimized.target_gross_exposure > 1.0:
+            raise ValueError(
+                "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 "
+                "when baselines.optimized.method='risk_parity'."
+            )
+        if optimized.expected_return_source != "historical_mean":
+            raise ValueError(
+                "baselines.optimized.expected_return_source must remain 'historical_mean' "
+                "when baselines.optimized.method='risk_parity'."
+            )
+        if optimized.external_expected_returns_path != "":
+            raise ValueError(
+                "baselines.optimized.external_expected_returns_path must be empty when "
+                "baselines.optimized.method='risk_parity'."
+            )
     if optimized.covariance_estimator == "external_csv":
         if optimized.external_covariance_path == "":
             raise ValueError(

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -43,10 +43,13 @@ from marketlab.reports.summary import build_fold_summary, build_model_summary
 from marketlab.strategies.allocation import generate_weights as allocation_weights
 from marketlab.strategies.buy_hold import generate_weights as buy_hold_weights
 from marketlab.strategies.optimized import (
-    MEAN_VARIANCE_STRATEGY_NAME,
+    generate_cash_only_weights as optimized_cash_only_weights,
 )
 from marketlab.strategies.optimized import (
     generate_weights as optimized_weights,
+)
+from marketlab.strategies.optimized import (
+    is_executable_method as optimized_method_is_executable,
 )
 from marketlab.strategies.ranking import generate_weights as ranking_weights
 from marketlab.strategies.sma import generate_weights as sma_weights
@@ -346,22 +349,6 @@ def _persist_experiment_outputs(
     )
 
 
-def _cash_only_weights(
-    *,
-    strategy_name: str,
-    effective_date: pd.Timestamp,
-    symbols: list[str],
-) -> pd.DataFrame:
-    return pd.DataFrame(
-        {
-            "strategy": strategy_name,
-            "effective_date": pd.Timestamp(effective_date),
-            "symbol": symbols,
-            "weight": [0.0] * len(symbols),
-        }
-    )
-
-
 def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResult:
     featured = add_feature_set(
         panel=panel,
@@ -401,10 +388,11 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
             )
 
     if config.baselines.optimized.enabled:
+        optimized_method = config.baselines.optimized.method
         weights = optimized_weights(
             panel=featured,
             symbols=config.data.symbols,
-            method=config.baselines.optimized.method,
+            method=optimized_method,
             lookback_days=config.baselines.optimized.lookback_days,
             frequency=config.baselines.optimized.rebalance_frequency,
             covariance_estimator=config.baselines.optimized.covariance_estimator,
@@ -418,9 +406,9 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
             max_position_weight=config.portfolio.risk.max_position_weight,
             max_group_weight=config.portfolio.risk.max_group_weight,
         )
-        if weights.empty and config.baselines.optimized.method == "mean_variance":
-            weights = _cash_only_weights(
-                strategy_name=MEAN_VARIANCE_STRATEGY_NAME,
+        if weights.empty and optimized_method_is_executable(optimized_method):
+            weights = optimized_cash_only_weights(
+                optimized_method,
                 effective_date=pd.Timestamp(featured["timestamp"].min()),
                 symbols=config.data.symbols,
             )

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -353,16 +353,6 @@ def build_optimizer_inputs(
     external_expected_returns_path: Path | str | None = None,
 ) -> list[OptimizerInput]:
     ordered_symbols = list(symbols)
-    covariance_inputs = build_covariance_inputs(
-        panel,
-        symbols=ordered_symbols,
-        lookback_days=lookback_days,
-        frequency=frequency,
-        covariance_estimator=covariance_estimator,
-        external_covariance_path=external_covariance_path,
-    )
-    if not covariance_inputs:
-        return []
 
     shared_expected_returns: pd.Series | None = None
     if expected_return_source == "external_csv":
@@ -380,6 +370,17 @@ def build_optimizer_inputs(
             source=expected_return_source,
             external_path=external_expected_returns_path,
         )
+
+    covariance_inputs = build_covariance_inputs(
+        panel,
+        symbols=ordered_symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+    )
+    if not covariance_inputs:
+        return []
 
     inputs: list[OptimizerInput] = []
     for optimizer_input in covariance_inputs:

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -19,6 +19,10 @@ WEIGHT_EPSILON = 1e-12
 REQUIRED_PANEL_COLUMNS = {"adj_close", "symbol", "timestamp"}
 WEIGHTS_COLUMNS = ["strategy", "effective_date", "symbol", "weight"]
 MEAN_VARIANCE_STRATEGY_NAME = "mean_variance"
+RISK_PARITY_STRATEGY_NAME = "risk_parity"
+EXECUTABLE_METHODS = frozenset(
+    {MEAN_VARIANCE_STRATEGY_NAME, RISK_PARITY_STRATEGY_NAME}
+)
 
 
 @dataclass(slots=True)
@@ -36,11 +40,49 @@ class OptimizerInput:
     symbols: list[str]
     returns: pd.DataFrame
     covariance: pd.DataFrame
-    expected_returns: pd.Series
+    expected_returns: pd.Series | None = None
+
+
+@dataclass(slots=True)
+class LongOnlyProblem:
+    symbols: list[str]
+    feasible_weights: np.ndarray
+    achieved_target_exposure: float
+    covariance: np.ndarray
+    upper_bounds: np.ndarray
+    grouped_indices: dict[str, np.ndarray]
 
 
 def _empty_weights_frame() -> pd.DataFrame:
     return pd.DataFrame(columns=WEIGHTS_COLUMNS)
+
+
+def is_executable_method(method: str) -> bool:
+    return method in EXECUTABLE_METHODS
+
+
+def strategy_name_for_method(method: str) -> str:
+    if method == "mean_variance":
+        return MEAN_VARIANCE_STRATEGY_NAME
+    if method == "risk_parity":
+        return RISK_PARITY_STRATEGY_NAME
+    raise _unsupported_method_error(method)
+
+
+def generate_cash_only_weights(
+    method: str,
+    *,
+    effective_date: pd.Timestamp,
+    symbols: list[str],
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": strategy_name_for_method(method),
+            "effective_date": pd.Timestamp(effective_date),
+            "symbol": symbols,
+            "weight": [0.0] * len(symbols),
+        }
+    )
 
 
 def _require_columns(panel: pd.DataFrame) -> None:
@@ -244,7 +286,7 @@ def estimate_expected_returns(
     return returns.loc[:, ordered_symbols].mean(axis=0).astype(float).rename("expected_return")
 
 
-def build_optimizer_inputs(
+def build_covariance_inputs(
     panel: pd.DataFrame,
     *,
     symbols: list[str],
@@ -252,8 +294,6 @@ def build_optimizer_inputs(
     frequency: str = "W-FRI",
     covariance_estimator: str = "sample",
     external_covariance_path: Path | str | None = None,
-    expected_return_source: str = "historical_mean",
-    external_expected_returns_path: Path | str | None = None,
 ) -> list[OptimizerInput]:
     ordered_symbols = list(symbols)
 
@@ -272,6 +312,58 @@ def build_optimizer_inputs(
             external_path=external_covariance_path,
         )
 
+    windows = build_optimizer_windows(
+        panel,
+        symbols=ordered_symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+    )
+    if not windows:
+        return []
+
+    inputs: list[OptimizerInput] = []
+    for window in windows:
+        covariance = (
+            shared_covariance.copy()
+            if shared_covariance is not None
+            else estimate_covariance_matrix(window.returns, method=covariance_estimator)
+        )
+        inputs.append(
+            OptimizerInput(
+                signal_date=window.signal_date,
+                effective_date=window.effective_date,
+                symbols=window.symbols,
+                returns=window.returns.copy(),
+                covariance=covariance.loc[window.symbols, window.symbols].copy(),
+            )
+        )
+
+    return inputs
+
+
+def build_optimizer_inputs(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    lookback_days: int,
+    frequency: str = "W-FRI",
+    covariance_estimator: str = "sample",
+    external_covariance_path: Path | str | None = None,
+    expected_return_source: str = "historical_mean",
+    external_expected_returns_path: Path | str | None = None,
+) -> list[OptimizerInput]:
+    ordered_symbols = list(symbols)
+    covariance_inputs = build_covariance_inputs(
+        panel,
+        symbols=ordered_symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+    )
+    if not covariance_inputs:
+        return []
+
     shared_expected_returns: pd.Series | None = None
     if expected_return_source == "external_csv":
         if external_expected_returns_path is None:
@@ -289,35 +381,24 @@ def build_optimizer_inputs(
             external_path=external_expected_returns_path,
         )
 
-    windows = build_optimizer_windows(
-        panel,
-        symbols=ordered_symbols,
-        lookback_days=lookback_days,
-        frequency=frequency,
-    )
-    if not windows:
-        return []
-
     inputs: list[OptimizerInput] = []
-    for window in windows:
-        covariance = (
-            shared_covariance.copy()
-            if shared_covariance is not None
-            else estimate_covariance_matrix(window.returns, method=covariance_estimator)
-        )
+    for optimizer_input in covariance_inputs:
         expected_returns = (
             shared_expected_returns.copy()
             if shared_expected_returns is not None
-            else estimate_expected_returns(window.returns, source=expected_return_source)
+            else estimate_expected_returns(
+                optimizer_input.returns,
+                source=expected_return_source,
+            )
         )
         inputs.append(
             OptimizerInput(
-                signal_date=window.signal_date,
-                effective_date=window.effective_date,
-                symbols=window.symbols,
-                returns=window.returns.copy(),
-                covariance=covariance.loc[window.symbols, window.symbols].copy(),
-                expected_returns=expected_returns.loc[window.symbols].copy(),
+                signal_date=optimizer_input.signal_date,
+                effective_date=optimizer_input.effective_date,
+                symbols=optimizer_input.symbols,
+                returns=optimizer_input.returns.copy(),
+                covariance=optimizer_input.covariance.copy(),
+                expected_returns=expected_returns.loc[optimizer_input.symbols].copy(),
             )
         )
 
@@ -447,6 +528,160 @@ def _optimizer_failure(
     )
 
 
+def _regularized_covariance_matrix(
+    optimizer_input: OptimizerInput,
+    *,
+    method: str,
+) -> np.ndarray:
+    covariance = optimizer_input.covariance.loc[
+        optimizer_input.symbols,
+        optimizer_input.symbols,
+    ].to_numpy(dtype=float)
+    if not np.isfinite(covariance).all():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="covariance contains non-finite values",
+        )
+    covariance = (covariance + covariance.T) / 2.0
+    covariance += np.eye(len(optimizer_input.symbols), dtype=float) * COVARIANCE_REGULARIZATION
+    if (np.diag(covariance) <= 0.0).any():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="covariance contains non-positive diagonal entries after regularization",
+        )
+    return covariance
+
+
+def _prepare_long_only_problem(
+    optimizer_input: OptimizerInput,
+    *,
+    method: str,
+    target_gross_exposure: float,
+    max_position_weight: float | None,
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+) -> LongOnlyProblem:
+    symbols = optimizer_input.symbols
+    feasible_weights, achieved_target_exposure = _build_feasible_initializer(
+        symbols=symbols,
+        target_gross_exposure=target_gross_exposure,
+        max_position_weight=max_position_weight,
+        symbol_groups=symbol_groups,
+        max_group_weight=max_group_weight,
+    )
+    covariance = _regularized_covariance_matrix(
+        optimizer_input,
+        method=method,
+    )
+    upper_bounds = _position_upper_bounds(
+        symbols=symbols,
+        achieved_target_exposure=achieved_target_exposure,
+        max_position_weight=max_position_weight,
+        max_group_weight=max_group_weight,
+    )
+    resolved_symbol_groups = _validated_symbol_groups(
+        symbols,
+        symbol_groups,
+        max_group_weight,
+    )
+    grouped_indices = _group_indices(symbols, resolved_symbol_groups)
+    return LongOnlyProblem(
+        symbols=symbols,
+        feasible_weights=feasible_weights,
+        achieved_target_exposure=achieved_target_exposure,
+        covariance=covariance,
+        upper_bounds=upper_bounds,
+        grouped_indices=grouped_indices,
+    )
+
+
+def _constraints(
+    *,
+    achieved_target_exposure: float,
+    grouped_indices: dict[str, np.ndarray],
+    max_group_weight: float | None,
+) -> list[dict[str, object]]:
+    constraints: list[dict[str, object]] = [
+        {
+            "type": "eq",
+            "fun": lambda weights, target=achieved_target_exposure: float(
+                weights.sum() - target
+            ),
+        }
+    ]
+    if max_group_weight is None:
+        return constraints
+
+    for indices in grouped_indices.values():
+        constraints.append(
+            {
+                "type": "ineq",
+                "fun": lambda weights, idx=indices, cap=max_group_weight: float(
+                    cap - weights[idx].sum()
+                ),
+            }
+        )
+    return constraints
+
+
+def _finalize_optimized_weights(
+    *,
+    method: str,
+    optimizer_input: OptimizerInput,
+    problem: LongOnlyProblem,
+    weights: np.ndarray,
+    max_group_weight: float | None,
+) -> pd.Series:
+    if not np.isfinite(weights).all():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned non-finite weights",
+        )
+
+    weights = np.clip(np.asarray(weights, dtype=float), 0.0, problem.upper_bounds)
+    if abs(float(weights.sum()) - problem.achieved_target_exposure) > CONSTRAINT_TOLERANCE:
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned weights that violate the target exposure constraint",
+        )
+    if (weights > problem.upper_bounds + CONSTRAINT_TOLERANCE).any():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned weights that violate the position cap constraint",
+        )
+    if (weights < -CONSTRAINT_TOLERANCE).any():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="solver returned weights that violate the long-only constraint",
+        )
+    if max_group_weight is not None:
+        for group_name, indices in problem.grouped_indices.items():
+            group_weight = float(weights[indices].sum())
+            if group_weight > max_group_weight + CONSTRAINT_TOLERANCE:
+                raise _optimizer_failure(
+                    method=method,
+                    signal_date=optimizer_input.signal_date,
+                    effective_date=optimizer_input.effective_date,
+                    message=(
+                        "solver returned weights that violate the group cap constraint "
+                        f"for group '{group_name}'"
+                    ),
+                )
+    return pd.Series(weights, index=problem.symbols, dtype=float)
+
+
 def _solve_mean_variance_weights(
     optimizer_input: OptimizerInput,
     *,
@@ -456,56 +691,43 @@ def _solve_mean_variance_weights(
     symbol_groups: dict[str, str] | None,
     max_group_weight: float | None,
 ) -> pd.Series:
-    symbols = optimizer_input.symbols
-    feasible_weights, achieved_target_exposure = _build_feasible_initializer(
-        symbols=symbols,
+    if optimizer_input.expected_returns is None:
+        raise ValueError("Mean-variance optimized inputs require expected_returns.")
+
+    problem = _prepare_long_only_problem(
+        optimizer_input,
+        method="mean_variance",
         target_gross_exposure=target_gross_exposure,
         max_position_weight=max_position_weight,
         symbol_groups=symbol_groups,
         max_group_weight=max_group_weight,
     )
-    if achieved_target_exposure <= WEIGHT_EPSILON:
-        return pd.Series(0.0, index=symbols, dtype=float)
+    if problem.achieved_target_exposure <= WEIGHT_EPSILON:
+        return pd.Series(0.0, index=problem.symbols, dtype=float)
 
-    if len(symbols) == 1:
-        return pd.Series(feasible_weights, index=symbols, dtype=float)
+    if len(problem.symbols) == 1:
+        return pd.Series(problem.feasible_weights, index=problem.symbols, dtype=float)
 
-    covariance = optimizer_input.covariance.loc[symbols, symbols].to_numpy(dtype=float)
-    covariance = (covariance + covariance.T) / 2.0
-    covariance += np.eye(len(symbols), dtype=float) * COVARIANCE_REGULARIZATION
-    expected_returns = optimizer_input.expected_returns.loc[symbols].to_numpy(dtype=float)
-    upper_bounds = _position_upper_bounds(
-        symbols=symbols,
-        achieved_target_exposure=achieved_target_exposure,
-        max_position_weight=max_position_weight,
-        max_group_weight=max_group_weight,
+    expected_returns = optimizer_input.expected_returns.loc[problem.symbols].to_numpy(
+        dtype=float
     )
-    resolved_symbol_groups = _validated_symbol_groups(symbols, symbol_groups, max_group_weight)
-    grouped_indices = _group_indices(symbols, resolved_symbol_groups)
 
     def objective(weights: np.ndarray) -> float:
-        return float(0.5 * risk_aversion * (weights @ covariance @ weights) - (expected_returns @ weights))
-
-    constraints: list[dict[str, object]] = [
-        {
-            "type": "eq",
-            "fun": lambda weights: float(weights.sum() - achieved_target_exposure),
-        }
-    ]
-    for indices in grouped_indices.values():
-        constraints.append(
-            {
-                "type": "ineq",
-                "fun": lambda weights, idx=indices: float(max_group_weight - weights[idx].sum()),
-            }
+        return float(
+            0.5 * risk_aversion * (weights @ problem.covariance @ weights)
+            - (expected_returns @ weights)
         )
 
     result = minimize(
         objective,
-        x0=feasible_weights,
+        x0=problem.feasible_weights,
         method="SLSQP",
-        bounds=[(0.0, float(bound)) for bound in upper_bounds],
-        constraints=constraints,
+        bounds=[(0.0, float(bound)) for bound in problem.upper_bounds],
+        constraints=_constraints(
+            achieved_target_exposure=problem.achieved_target_exposure,
+            grouped_indices=problem.grouped_indices,
+            max_group_weight=max_group_weight,
+        ),
         options={"ftol": 1e-9, "maxiter": 500},
     )
     if not result.success:
@@ -516,44 +738,90 @@ def _solve_mean_variance_weights(
             message=result.message,
         )
 
-    weights = np.asarray(result.x, dtype=float)
-    if not np.isfinite(weights).all():
-        raise _optimizer_failure(
-            method="mean_variance",
-            signal_date=optimizer_input.signal_date,
-            effective_date=optimizer_input.effective_date,
-            message="solver returned non-finite weights",
-        )
+    return _finalize_optimized_weights(
+        method="mean_variance",
+        optimizer_input=optimizer_input,
+        problem=problem,
+        weights=np.asarray(result.x, dtype=float),
+        max_group_weight=max_group_weight,
+    )
 
-    weights = np.clip(weights, 0.0, upper_bounds)
-    if abs(float(weights.sum()) - achieved_target_exposure) > CONSTRAINT_TOLERANCE:
-        raise _optimizer_failure(
-            method="mean_variance",
-            signal_date=optimizer_input.signal_date,
-            effective_date=optimizer_input.effective_date,
-            message="solver returned weights that violate the target exposure constraint",
-        )
-    if (weights > upper_bounds + CONSTRAINT_TOLERANCE).any():
-        raise _optimizer_failure(
-            method="mean_variance",
-            signal_date=optimizer_input.signal_date,
-            effective_date=optimizer_input.effective_date,
-            message="solver returned weights that violate the position cap constraint",
-        )
-    for group_name, indices in grouped_indices.items():
-        group_weight = float(weights[indices].sum())
-        if group_weight > max_group_weight + CONSTRAINT_TOLERANCE:
+
+def _solve_risk_parity_weights(
+    optimizer_input: OptimizerInput,
+    *,
+    target_gross_exposure: float,
+    max_position_weight: float | None,
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+) -> pd.Series:
+    problem = _prepare_long_only_problem(
+        optimizer_input,
+        method="risk_parity",
+        target_gross_exposure=target_gross_exposure,
+        max_position_weight=max_position_weight,
+        symbol_groups=symbol_groups,
+        max_group_weight=max_group_weight,
+    )
+    if problem.achieved_target_exposure <= WEIGHT_EPSILON:
+        return pd.Series(0.0, index=problem.symbols, dtype=float)
+
+    if len(problem.symbols) == 1:
+        return pd.Series(problem.feasible_weights, index=problem.symbols, dtype=float)
+
+    target_share = 1.0 / len(problem.symbols)
+
+    def objective(weights: np.ndarray) -> float:
+        portfolio_variance = float(weights @ problem.covariance @ weights)
+        if portfolio_variance <= 0.0:
             raise _optimizer_failure(
-                method="mean_variance",
+                method="risk_parity",
                 signal_date=optimizer_input.signal_date,
                 effective_date=optimizer_input.effective_date,
-                message=(
-                    "solver returned weights that violate the group cap constraint "
-                    f"for group '{group_name}'"
-                ),
+                message="covariance produced non-positive portfolio variance during optimization",
             )
+        marginal_contributions = problem.covariance @ weights
+        contribution_shares = (weights * marginal_contributions) / portfolio_variance
+        return float(np.square(contribution_shares - target_share).sum())
 
-    return pd.Series(weights, index=symbols, dtype=float)
+    result = minimize(
+        objective,
+        x0=problem.feasible_weights,
+        method="SLSQP",
+        bounds=[(0.0, float(bound)) for bound in problem.upper_bounds],
+        constraints=_constraints(
+            achieved_target_exposure=problem.achieved_target_exposure,
+            grouped_indices=problem.grouped_indices,
+            max_group_weight=max_group_weight,
+        ),
+        options={"ftol": 1e-9, "maxiter": 500},
+    )
+    if not result.success:
+        raise _optimizer_failure(
+            method="risk_parity",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message=result.message,
+        )
+
+    weights = _finalize_optimized_weights(
+        method="risk_parity",
+        optimizer_input=optimizer_input,
+        problem=problem,
+        weights=np.asarray(result.x, dtype=float),
+        max_group_weight=max_group_weight,
+    )
+    portfolio_variance = float(
+        weights.to_numpy(dtype=float) @ problem.covariance @ weights.to_numpy(dtype=float)
+    )
+    if portfolio_variance <= 0.0:
+        raise _optimizer_failure(
+            method="risk_parity",
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="covariance produced non-positive portfolio variance for the final solution",
+        )
+    return weights
 
 
 def _weights_to_frame(
@@ -590,39 +858,74 @@ def generate_weights(
     max_position_weight: float | None = None,
     max_group_weight: float | None = None,
 ) -> pd.DataFrame:
-    if method != "mean_variance":
+    if method == "black_litterman":
+        raise _unsupported_method_error(method)
+    if method not in EXECUTABLE_METHODS:
         raise _unsupported_method_error(method)
     if not long_only:
-        raise ValueError("Mean-variance optimized baseline currently supports long_only=True only.")
+        raise ValueError(
+            f"{strategy_name_for_method(method)} optimized baseline currently supports long_only=True only."
+        )
+    if method == "risk_parity":
+        if expected_return_source != "historical_mean":
+            raise ValueError(
+                "Risk-parity optimized baseline does not use expected returns; "
+                "expected_return_source must remain 'historical_mean'."
+            )
+        if external_expected_returns_path is not None:
+            raise ValueError(
+                "Risk-parity optimized baseline does not use expected returns; "
+                "external_expected_returns_path must be omitted."
+            )
     if panel.empty:
         return _empty_weights_frame()
 
-    optimizer_inputs = build_optimizer_inputs(
-        panel,
-        symbols=list(symbols),
-        lookback_days=lookback_days,
-        frequency=frequency,
-        covariance_estimator=covariance_estimator,
-        external_covariance_path=external_covariance_path,
-        expected_return_source=expected_return_source,
-        external_expected_returns_path=external_expected_returns_path,
-    )
+    strategy_name = strategy_name_for_method(method)
+    if method == "mean_variance":
+        optimizer_inputs = build_optimizer_inputs(
+            panel,
+            symbols=list(symbols),
+            lookback_days=lookback_days,
+            frequency=frequency,
+            covariance_estimator=covariance_estimator,
+            external_covariance_path=external_covariance_path,
+            expected_return_source=expected_return_source,
+            external_expected_returns_path=external_expected_returns_path,
+        )
+    else:
+        optimizer_inputs = build_covariance_inputs(
+            panel,
+            symbols=list(symbols),
+            lookback_days=lookback_days,
+            frequency=frequency,
+            covariance_estimator=covariance_estimator,
+            external_covariance_path=external_covariance_path,
+        )
     if not optimizer_inputs:
         return _empty_weights_frame()
 
     weight_frames = []
     for optimizer_input in optimizer_inputs:
-        weights = _solve_mean_variance_weights(
-            optimizer_input,
-            target_gross_exposure=target_gross_exposure,
-            risk_aversion=risk_aversion,
-            max_position_weight=max_position_weight,
-            symbol_groups=symbol_groups,
-            max_group_weight=max_group_weight,
-        )
+        if method == "mean_variance":
+            weights = _solve_mean_variance_weights(
+                optimizer_input,
+                target_gross_exposure=target_gross_exposure,
+                risk_aversion=risk_aversion,
+                max_position_weight=max_position_weight,
+                symbol_groups=symbol_groups,
+                max_group_weight=max_group_weight,
+            )
+        else:
+            weights = _solve_risk_parity_weights(
+                optimizer_input,
+                target_gross_exposure=target_gross_exposure,
+                max_position_weight=max_position_weight,
+                symbol_groups=symbol_groups,
+                max_group_weight=max_group_weight,
+            )
         weight_frames.append(
             _weights_to_frame(
-                MEAN_VARIANCE_STRATEGY_NAME,
+                strategy_name,
                 optimizer_input.effective_date,
                 optimizer_input.symbols,
                 weights,

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -18,7 +18,6 @@ run_marketlab_cli = getattr(
 )
 write_yaml_config = _cli_harness.write_yaml_config
 
-RISK_PARITY_ERROR = "baselines.optimized.method='risk_parity' is not implemented yet."
 BLACK_LITTERMAN_ERROR = "baselines.optimized.method='black_litterman' is not implemented yet."
 
 
@@ -206,21 +205,63 @@ def test_backtest_keeps_mean_variance_as_cash_when_no_windows_exist(tmp_path: Pa
     assert mean_variance_row["avg_cash_weight"] == 1.0
 
 
-def test_backtest_rejects_unimplemented_risk_parity_baseline(tmp_path: Path) -> None:
+def test_backtest_supports_risk_parity_optimized_baseline(tmp_path: Path) -> None:
     config_path = _write_backtest_config(
         tmp_path,
         optimized={
             "enabled": True,
             "method": "risk_parity",
+            "lookback_days": 3,
+            "target_gross_exposure": 0.6,
         },
     )
 
     result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
 
-    assert result.returncode != 0
-    combined_output = f"{result.stdout}\n{result.stderr}"
-    assert RISK_PARITY_ERROR in combined_output
-    assert not (tmp_path / "runs" / "optimized_scaffold_backtest").exists()
+    run_root = tmp_path / "runs" / "optimized_scaffold_backtest"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert set(metrics["strategy"]) == {"buy_hold", "sma", "risk_parity"}
+    assert set(strategy_summary["strategy"]) == {"buy_hold", "sma", "risk_parity"}
+    risk_parity_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "risk_parity"
+    ].iloc[0]
+    assert risk_parity_row["avg_gross_exposure"] <= 0.6 + 1e-6
+    assert "risk_parity" in report_text
+
+
+def test_backtest_keeps_risk_parity_as_cash_when_no_windows_exist(tmp_path: Path) -> None:
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "risk_parity",
+            "lookback_days": 10_000,
+            "target_gross_exposure": 0.6,
+        },
+        buy_hold=False,
+        sma_enabled=False,
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_backtest"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+
+    assert set(metrics["strategy"]) == {"risk_parity"}
+    assert set(strategy_summary["strategy"]) == {"risk_parity"}
+    risk_parity_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "risk_parity"
+    ].iloc[0]
+    assert risk_parity_row["avg_gross_exposure"] == 0.0
+    assert risk_parity_row["avg_cash_weight"] == 1.0
 
 
 

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -502,6 +502,40 @@ def test_run_experiment_supports_mean_variance_baseline(tmp_path: Path) -> None:
     assert mean_variance_row["avg_gross_exposure"] <= 0.7 + 1e-6
     assert "mean_variance" in report_text
 
+
+def test_run_experiment_supports_risk_parity_baseline(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        optimized={
+            "enabled": True,
+            "method": "risk_parity",
+            "lookback_days": 5,
+            "target_gross_exposure": 0.7,
+        },
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    performance = pd.read_csv(run_dir / "performance.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    expected_strategies = {"buy_hold", "sma", "risk_parity", "ml_logistic_regression"}
+    assert set(metrics["strategy"]) == expected_strategies
+    assert set(performance["strategy"]) == expected_strategies
+    assert set(strategy_summary["strategy"]) == expected_strategies
+    risk_parity_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "risk_parity"
+    ].iloc[0]
+    assert risk_parity_row["avg_gross_exposure"] <= 0.71
+    assert "risk_parity" in report_text
+
+
 def test_run_experiment_supports_group_weight_allocation_baseline(tmp_path: Path) -> None:
     config_path = _write_run_experiment_config(
         tmp_path,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -307,6 +307,22 @@ def test_load_config_rejects_invalid_cost_sensitivity_bps(
             "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 when baselines.optimized.method='mean_variance'",
         ),
         (
+            {"method": "risk_parity", "long_only": False},
+            "baselines.optimized.long_only must be true when baselines.optimized.method='risk_parity'",
+        ),
+        (
+            {"method": "risk_parity", "target_gross_exposure": 1.2},
+            "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 when baselines.optimized.method='risk_parity'",
+        ),
+        (
+            {"method": "risk_parity", "expected_return_source": "external_csv"},
+            "baselines.optimized.expected_return_source must remain 'historical_mean' when baselines.optimized.method='risk_parity'",
+        ),
+        (
+            {"method": "risk_parity", "external_expected_returns_path": "expected.csv"},
+            "baselines.optimized.external_expected_returns_path must be empty when baselines.optimized.method='risk_parity'",
+        ),
+        (
             {"covariance_estimator": "external_csv"},
             "baselines.optimized.external_covariance_path is required when baselines.optimized.covariance_estimator='external_csv'",
         ),

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -9,6 +9,7 @@ import pytest
 from marketlab.strategies.optimized import (
     DIAGONAL_SHRINKAGE_WEIGHT,
     EWMA_LAMBDA,
+    build_covariance_inputs,
     build_optimizer_inputs,
     build_optimizer_windows,
     estimate_covariance_matrix,
@@ -252,6 +253,33 @@ def test_build_optimizer_inputs_supports_external_sources(tmp_path: Path) -> Non
     assert first_input.expected_returns.loc["AAA"] == pytest.approx(0.01)
     assert first_input.covariance.loc["BBB", "BBB"] == pytest.approx(0.04)
 
+
+def test_build_covariance_inputs_supports_external_covariance_only(tmp_path: Path) -> None:
+    panel = _build_panel()
+    covariance_path = tmp_path / "covariance.csv"
+    pd.DataFrame(
+        {
+            "symbol": ["AAA", "BBB"],
+            "AAA": [0.09, 0.01],
+            "BBB": [0.01, 0.04],
+        }
+    ).to_csv(covariance_path, index=False)
+
+    optimizer_inputs = build_covariance_inputs(
+        panel,
+        symbols=["AAA", "BBB"],
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+    )
+
+    assert len(optimizer_inputs) >= 1
+    first_input = optimizer_inputs[0]
+    assert first_input.expected_returns is None
+    assert list(first_input.covariance.index) == ["AAA", "BBB"]
+    assert first_input.covariance.loc["BBB", "BBB"] == pytest.approx(0.04)
+
+
 def test_build_optimizer_inputs_validates_external_requirements_before_window_generation() -> None:
     empty_panel = pd.DataFrame(columns=["symbol", "timestamp", "adj_close"])
 
@@ -491,13 +519,185 @@ def test_generate_weights_respects_group_caps(tmp_path: Path) -> None:
     assert float(first_weights.sum()) == pytest.approx(0.8, abs=1e-5)
 
 
-def test_generate_weights_rejects_unimplemented_methods() -> None:
+def test_generate_weights_produces_equal_risk_parity_solution(tmp_path: Path) -> None:
     panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
 
-    with pytest.raises(RuntimeError, match="baselines.optimized.method='risk_parity' is not implemented yet"):
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="risk_parity",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+    )
+
+    assert set(weights["strategy"]) == {"risk_parity"}
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.5, abs=1e-6)
+    assert first_weights.loc["BBB"] == pytest.approx(0.5, abs=1e-6)
+
+
+def test_generate_weights_overweights_lower_volatility_in_risk_parity(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.01, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="risk_parity",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(2.0 / 3.0, abs=1e-3)
+    assert first_weights.loc["BBB"] == pytest.approx(1.0 / 3.0, abs=1e-3)
+
+
+def test_generate_weights_respects_target_gross_exposure_for_risk_parity(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="risk_parity",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        target_gross_exposure=0.6,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert float(first_weights.sum()) == pytest.approx(0.6, abs=1e-6)
+    assert first_weights.loc["AAA"] == pytest.approx(0.3, abs=1e-6)
+    assert first_weights.loc["BBB"] == pytest.approx(0.3, abs=1e-6)
+
+
+def test_generate_weights_respects_position_caps_for_risk_parity(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.01, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="risk_parity",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        max_position_weight=0.6,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.6, abs=1e-5)
+    assert first_weights.loc["BBB"] == pytest.approx(0.4, abs=1e-5)
+
+
+def test_generate_weights_respects_group_caps_for_risk_parity(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel(
+        (("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0), ("CCC", 140.0, 1.0))
+    )
+    covariance = pd.DataFrame(
+        np.diag([0.04, 0.04, 0.04]),
+        index=["AAA", "BBB", "CCC"],
+        columns=["AAA", "BBB", "CCC"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB", "CCC"],
+        method="risk_parity",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        symbol_groups={"AAA": "growth", "BBB": "growth", "CCC": "defensive"},
+        max_group_weight=0.4,
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert float(first_weights.loc[["AAA", "BBB"]].sum()) == pytest.approx(0.4, abs=1e-5)
+    assert first_weights.loc["CCC"] == pytest.approx(0.4, abs=1e-5)
+    assert float(first_weights.sum()) == pytest.approx(0.8, abs=1e-5)
+
+
+def test_generate_weights_rejects_expected_return_inputs_for_risk_parity(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    with pytest.raises(
+        ValueError,
+        match="Risk-parity optimized baseline does not use expected returns",
+    ):
         generate_weights(
             panel,
             symbols=["AAA", "BBB"],
             method="risk_parity",
+            lookback_days=3,
+            covariance_estimator="external_csv",
+            external_covariance_path=covariance_path,
+            expected_return_source="external_csv",
+            external_expected_returns_path=tmp_path / "expected.csv",
+        )
+
+
+def test_generate_weights_rejects_unimplemented_methods() -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+
+    with pytest.raises(
+        RuntimeError,
+        match="baselines.optimized.method='black_litterman' is not implemented yet",
+    ):
+        generate_weights(
+            panel,
+            symbols=["AAA", "BBB"],
+            method="black_litterman",
             lookback_days=3,
         )


### PR DESCRIPTION
## Summary
- add the executable `risk_parity` optimized baseline on top of the existing optimizer scaffold
- make optimized inputs method-aware so covariance-only methods do not depend on expected-return loading
- keep `black_litterman` on the explicit not-implemented path and preserve the current artifact/report contracts

## Validation
- `python -m ruff check src/marketlab/config.py src/marketlab/pipeline.py src/marketlab/strategies/optimized.py tests/unit/test_config.py tests/unit/test_optimized.py tests/integration/test_optimized_scaffold.py tests/integration/test_run_experiment.py README.md docs/architecture.md`
- `python -m mkdocs build --strict`
- direct unit harnesses for config validation, covariance-only optimizer inputs, risk-parity solver behavior, hard cap behavior, and mean-variance regression coverage
- direct integration harnesses for `backtest` and `run-experiment` with `mean_variance`, `risk_parity`, no-window cash fallback, and explicit `black_litterman` failure behavior

## Notes
- local `pytest` and `python -m build --no-isolation` are still affected by the existing Windows temp-permission issue on this machine, so the validation above uses the passing direct harness path for the new tests

Closes #41