### PR TITLE
feat: add Black-Litterman optimizer baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,16 +233,21 @@ Add to `baselines`:
 - `optimized.long_only`
 - `optimized.target_gross_exposure`
 - `optimized.risk_aversion`
+- `optimized.equilibrium_weights`
+- `optimized.tau`
+- `optimized.views`
 
 Current Phase 5 behavior is intentionally narrow:
 
-- `mean_variance` and `risk_parity` are executable optimized methods
-- `black_litterman` still fails fast with an explicit not-implemented error
+- `mean_variance`, `risk_parity`, and `black_litterman` are executable optimized methods
+- `black_litterman` uses signed basket views as written, does not renormalize them, and defaults to the diagonal `Omega = diag(P * tau * Sigma * P^T)` uncertainty rule
+- successful Black-Litterman runs write `black_litterman_assumptions.csv` alongside the other run artifacts and reference it from `report.md`
 - the optimizer uses trailing daily adjusted-close returns ending on the `signal_date` and applies the weights on the next market open
 - no allocation is emitted before the first rebalance window with a full optimizer lookback
 - `target_gross_exposure < 1.0` leaves the undeployed exposure in cash
 - `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard long-only optimizer constraints
-- `risk_aversion` only applies to `mean_variance`
+- `long_only` and `target_gross_exposure <= 1.0` remain mandatory for all executable optimized methods
+- `risk_aversion` applies to `mean_variance` and is also reused as the market-implied prior scalar for `black_litterman`
 - `risk_parity` uses only the configured covariance estimator and does not consume expected-return inputs
 - capped `risk_parity` portfolios are the best feasible approximation to equal risk contributions, not exact parity under binding caps
 
@@ -250,6 +255,7 @@ External input rules:
 
 - covariance CSVs must be square daily-return covariance matrices keyed by the configured symbols
 - expected-return CSVs must contain exactly `symbol,expected_return`, where `expected_return` is a daily decimal return
+- Black-Litterman views are signed basket weights over configured symbols; the loader rejects unknown symbols, empty views, and all-zero coefficients
 - both loaders reorder to `data.symbols` and reject missing, extra, or non-numeric values
 
 ## Single-Symbol VOO Timing Example

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance and risk-parity baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -76,9 +76,9 @@ flowchart TD
     Launcher --> Experiment[run-experiment]
 
     Prepare --> Panel[prepared panel cache]
-    Backtest --> BaselineArtifacts[metrics.csv performance.csv analytics report.md plots]
+    Backtest --> BaselineArtifacts[metrics.csv performance.csv analytics report.md plots black_litterman_assumptions.csv when applicable]
     Train --> TrainingArtifacts[folds.csv fold_diagnostics.csv ranking_diagnostics.csv calibration_diagnostics.csv score_histograms.csv threshold_diagnostics.csv manifest metrics predictions summaries plots models/]
-    Experiment --> ExperimentArtifacts[metrics.csv performance.csv analytics report.md strategy plots calibration plots diagnostics summaries optional models/]
+    Experiment --> ExperimentArtifacts[metrics.csv performance.csv analytics report.md strategy plots calibration plots diagnostics summaries optional models/black_litterman_assumptions.csv when applicable]
 ```
 
 ## Automation Split
@@ -124,13 +124,16 @@ The required CI path stays offline and deterministic through tox. The Docker run
 
 ## Optimized Baseline Rules
 
-- `baselines.optimized.method="mean_variance"` and `baselines.optimized.method="risk_parity"` are executable optimized baselines in the current phase.
-- `black_litterman` remains scaffold-only and fails fast with an explicit not-implemented error.
+- `baselines.optimized.method="mean_variance"`, `baselines.optimized.method="risk_parity"`, and `baselines.optimized.method="black_litterman"` are executable optimized baselines in the current phase.
+- Black-Litterman views are signed basket weights over configured symbols; MarketLab uses them as written and does not renormalize them.
+- Black-Litterman posterior uncertainty defaults to the diagonal `Omega = diag(P * tau * Sigma * P^T)` rule.
+- Successful Black-Litterman runs persist `black_litterman_assumptions.csv` and reference it from `report.md`.
 - Trailing return windows are built from adjusted close data only, and the latest included return must end on the `signal_date`.
 - Optimized weights are applied on the next market open after the `signal_date`, and no allocation is emitted before the first full optimizer lookback window exists.
 - `target_gross_exposure` is a long-only invested-fraction request; any undeployed exposure remains cash in the backtest engine.
 - `portfolio.risk.max_position_weight` and `portfolio.risk.max_group_weight` are enforced as hard optimizer constraints for the long-only optimized methods.
-- `risk_aversion` applies only to `mean_variance`.
+- `long_only` and `target_gross_exposure <= 1.0` remain mandatory for the executable optimized baselines.
+- `risk_aversion` applies to `mean_variance` and is also reused as the market-implied prior scalar for `black_litterman`.
 - `risk_parity` uses only the configured covariance estimator and does not consume expected-return inputs.
 - Binding position or group caps turn `risk_parity` into the best feasible approximation to equal risk contributions rather than exact parity.
 - External covariance inputs must be square daily-return covariance matrices keyed by the configured symbols.
@@ -439,6 +442,7 @@ classDiagram
       +ranking_diagnostics_path: Path | None
       +fold_summary_path: Path | None
       +report_path: Path | None
+      +black_litterman_assumptions_path: Path | None
       +cumulative_plot_path: Path | None
       +drawdown_plot_path: Path | None
       +turnover_plot_path: Path | None
@@ -733,11 +737,12 @@ Best practice:
 - Provides covariance helpers for `sample`, `ewma`, `diagonal_shrinkage`, and `external_csv` inputs.
 - Provides expected-return helpers for `historical_mean` and `external_csv` inputs.
 - Reorders and validates external covariance and expected-return files against `data.symbols`.
-- Executes the long-only `mean_variance` and `risk_parity` baselines with hard position and group constraints, while leaving `black_litterman` scaffold-only.
+- Provides the solver plumbing reused by the executable long-only optimized baselines, including the Black-Litterman posterior-return and assumptions builders.
 
 Best practice:
 - Keep adjusted-close return windows and optimizer timing leakage-safe: signal on the close, execute on the next open.
 - Keep hard constraints explicit inside the solver instead of post-solve clipping.
+- Keep Black-Litterman views signed, maintain the diagonal `Omega` default, and preserve the long-only execution scope.
 - Reject malformed external files early and keep unsupported optimized methods on explicit errors until they are implemented.
 
 ### `src/marketlab/strategies/buy_hold.py`

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -88,6 +88,13 @@ class AllocationConfig:
 
 
 @dataclass(slots=True)
+class BlackLittermanViewConfig:
+    name: str = ""
+    weights: dict[str, float] = field(default_factory=dict)
+    view_return: float = 0.0
+
+
+@dataclass(slots=True)
 class OptimizedConfig:
     enabled: bool = False
     method: str = "mean_variance"
@@ -100,6 +107,9 @@ class OptimizedConfig:
     long_only: bool = True
     target_gross_exposure: float = 1.0
     risk_aversion: float = 1.0
+    equilibrium_weights: dict[str, float] = field(default_factory=dict)
+    tau: float = 0.05
+    views: list[BlackLittermanViewConfig] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -226,11 +236,18 @@ def _normalize_mapping_sections(config: ExperimentConfig) -> None:
         optimized.external_covariance_path = ""
     if optimized.external_expected_returns_path is None:
         optimized.external_expected_returns_path = ""
+    if optimized.equilibrium_weights is None:
+        optimized.equilibrium_weights = {}
+    if optimized.views is None:
+        optimized.views = []
 
 
 def _validate_weights(label: str, weights: dict[str, float]) -> None:
-    if any(value < 0.0 for value in weights.values()):
-        raise ValueError(f"{label} must contain non-negative weights.")
+    for value in weights.values():
+        if not math.isfinite(value):
+            raise ValueError(f"{label} must contain only finite numeric values.")
+        if value < 0.0:
+            raise ValueError(f"{label} must contain non-negative weights.")
 
     if abs(sum(weights.values()) - 1.0) > WEIGHT_TOLERANCE:
         raise ValueError(f"{label} must sum to 1.0.")
@@ -309,6 +326,7 @@ def _validate_config(config: ExperimentConfig) -> None:
         "baselines.optimized.risk_aversion",
         optimized.risk_aversion,
     )
+    _validate_positive_float("baselines.optimized.tau", optimized.tau)
     if optimized.method == "mean_variance":
         if not optimized.long_only:
             raise ValueError(
@@ -341,6 +359,61 @@ def _validate_config(config: ExperimentConfig) -> None:
                 "baselines.optimized.external_expected_returns_path must be empty when "
                 "baselines.optimized.method='risk_parity'."
             )
+    if optimized.method == "black_litterman":
+        if not optimized.long_only:
+            raise ValueError(
+                "baselines.optimized.long_only must be true when "
+                "baselines.optimized.method='black_litterman'."
+            )
+        if optimized.target_gross_exposure > 1.0:
+            raise ValueError(
+                "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 "
+                "when baselines.optimized.method='black_litterman'."
+            )
+        if optimized.expected_return_source != "historical_mean":
+            raise ValueError(
+                "baselines.optimized.expected_return_source must remain 'historical_mean' "
+                "when baselines.optimized.method='black_litterman'."
+            )
+        if optimized.external_expected_returns_path != "":
+            raise ValueError(
+                "baselines.optimized.external_expected_returns_path must be empty when "
+                "baselines.optimized.method='black_litterman'."
+            )
+        if set(optimized.equilibrium_weights) != symbol_set:
+            raise ValueError(
+                "baselines.optimized.equilibrium_weights must match data.symbols exactly "
+                "when baselines.optimized.method='black_litterman'."
+            )
+        _validate_weights(
+            "baselines.optimized.equilibrium_weights",
+            optimized.equilibrium_weights,
+        )
+        if not optimized.views:
+            raise ValueError(
+                "baselines.optimized.views must be non-empty when "
+                "baselines.optimized.method='black_litterman'."
+            )
+        for index, view in enumerate(optimized.views):
+            label = f"baselines.optimized.views[{index}]"
+            if not view.name:
+                raise ValueError(f"{label}.name must be non-empty.")
+            unknown_view_symbols = sorted(set(view.weights) - symbol_set)
+            if unknown_view_symbols:
+                joined = ", ".join(unknown_view_symbols)
+                raise ValueError(f"{label}.weights contains unknown symbols: {joined}")
+            if not view.weights:
+                raise ValueError(f"{label}.weights must not be empty.")
+            if not math.isfinite(view.view_return):
+                raise ValueError(f"{label}.view_return must be finite.")
+            non_zero_weights = 0
+            for symbol, coefficient in view.weights.items():
+                if not math.isfinite(coefficient):
+                    raise ValueError(f"{label}.weights[{symbol}] must be finite.")
+                if abs(coefficient) > WEIGHT_TOLERANCE:
+                    non_zero_weights += 1
+            if non_zero_weights == 0:
+                raise ValueError(f"{label}.weights must contain at least one non-zero coefficient.")
     if optimized.covariance_estimator == "external_csv":
         if optimized.external_covariance_path == "":
             raise ValueError(
@@ -457,5 +530,9 @@ def load_config(path: str | Path) -> ExperimentConfig:
         base_dir=_config_base_dir(config_path),
     )
     _normalize_mapping_sections(config)
+    config.baselines.optimized.views = [
+        _section(BlackLittermanViewConfig, view)
+        for view in config.baselines.optimized.views
+    ]
     _validate_config(config)
     return config

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -42,6 +42,7 @@ from marketlab.reports.plots import (
 from marketlab.reports.summary import build_fold_summary, build_model_summary
 from marketlab.strategies.allocation import generate_weights as allocation_weights
 from marketlab.strategies.buy_hold import generate_weights as buy_hold_weights
+from marketlab.strategies.optimized import generate_black_litterman_output
 from marketlab.strategies.optimized import (
     generate_cash_only_weights as optimized_cash_only_weights,
 )
@@ -85,6 +86,7 @@ class ExperimentArtifacts:
     threshold_diagnostics_path: Path | None
     fold_summary_path: Path | None
     model_summary_path: Path | None
+    black_litterman_assumptions_path: Path | None = None
 
 
 @dataclass(slots=True)
@@ -131,6 +133,23 @@ def _slice_backtest_result(
             backtest_result.daily_cash["date"].isin(oos_dates)
         ].copy(),
     )
+
+
+def _slice_black_litterman_assumptions(
+    assumptions: pd.DataFrame | None,
+    oos_dates: pd.Index,
+) -> pd.DataFrame | None:
+    if assumptions is None:
+        return None
+    if assumptions.empty:
+        return None
+
+    sliced = assumptions.loc[
+        pd.to_datetime(assumptions["effective_date"]).isin(oos_dates)
+    ].copy()
+    if sliced.empty:
+        return None
+    return sliced.reset_index(drop=True)
 
 def prepare_data(config: ExperimentConfig) -> tuple[pd.DataFrame, Path]:
     config.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -179,6 +198,7 @@ def _persist_experiment_outputs(
     score_histograms_path: Path | None = None,
     threshold_diagnostics: pd.DataFrame | None = None,
     threshold_diagnostics_path: Path | None = None,
+    black_litterman_assumptions: pd.DataFrame | None = None,
 ) -> ExperimentArtifacts:
     artifact_run_dir = run_dir or _run_dir(config)
     metrics = compute_strategy_metrics(performance)
@@ -255,6 +275,15 @@ def _persist_experiment_outputs(
         persisted_threshold_diagnostics_path = artifact_run_dir / "threshold_diagnostics.csv"
         threshold_diagnostics.to_csv(persisted_threshold_diagnostics_path, index=False)
 
+    black_litterman_assumptions_path: Path | None = None
+    if black_litterman_assumptions is not None:
+        black_litterman_assumptions_path = artifact_run_dir / "black_litterman_assumptions.csv"
+        black_litterman_assumptions.to_csv(
+            black_litterman_assumptions_path,
+            index=False,
+            date_format="%Y-%m-%d",
+        )
+
     model_summary_path: Path | None = None
     if model_summary is not None:
         model_summary_path = artifact_run_dir / "model_summary.csv"
@@ -318,6 +347,7 @@ def _persist_experiment_outputs(
             calibration_curves_plot_path=calibration_curves_plot_path,
             score_histograms_plot_path=score_histograms_plot_path,
             threshold_sweeps_plot_path=threshold_sweeps_plot_path,
+            black_litterman_assumptions_path=black_litterman_assumptions_path,
         )
 
     return ExperimentArtifacts(
@@ -346,10 +376,51 @@ def _persist_experiment_outputs(
         threshold_diagnostics_path=persisted_threshold_diagnostics_path,
         fold_summary_path=fold_summary_path,
         model_summary_path=model_summary_path,
+        black_litterman_assumptions_path=black_litterman_assumptions_path,
     )
 
 
-def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResult:
+def _run_black_litterman_baseline(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    lookback_days: int,
+    frequency: str,
+    covariance_estimator: str,
+    external_covariance_path: Path | None,
+    target_gross_exposure: float,
+    risk_aversion: float,
+    equilibrium_weights: dict[str, float],
+    tau: float,
+    views: list,
+    symbol_groups: dict[str, str],
+    max_position_weight: float | None,
+    max_group_weight: float | None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    output = generate_black_litterman_output(
+        panel,
+        symbols=symbols,
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+        long_only=True,
+        target_gross_exposure=target_gross_exposure,
+        risk_aversion=risk_aversion,
+        symbol_groups=symbol_groups,
+        max_position_weight=max_position_weight,
+        max_group_weight=max_group_weight,
+        equilibrium_weights=equilibrium_weights,
+        tau=tau,
+        views=views,
+    )
+    return output.weights, output.assumptions
+
+
+def run_baselines(
+    config: ExperimentConfig,
+    panel: pd.DataFrame,
+) -> tuple[BacktestResult, pd.DataFrame | None]:
     featured = add_feature_set(
         panel=panel,
         return_windows=config.features.return_windows,
@@ -387,26 +458,47 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
                 )
             )
 
+    black_litterman_assumptions: pd.DataFrame | None = None
     if config.baselines.optimized.enabled:
         optimized_method = config.baselines.optimized.method
-        weights = optimized_weights(
-            panel=featured,
-            symbols=config.data.symbols,
-            method=optimized_method,
-            lookback_days=config.baselines.optimized.lookback_days,
-            frequency=config.baselines.optimized.rebalance_frequency,
-            covariance_estimator=config.baselines.optimized.covariance_estimator,
-            external_covariance_path=config.optimized_external_covariance_path,
-            expected_return_source=config.baselines.optimized.expected_return_source,
-            external_expected_returns_path=config.optimized_external_expected_returns_path,
-            long_only=config.baselines.optimized.long_only,
-            target_gross_exposure=config.baselines.optimized.target_gross_exposure,
-            risk_aversion=config.baselines.optimized.risk_aversion,
-            symbol_groups=config.data.symbol_groups,
-            max_position_weight=config.portfolio.risk.max_position_weight,
-            max_group_weight=config.portfolio.risk.max_group_weight,
-        )
+        if optimized_method == "black_litterman":
+            weights, black_litterman_assumptions = _run_black_litterman_baseline(
+                featured,
+                symbols=config.data.symbols,
+                lookback_days=config.baselines.optimized.lookback_days,
+                frequency=config.baselines.optimized.rebalance_frequency,
+                covariance_estimator=config.baselines.optimized.covariance_estimator,
+                external_covariance_path=config.optimized_external_covariance_path,
+                target_gross_exposure=config.baselines.optimized.target_gross_exposure,
+                risk_aversion=config.baselines.optimized.risk_aversion,
+                equilibrium_weights=config.baselines.optimized.equilibrium_weights,
+                tau=config.baselines.optimized.tau,
+                views=config.baselines.optimized.views,
+                symbol_groups=config.data.symbol_groups,
+                max_position_weight=config.portfolio.risk.max_position_weight,
+                max_group_weight=config.portfolio.risk.max_group_weight,
+            )
+        else:
+            weights = optimized_weights(
+                panel=featured,
+                symbols=config.data.symbols,
+                method=optimized_method,
+                lookback_days=config.baselines.optimized.lookback_days,
+                frequency=config.baselines.optimized.rebalance_frequency,
+                covariance_estimator=config.baselines.optimized.covariance_estimator,
+                external_covariance_path=config.optimized_external_covariance_path,
+                expected_return_source=config.baselines.optimized.expected_return_source,
+                external_expected_returns_path=config.optimized_external_expected_returns_path,
+                long_only=config.baselines.optimized.long_only,
+                target_gross_exposure=config.baselines.optimized.target_gross_exposure,
+                risk_aversion=config.baselines.optimized.risk_aversion,
+                symbol_groups=config.data.symbol_groups,
+                max_position_weight=config.portfolio.risk.max_position_weight,
+                max_group_weight=config.portfolio.risk.max_group_weight,
+            )
         if weights.empty and optimized_method_is_executable(optimized_method):
+            if optimized_method == "black_litterman":
+                black_litterman_assumptions = None
             weights = optimized_cash_only_weights(
                 optimized_method,
                 effective_date=pd.Timestamp(featured["timestamp"].min()),
@@ -436,7 +528,7 @@ def run_baselines(config: ExperimentConfig, panel: pd.DataFrame) -> BacktestResu
                 )
             )
 
-    return _concat_backtest_results(backtest_results)
+    return _concat_backtest_results(backtest_results), black_litterman_assumptions
 
 def _shared_oos_dates(
     panel: pd.DataFrame,
@@ -636,7 +728,7 @@ def train_models(config: ExperimentConfig) -> TrainModelsArtifacts:
 
 def backtest(config: ExperimentConfig) -> ExperimentArtifacts:
     panel, panel_path = prepare_data(config)
-    baseline_outputs = run_baselines(config, panel)
+    baseline_outputs, black_litterman_assumptions = run_baselines(config, panel)
     return _persist_experiment_outputs(
         config=config,
         panel_path=panel_path,
@@ -644,12 +736,13 @@ def backtest(config: ExperimentConfig) -> ExperimentArtifacts:
         daily_holdings=baseline_outputs.daily_holdings,
         daily_cash=baseline_outputs.daily_cash,
         symbol_groups=config.data.symbol_groups,
+        black_litterman_assumptions=black_litterman_assumptions,
     )
 
 
 def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
     panel, panel_path = prepare_data(config)
-    baseline_outputs = run_baselines(config, panel)
+    baseline_outputs, black_litterman_assumptions = run_baselines(config, panel)
 
     if not config.models:
         return _persist_experiment_outputs(
@@ -659,6 +752,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
             daily_holdings=baseline_outputs.daily_holdings,
             daily_cash=baseline_outputs.daily_cash,
             symbol_groups=config.data.symbol_groups,
+            black_litterman_assumptions=black_litterman_assumptions,
         )
 
     modeling_dataset = build_weekly_modeling_dataset(panel, config)
@@ -709,6 +803,10 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
     )
     combined_outputs = _concat_backtest_results([baseline_outputs, ml_outputs])
     oos_outputs = _slice_backtest_result(combined_outputs, oos_dates)
+    black_litterman_assumptions = _slice_black_litterman_assumptions(
+        black_litterman_assumptions,
+        oos_dates,
+    )
     model_summary = build_model_summary(
         model_metrics=training_outputs.metrics,
         model_manifest=training_outputs.manifest,
@@ -734,6 +832,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         calibration_diagnostics=training_outputs.calibration_diagnostics,
         score_histograms=training_outputs.score_histograms,
         threshold_diagnostics=training_outputs.threshold_diagnostics,
+        black_litterman_assumptions=black_litterman_assumptions,
     )
 
 

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -289,6 +289,47 @@ def _benchmark_summary_lines(strategy_summary: pd.DataFrame) -> list[str]:
     return lines
 
 
+def _black_litterman_view_lines(
+    config: ExperimentConfig,
+    report_path: Path,
+    black_litterman_assumptions_path: Path | None,
+) -> list[str]:
+    optimized = config.baselines.optimized
+    if (
+        optimized.method != "black_litterman"
+        or not optimized.views
+        or black_litterman_assumptions_path is None
+    ):
+        return []
+
+    rows = []
+    for view in optimized.views:
+        weights = ", ".join(
+            f"{symbol}:{view.weights[symbol]:+g}"
+            for symbol in config.data.symbols
+            if symbol in view.weights and abs(view.weights[symbol]) > 0.0
+        )
+        rows.append(
+            {
+                "name": view.name,
+                "weights": weights,
+                "view_return": view.view_return,
+            }
+        )
+
+    lines = [
+        _markdown_table(_display_frame(pd.DataFrame(rows))),
+        "",
+        "- View weights are signed basket coefficients and are used as written.",
+        "- The default view uncertainty rule is `Omega = diag(P * tau * Sigma * P^T)`.",
+    ]
+    relative_path = os.path.relpath(black_litterman_assumptions_path, start=report_path.parent)
+    lines.append(
+        f"- Assumptions artifact: [{black_litterman_assumptions_path.name}]({relative_path})"
+    )
+    return lines
+
+
 def _cost_sensitivity_lines(cost_sensitivity: pd.DataFrame) -> list[str]:
     if not set(COST_SENSITIVITY_SUMMARY_COLUMNS).issubset(cost_sensitivity.columns):
         return []
@@ -326,6 +367,7 @@ def write_markdown_report(
     calibration_curves_plot_path: Path | None = None,
     score_histograms_plot_path: Path | None = None,
     threshold_sweeps_plot_path: Path | None = None,
+    black_litterman_assumptions_path: Path | None = None,
 ) -> Path:
     output_path = Path(path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -368,6 +410,14 @@ def write_markdown_report(
         benchmark_lines = _benchmark_summary_lines(strategy_summary)
         if benchmark_lines:
             content_lines.extend(_section("Benchmark-Relative Summary", benchmark_lines))
+
+    black_litterman_lines = _black_litterman_view_lines(
+        config,
+        output_path,
+        black_litterman_assumptions_path,
+    )
+    if black_litterman_lines:
+        content_lines.extend(_section("Black-Litterman Assumptions", black_litterman_lines))
 
     if monthly_returns is not None and not monthly_returns.empty:
         content_lines.extend(

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,8 +21,18 @@ REQUIRED_PANEL_COLUMNS = {"adj_close", "symbol", "timestamp"}
 WEIGHTS_COLUMNS = ["strategy", "effective_date", "symbol", "weight"]
 MEAN_VARIANCE_STRATEGY_NAME = "mean_variance"
 RISK_PARITY_STRATEGY_NAME = "risk_parity"
+BLACK_LITTERMAN_STRATEGY_NAME = "black_litterman"
+BLACK_LITTERMAN_ASSUMPTIONS_COLUMNS = [
+    "signal_date",
+    "effective_date",
+    "symbol",
+    "equilibrium_weight",
+    "implied_prior_return",
+    "posterior_expected_return",
+    "tau",
+]
 EXECUTABLE_METHODS = frozenset(
-    {MEAN_VARIANCE_STRATEGY_NAME, RISK_PARITY_STRATEGY_NAME}
+    {MEAN_VARIANCE_STRATEGY_NAME, RISK_PARITY_STRATEGY_NAME, BLACK_LITTERMAN_STRATEGY_NAME}
 )
 
 
@@ -53,6 +64,12 @@ class LongOnlyProblem:
     grouped_indices: dict[str, np.ndarray]
 
 
+@dataclass(slots=True)
+class BlackLittermanOutput:
+    weights: pd.DataFrame
+    assumptions: pd.DataFrame
+
+
 def _empty_weights_frame() -> pd.DataFrame:
     return pd.DataFrame(columns=WEIGHTS_COLUMNS)
 
@@ -66,6 +83,8 @@ def strategy_name_for_method(method: str) -> str:
         return MEAN_VARIANCE_STRATEGY_NAME
     if method == "risk_parity":
         return RISK_PARITY_STRATEGY_NAME
+    if method == "black_litterman":
+        return BLACK_LITTERMAN_STRATEGY_NAME
     raise _unsupported_method_error(method)
 
 
@@ -83,6 +102,173 @@ def generate_cash_only_weights(
             "weight": [0.0] * len(symbols),
         }
     )
+
+
+def _black_litterman_view_field(view: object, field: str) -> object:
+    if isinstance(view, dict):
+        return view.get(field)
+    return getattr(view, field, None)
+
+
+def _validated_black_litterman_inputs(
+    *,
+    symbols: list[str],
+    equilibrium_weights: dict[str, float] | None,
+    tau: float,
+    views: list[object] | None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    symbol_set = set(symbols)
+    symbol_positions = {symbol: index for index, symbol in enumerate(symbols)}
+    if not isinstance(equilibrium_weights, Mapping) or set(equilibrium_weights) != symbol_set:
+        raise ValueError(
+            "baselines.optimized.equilibrium_weights must match data.symbols exactly when "
+            "baselines.optimized.method='black_litterman'."
+        )
+
+    try:
+        equilibrium_vector = np.asarray(
+            [float(equilibrium_weights[symbol]) for symbol in symbols],
+            dtype=float,
+        )
+    except (TypeError, ValueError):
+        raise ValueError("baselines.optimized.equilibrium_weights must contain only finite numeric values.")
+
+    if not np.isfinite(equilibrium_vector).all():
+        raise ValueError("baselines.optimized.equilibrium_weights must contain only finite numeric values.")
+    if (equilibrium_vector < 0.0).any():
+        raise ValueError("baselines.optimized.equilibrium_weights must contain non-negative weights.")
+    if abs(float(equilibrium_vector.sum()) - 1.0) > CONSTRAINT_TOLERANCE:
+        raise ValueError("baselines.optimized.equilibrium_weights must sum to 1.0.")
+    if not np.isfinite(tau) or tau <= 0.0:
+        raise ValueError("baselines.optimized.tau must be a finite positive value.")
+    if not views:
+        raise ValueError(
+            "baselines.optimized.views must be non-empty when "
+            "baselines.optimized.method='black_litterman'."
+        )
+
+    view_rows: list[np.ndarray] = []
+    view_returns: list[float] = []
+    for index, view in enumerate(views):
+        label = f"baselines.optimized.views[{index}]"
+        view_name = _black_litterman_view_field(view, "name")
+        if not view_name:
+            raise ValueError(f"{label}.name must be non-empty.")
+
+        view_weights = _black_litterman_view_field(view, "weights")
+        if not isinstance(view_weights, Mapping):
+            raise ValueError(f"{label}.weights must be a mapping of symbol to coefficient.")
+
+        view_weights = dict(view_weights)
+        unknown_view_symbols = sorted(set(view_weights) - symbol_set)
+        if unknown_view_symbols:
+            joined = ", ".join(unknown_view_symbols)
+            raise ValueError(f"{label}.weights contains unknown symbols: {joined}")
+        if not view_weights:
+            raise ValueError(f"{label}.weights must not be empty.")
+
+        view_row = np.zeros(len(symbols), dtype=float)
+        non_zero_weights = 0
+        for symbol, coefficient in view_weights.items():
+            try:
+                coefficient_value = float(coefficient)
+            except (TypeError, ValueError):
+                raise ValueError(f"{label}.weights[{symbol}] must be finite.")
+            if not np.isfinite(coefficient_value):
+                raise ValueError(f"{label}.weights[{symbol}] must be finite.")
+            view_row[symbol_positions[symbol]] = coefficient_value
+            if abs(coefficient_value) > WEIGHT_EPSILON:
+                non_zero_weights += 1
+
+        if non_zero_weights == 0:
+            raise ValueError(f"{label}.weights must contain at least one non-zero coefficient.")
+
+        view_return = _black_litterman_view_field(view, "view_return")
+        if view_return is None:
+            raise ValueError(f"{label}.view_return must be finite.")
+        try:
+            view_return_value = float(view_return)
+        except (TypeError, ValueError):
+            raise ValueError(f"{label}.view_return must be finite.")
+        if not np.isfinite(view_return_value):
+            raise ValueError(f"{label}.view_return must be finite.")
+
+        view_rows.append(view_row)
+        view_returns.append(view_return_value)
+
+    return (
+        equilibrium_vector,
+        np.asarray(view_rows, dtype=float),
+        np.asarray(view_returns, dtype=float),
+        float(tau),
+    )
+
+
+def _black_litterman_expected_returns(
+    covariance: np.ndarray,
+    *,
+    symbols: list[str],
+    risk_aversion: float,
+    equilibrium_weights: np.ndarray,
+    tau: float,
+    view_matrix: np.ndarray,
+    view_returns: np.ndarray,
+) -> pd.Series:
+    covariance = np.asarray(covariance, dtype=float)
+    if not np.isfinite(covariance).all():
+        raise ValueError("Black-Litterman covariance contains non-finite values.")
+
+    tau_covariance = tau * covariance
+    implied_returns = risk_aversion * (covariance @ equilibrium_weights)
+    projected_variance = view_matrix @ tau_covariance @ view_matrix.T
+    omega_diagonal = np.diag(projected_variance).astype(float)
+    omega_diagonal = np.maximum(omega_diagonal, COVARIANCE_REGULARIZATION)
+    omega = np.diag(omega_diagonal)
+    middle = projected_variance + omega
+    rhs = view_returns - (view_matrix @ implied_returns)
+
+    try:
+        adjustment = np.linalg.solve(middle, rhs)
+    except np.linalg.LinAlgError:
+        adjustment = np.linalg.pinv(middle) @ rhs
+
+    posterior_expected_returns = implied_returns + (tau_covariance @ view_matrix.T @ adjustment)
+    if not np.isfinite(posterior_expected_returns).all():
+        raise ValueError("Black-Litterman posterior expected returns contain non-finite values.")
+
+    return (
+        pd.Series(implied_returns, index=symbols, dtype=float, name="implied_prior_return"),
+        pd.Series(
+            posterior_expected_returns,
+            index=symbols,
+            dtype=float,
+            name="expected_return",
+        ),
+    )
+
+
+def _black_litterman_assumptions_frame(
+    optimizer_input: OptimizerInput,
+    *,
+    equilibrium_weights: pd.Series,
+    prior_returns: pd.Series,
+    posterior_expected_returns: pd.Series,
+    tau: float,
+) -> pd.DataFrame:
+    rows = []
+    for symbol in optimizer_input.symbols:
+        rows.append(
+            {
+                "signal_date": pd.Timestamp(optimizer_input.signal_date),
+                "effective_date": pd.Timestamp(optimizer_input.effective_date),
+                "symbol": symbol,
+                "equilibrium_weight": float(equilibrium_weights.loc[symbol]),
+                "implied_prior_return": float(prior_returns.loc[symbol]),
+                "posterior_expected_return": float(posterior_expected_returns.loc[symbol]),
+                "tau": float(tau),
+            }
+        )
+    return pd.DataFrame(rows, columns=BLACK_LITTERMAN_ASSUMPTIONS_COLUMNS)
 
 
 def _require_columns(panel: pd.DataFrame) -> None:
@@ -406,6 +592,123 @@ def build_optimizer_inputs(
     return inputs
 
 
+def generate_black_litterman_output(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    lookback_days: int,
+    frequency: str = "W-FRI",
+    covariance_estimator: str = "sample",
+    external_covariance_path: Path | str | None = None,
+    long_only: bool = True,
+    target_gross_exposure: float = 1.0,
+    risk_aversion: float = 1.0,
+    symbol_groups: dict[str, str] | None = None,
+    max_position_weight: float | None = None,
+    max_group_weight: float | None = None,
+    equilibrium_weights: dict[str, float] | None = None,
+    tau: float = 0.05,
+    views: list[object] | None = None,
+) -> BlackLittermanOutput:
+    if not long_only:
+        raise ValueError(
+            f"{strategy_name_for_method(BLACK_LITTERMAN_STRATEGY_NAME)} optimized baseline currently supports long_only=True only."
+        )
+    if panel.empty:
+        return BlackLittermanOutput(
+            weights=_empty_weights_frame(),
+            assumptions=pd.DataFrame(columns=BLACK_LITTERMAN_ASSUMPTIONS_COLUMNS),
+        )
+
+    (
+        bl_equilibrium_weights,
+        bl_view_matrix,
+        bl_view_returns,
+        bl_tau,
+    ) = _validated_black_litterman_inputs(
+        symbols=list(symbols),
+        equilibrium_weights=equilibrium_weights,
+        tau=tau,
+        views=views,
+    )
+    equilibrium_weight_series = pd.Series(
+        bl_equilibrium_weights,
+        index=list(symbols),
+        dtype=float,
+        name="equilibrium_weight",
+    )
+
+    optimizer_inputs = build_covariance_inputs(
+        panel,
+        symbols=list(symbols),
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+    )
+    if not optimizer_inputs:
+        return BlackLittermanOutput(
+            weights=_empty_weights_frame(),
+            assumptions=pd.DataFrame(columns=BLACK_LITTERMAN_ASSUMPTIONS_COLUMNS),
+        )
+
+    weight_frames: list[pd.DataFrame] = []
+    assumptions_frames: list[pd.DataFrame] = []
+    for optimizer_input in optimizer_inputs:
+        problem = _prepare_long_only_problem(
+            optimizer_input,
+            method=BLACK_LITTERMAN_STRATEGY_NAME,
+            target_gross_exposure=target_gross_exposure,
+            max_position_weight=max_position_weight,
+            symbol_groups=symbol_groups,
+            max_group_weight=max_group_weight,
+        )
+        prior_returns, posterior_expected_returns = _black_litterman_expected_returns(
+            problem.covariance,
+            symbols=problem.symbols,
+            risk_aversion=risk_aversion,
+            equilibrium_weights=bl_equilibrium_weights,
+            tau=bl_tau,
+            view_matrix=bl_view_matrix,
+            view_returns=bl_view_returns,
+        )
+        weights = _solve_long_only_expected_return_weights(
+            optimizer_input,
+            method=BLACK_LITTERMAN_STRATEGY_NAME,
+            problem=problem,
+            expected_returns=posterior_expected_returns,
+            risk_aversion=risk_aversion,
+            max_position_weight=max_position_weight,
+            max_group_weight=max_group_weight,
+        )
+        weight_frames.append(
+            _weights_to_frame(
+                BLACK_LITTERMAN_STRATEGY_NAME,
+                optimizer_input.effective_date,
+                optimizer_input.symbols,
+                weights,
+            )
+        )
+        assumptions_frames.append(
+            _black_litterman_assumptions_frame(
+                optimizer_input,
+                equilibrium_weights=equilibrium_weight_series,
+                prior_returns=prior_returns,
+                posterior_expected_returns=posterior_expected_returns,
+                tau=bl_tau,
+            )
+        )
+
+    return BlackLittermanOutput(
+        weights=pd.concat(weight_frames, ignore_index=True)
+        .sort_values(["effective_date", "symbol"])
+        .reset_index(drop=True),
+        assumptions=pd.concat(assumptions_frames, ignore_index=True)
+        .sort_values(["signal_date", "effective_date", "symbol"])
+        .reset_index(drop=True),
+    )
+
+
 def _unsupported_method_error(method: str) -> RuntimeError:
     return RuntimeError(f"baselines.optimized.method='{method}' is not implemented yet.")
 
@@ -636,7 +939,7 @@ def _finalize_optimized_weights(
     problem: LongOnlyProblem,
     weights: np.ndarray,
     max_group_weight: float | None,
-) -> pd.Series:
+    ) -> pd.Series:
     if not np.isfinite(weights).all():
         raise _optimizer_failure(
             method=method,
@@ -683,40 +986,35 @@ def _finalize_optimized_weights(
     return pd.Series(weights, index=problem.symbols, dtype=float)
 
 
-def _solve_mean_variance_weights(
+def _solve_long_only_expected_return_weights(
     optimizer_input: OptimizerInput,
     *,
-    target_gross_exposure: float,
+    method: str,
+    problem: LongOnlyProblem,
+    expected_returns: pd.Series,
     risk_aversion: float,
     max_position_weight: float | None,
-    symbol_groups: dict[str, str] | None,
     max_group_weight: float | None,
 ) -> pd.Series:
-    if optimizer_input.expected_returns is None:
-        raise ValueError("Mean-variance optimized inputs require expected_returns.")
-
-    problem = _prepare_long_only_problem(
-        optimizer_input,
-        method="mean_variance",
-        target_gross_exposure=target_gross_exposure,
-        max_position_weight=max_position_weight,
-        symbol_groups=symbol_groups,
-        max_group_weight=max_group_weight,
-    )
     if problem.achieved_target_exposure <= WEIGHT_EPSILON:
         return pd.Series(0.0, index=problem.symbols, dtype=float)
 
     if len(problem.symbols) == 1:
         return pd.Series(problem.feasible_weights, index=problem.symbols, dtype=float)
 
-    expected_returns = optimizer_input.expected_returns.loc[problem.symbols].to_numpy(
-        dtype=float
-    )
+    expected_returns_array = expected_returns.loc[problem.symbols].to_numpy(dtype=float)
+    if not np.isfinite(expected_returns_array).all():
+        raise _optimizer_failure(
+            method=method,
+            signal_date=optimizer_input.signal_date,
+            effective_date=optimizer_input.effective_date,
+            message="expected returns contain non-finite values",
+        )
 
     def objective(weights: np.ndarray) -> float:
         return float(
             0.5 * risk_aversion * (weights @ problem.covariance @ weights)
-            - (expected_returns @ weights)
+            - (expected_returns_array @ weights)
         )
 
     result = minimize(
@@ -733,17 +1031,49 @@ def _solve_mean_variance_weights(
     )
     if not result.success:
         raise _optimizer_failure(
-            method="mean_variance",
+            method=method,
             signal_date=optimizer_input.signal_date,
             effective_date=optimizer_input.effective_date,
             message=result.message,
         )
 
     return _finalize_optimized_weights(
-        method="mean_variance",
+        method=method,
         optimizer_input=optimizer_input,
         problem=problem,
         weights=np.asarray(result.x, dtype=float),
+        max_group_weight=max_group_weight,
+    )
+
+
+def _solve_mean_variance_weights(
+    optimizer_input: OptimizerInput,
+    *,
+    target_gross_exposure: float,
+    risk_aversion: float,
+    max_position_weight: float | None,
+    symbol_groups: dict[str, str] | None,
+    max_group_weight: float | None,
+    method: str = "mean_variance",
+) -> pd.Series:
+    if optimizer_input.expected_returns is None:
+        raise ValueError("Mean-variance optimized inputs require expected_returns.")
+
+    problem = _prepare_long_only_problem(
+        optimizer_input,
+        method="mean_variance",
+        target_gross_exposure=target_gross_exposure,
+        max_position_weight=max_position_weight,
+        symbol_groups=symbol_groups,
+        max_group_weight=max_group_weight,
+    )
+    return _solve_long_only_expected_return_weights(
+        optimizer_input,
+        method=method,
+        problem=problem,
+        expected_returns=optimizer_input.expected_returns,
+        risk_aversion=risk_aversion,
+        max_position_weight=max_position_weight,
         max_group_weight=max_group_weight,
     )
 
@@ -858,14 +1188,32 @@ def generate_weights(
     symbol_groups: dict[str, str] | None = None,
     max_position_weight: float | None = None,
     max_group_weight: float | None = None,
+    equilibrium_weights: dict[str, float] | None = None,
+    tau: float = 0.05,
+    views: list[object] | None = None,
 ) -> pd.DataFrame:
-    if method == "black_litterman":
-        raise _unsupported_method_error(method)
     if method not in EXECUTABLE_METHODS:
         raise _unsupported_method_error(method)
     if not long_only:
         raise ValueError(
             f"{strategy_name_for_method(method)} optimized baseline currently supports long_only=True only."
+        )
+    if method == BLACK_LITTERMAN_STRATEGY_NAME:
+        if expected_return_source != "historical_mean":
+            raise ValueError(
+                "Black-Litterman optimized baseline does not use external expected returns; "
+                "expected_return_source must remain 'historical_mean'."
+            )
+        if external_expected_returns_path is not None:
+            raise ValueError(
+                "Black-Litterman optimized baseline does not use external expected returns; "
+                "external_expected_returns_path must be omitted."
+            )
+        _validated_black_litterman_inputs(
+            symbols=list(symbols),
+            equilibrium_weights=equilibrium_weights,
+            tau=tau,
+            views=views,
         )
     if method == "risk_parity":
         if expected_return_source != "historical_mean":
@@ -880,6 +1228,24 @@ def generate_weights(
             )
     if panel.empty:
         return _empty_weights_frame()
+    if method == BLACK_LITTERMAN_STRATEGY_NAME:
+        return generate_black_litterman_output(
+            panel,
+            symbols=list(symbols),
+            lookback_days=lookback_days,
+            frequency=frequency,
+            covariance_estimator=covariance_estimator,
+            external_covariance_path=external_covariance_path,
+            long_only=long_only,
+            target_gross_exposure=target_gross_exposure,
+            risk_aversion=risk_aversion,
+            symbol_groups=symbol_groups,
+            max_position_weight=max_position_weight,
+            max_group_weight=max_group_weight,
+            equilibrium_weights=equilibrium_weights,
+            tau=tau,
+            views=views,
+        ).weights
 
     strategy_name = strategy_name_for_method(method)
     if method == "mean_variance":
@@ -915,6 +1281,7 @@ def generate_weights(
                 max_position_weight=max_position_weight,
                 symbol_groups=symbol_groups,
                 max_group_weight=max_group_weight,
+                method="mean_variance",
             )
         else:
             weights = _solve_risk_parity_weights(
@@ -933,6 +1300,6 @@ def generate_weights(
             )
         )
 
-    return pd.concat(weight_frames, ignore_index=True).sort_values(
-        ["effective_date", "symbol"]
-    ).reset_index(drop=True)
+    return pd.concat(weight_frames, ignore_index=True).sort_values(["effective_date", "symbol"]).reset_index(
+        drop=True
+    )

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -18,7 +18,32 @@ run_marketlab_cli = getattr(
 )
 write_yaml_config = _cli_harness.write_yaml_config
 
-BLACK_LITTERMAN_ERROR = "baselines.optimized.method='black_litterman' is not implemented yet."
+
+def _black_litterman_optimized(symbols: list[str]) -> dict[str, object]:
+    equilibrium = {symbol: round(1.0 / len(symbols), 6) for symbol in symbols}
+    first, second, third = symbols[:3]
+    last = symbols[-1]
+    return {
+        "enabled": True,
+        "method": "black_litterman",
+        "lookback_days": 3,
+        "target_gross_exposure": 0.6,
+        "risk_aversion": 1.0,
+        "equilibrium_weights": equilibrium,
+        "tau": 0.05,
+        "views": [
+            {
+                "name": "growth_over_defensive",
+                "weights": {first: 1.0, second: 1.0, third: -1.0},
+                "view_return": 0.0025,
+            },
+            {
+                "name": "core_over_tail",
+                "weights": {first: 1.0, last: -1.0},
+                "view_return": 0.001,
+            },
+        ],
+    }
 
 
 def _write_backtest_config(
@@ -171,6 +196,7 @@ def test_backtest_supports_mean_variance_optimized_baseline(tmp_path: Path) -> N
     ].iloc[0]
     assert mean_variance_row["avg_gross_exposure"] <= 0.6 + 1e-6
     assert "mean_variance" in report_text
+    assert not (run_dir / "black_litterman_assumptions.csv").exists()
 
 
 
@@ -264,19 +290,98 @@ def test_backtest_keeps_risk_parity_as_cash_when_no_windows_exist(tmp_path: Path
     assert risk_parity_row["avg_cash_weight"] == 1.0
 
 
-
-def test_run_experiment_rejects_unimplemented_black_litterman_baseline(tmp_path: Path) -> None:
+def test_backtest_supports_black_litterman_optimized_baseline(tmp_path: Path) -> None:
     config_path = _write_run_experiment_config(
         tmp_path,
-        optimized={
-            "enabled": True,
-            "method": "black_litterman",
-        },
+        optimized=_black_litterman_optimized(["AAA", "BBB", "CCC", "DDD"]),
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_experiment"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    assumptions = pd.read_csv(run_dir / "black_litterman_assumptions.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert "black_litterman" in set(metrics["strategy"])
+    assert "black_litterman" in set(strategy_summary["strategy"])
+    assert not assumptions.empty
+    assert set(assumptions.columns) >= {
+        "signal_date",
+        "effective_date",
+        "symbol",
+        "equilibrium_weight",
+        "implied_prior_return",
+        "posterior_expected_return",
+        "tau",
+    }
+    assert assumptions["tau"].eq(0.05).all()
+    assert "Black-Litterman Assumptions" in report_text
+    assert "growth_over_defensive" in report_text
+    assert "black_litterman_assumptions.csv" in report_text
+
+
+def test_backtest_black_litterman_cash_fallback_skips_assumptions_artifact(tmp_path: Path) -> None:
+    optimized = _black_litterman_optimized(["VOO", "QQQ", "SMH", "XLV", "IEMG"])
+    optimized["lookback_days"] = 10_000
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized=optimized,
+        buy_hold=False,
+        sma_enabled=False,
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_backtest"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert set(metrics["strategy"]) == {"black_litterman"}
+    assert set(strategy_summary["strategy"]) == {"black_litterman"}
+    black_litterman_row = strategy_summary.loc[
+        strategy_summary["strategy"] == "black_litterman"
+    ].iloc[0]
+    assert black_litterman_row["avg_gross_exposure"] == 0.0
+    assert black_litterman_row["avg_cash_weight"] == 1.0
+    assert not (run_dir / "black_litterman_assumptions.csv").exists()
+    assert "Black-Litterman Assumptions" not in report_text
+
+
+def test_run_experiment_supports_black_litterman_optimized_baseline(tmp_path: Path) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        optimized=_black_litterman_optimized(["AAA", "BBB", "CCC", "DDD"]),
     )
 
     result = run_marketlab_cli("run-experiment", config_path)
 
-    assert result.returncode != 0
-    combined_output = f"{result.stdout}\n{result.stderr}"
-    assert BLACK_LITTERMAN_ERROR in combined_output
-    assert not (tmp_path / "runs" / "optimized_scaffold_experiment").exists()
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "optimized_scaffold_experiment"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    performance = pd.read_csv(run_dir / "performance.csv", parse_dates=["date"])
+    strategy_summary = pd.read_csv(run_dir / "strategy_summary.csv")
+    assumptions = pd.read_csv(
+        run_dir / "black_litterman_assumptions.csv",
+        parse_dates=["signal_date", "effective_date"],
+    )
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert "black_litterman" in set(metrics["strategy"])
+    assert "black_litterman" in set(strategy_summary["strategy"])
+    assert not assumptions.empty
+    assert assumptions["tau"].eq(0.05).all()
+    assert assumptions["effective_date"].min() >= performance["date"].min()
+    assert assumptions["effective_date"].max() <= performance["date"].max()
+    assert set(assumptions["effective_date"]) <= set(performance["date"])
+    assert "Black-Litterman Assumptions" in report_text
+    assert "core_over_tail" in report_text
+    assert "black_litterman_assumptions.csv" in report_text

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,6 +60,9 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
     assert config.baselines.optimized.long_only is True
     assert config.baselines.optimized.target_gross_exposure == pytest.approx(1.0)
     assert config.baselines.optimized.risk_aversion == pytest.approx(1.0)
+    assert config.baselines.optimized.equilibrium_weights == {}
+    assert config.baselines.optimized.tau == pytest.approx(0.05)
+    assert config.baselines.optimized.views == []
     assert config.optimized_external_covariance_path is None
     assert config.optimized_external_expected_returns_path is None
     assert config.portfolio.risk.max_position_weight is None
@@ -82,6 +85,8 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
             "optimized": {
                 "external_covariance_path": None,
                 "external_expected_returns_path": None,
+                "equilibrium_weights": None,
+                "views": None,
             },
         },
         evaluation={"cost_sensitivity_bps": None},
@@ -94,6 +99,8 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
     assert config.baselines.allocation.group_weights == {}
     assert config.baselines.optimized.external_covariance_path == ""
     assert config.baselines.optimized.external_expected_returns_path == ""
+    assert config.baselines.optimized.equilibrium_weights == {}
+    assert config.baselines.optimized.views == []
     assert config.evaluation.cost_sensitivity_bps == []
 
 
@@ -243,6 +250,41 @@ def test_load_config_accepts_valid_risk_caps(tmp_path: Path) -> None:
     assert config.portfolio.risk.max_short_exposure == pytest.approx(0.45)
 
 
+def test_load_config_accepts_valid_black_litterman_settings(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        data={"symbols": ["AAA", "BBB", "CCC"]},
+        baselines={
+            "optimized": {
+                "enabled": True,
+                "method": "black_litterman",
+                "covariance_estimator": "sample",
+                "equilibrium_weights": {"AAA": 0.4, "BBB": 0.4, "CCC": 0.2},
+                "tau": 0.10,
+                "views": [
+                    {
+                        "name": "growth_over_defensive",
+                        "weights": {"AAA": 1.0, "BBB": 1.0, "CCC": -1.0},
+                        "view_return": 0.0025,
+                    }
+                ],
+            }
+        },
+    )
+
+    config = load_config(config_path)
+
+    optimized = config.baselines.optimized
+    assert optimized.method == "black_litterman"
+    assert optimized.equilibrium_weights == {"AAA": 0.4, "BBB": 0.4, "CCC": 0.2}
+    assert optimized.tau == pytest.approx(0.10)
+    assert len(optimized.views) == 1
+    view = optimized.views[0]
+    assert view.name == "growth_over_defensive"
+    assert view.weights == {"AAA": 1.0, "BBB": 1.0, "CCC": -1.0}
+    assert view.view_return == pytest.approx(0.0025)
+
+
 def test_load_config_accepts_cost_sensitivity_bps(tmp_path: Path) -> None:
     config_path = _write_config(
         tmp_path / "config.yaml",
@@ -323,6 +365,10 @@ def test_load_config_rejects_invalid_cost_sensitivity_bps(
             "baselines.optimized.external_expected_returns_path must be empty when baselines.optimized.method='risk_parity'",
         ),
         (
+            {"tau": 0.0},
+            "baselines.optimized.tau must be a finite positive value",
+        ),
+        (
             {"covariance_estimator": "external_csv"},
             "baselines.optimized.external_covariance_path is required when baselines.optimized.covariance_estimator='external_csv'",
         ),
@@ -338,9 +384,111 @@ def test_load_config_rejects_invalid_cost_sensitivity_bps(
             {"expected_return_source": "historical_mean", "external_expected_returns_path": "expected.csv"},
             "baselines.optimized.external_expected_returns_path must be empty unless baselines.optimized.expected_return_source='external_csv'",
         ),
+        (
+            {"method": "black_litterman", "long_only": False},
+            "baselines.optimized.long_only must be true when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {"method": "black_litterman", "target_gross_exposure": 1.2},
+            "baselines.optimized.target_gross_exposure must be less than or equal to 1.0 when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {"method": "black_litterman", "expected_return_source": "external_csv"},
+            "baselines.optimized.expected_return_source must remain 'historical_mean' when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {"method": "black_litterman", "external_expected_returns_path": "expected.csv"},
+            "baselines.optimized.external_expected_returns_path must be empty when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {"method": "black_litterman"},
+            "baselines.optimized.equilibrium_weights must match data.symbols exactly when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": float("nan"), "BBB": 1.0},
+                "views": [{"name": "good", "weights": {"AAA": 1.0}, "view_return": 0.01}],
+            },
+            "baselines.optimized.equilibrium_weights must contain only finite numeric values",
+        ),
     ],
 )
 def test_load_config_rejects_invalid_optimized_scaffold_settings(
+    tmp_path: Path,
+    optimized: dict[str, object],
+    message: str,
+) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        baselines={"optimized": optimized},
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_config(config_path)
+
+
+@pytest.mark.parametrize(
+    ("optimized", "message"),
+    [
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+            },
+            "baselines.optimized.views must be non-empty when baselines.optimized.method='black_litterman'",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "", "weights": {"AAA": 1.0}, "view_return": 0.01}],
+            },
+            r"baselines\.optimized\.views\[0\]\.name must be non-empty",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "bad", "weights": {"CCC": 1.0}, "view_return": 0.01}],
+            },
+            r"baselines\.optimized\.views\[0\]\.weights contains unknown symbols: CCC",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "bad", "weights": {}, "view_return": 0.01}],
+            },
+            r"baselines\.optimized\.views\[0\]\.weights must not be empty",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "bad", "weights": {"AAA": 0.0}, "view_return": 0.01}],
+            },
+            r"baselines\.optimized\.views\[0\]\.weights must contain at least one non-zero coefficient",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "bad", "weights": {"AAA": float("inf")}, "view_return": 0.01}],
+            },
+            r"baselines\.optimized\.views\[0\]\.weights\[AAA\] must be finite",
+        ),
+        (
+            {
+                "method": "black_litterman",
+                "equilibrium_weights": {"AAA": 0.5, "BBB": 0.5},
+                "views": [{"name": "bad", "weights": {"AAA": 1.0}, "view_return": float("nan")}],
+            },
+            r"baselines\.optimized\.views\[0\]\.view_return must be finite",
+        ),
+    ],
+)
+def test_load_config_rejects_invalid_black_litterman_view_settings(
     tmp_path: Path,
     optimized: dict[str, object],
     message: str,

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from marketlab.config import BlackLittermanViewConfig
 from marketlab.strategies.optimized import (
     DIAGONAL_SHRINKAGE_WEIGHT,
     EWMA_LAMBDA,
@@ -14,9 +15,12 @@ from marketlab.strategies.optimized import (
     build_optimizer_windows,
     estimate_covariance_matrix,
     estimate_expected_returns,
+    generate_cash_only_weights,
     generate_weights,
+    is_executable_method,
     load_external_covariance,
     load_external_expected_returns,
+    strategy_name_for_method,
 )
 
 
@@ -519,6 +523,165 @@ def test_generate_weights_respects_group_caps(tmp_path: Path) -> None:
     assert float(first_weights.sum()) == pytest.approx(0.8, abs=1e-5)
 
 
+def test_generate_weights_produces_symmetric_black_litterman_solution(tmp_path: Path) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="black_litterman",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        equilibrium_weights={"AAA": 0.5, "BBB": 0.5},
+        views=[
+            BlackLittermanViewConfig(
+                name="balanced_basket",
+                weights={"AAA": 1.0, "BBB": 1.0},
+                view_return=0.04,
+            )
+        ],
+    )
+
+    assert set(weights["strategy"]) == {"black_litterman"}
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.5, abs=1e-6)
+    assert first_weights.loc["BBB"] == pytest.approx(0.5, abs=1e-6)
+
+
+def test_generate_weights_tilts_toward_view_favored_asset_in_black_litterman(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="black_litterman",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        equilibrium_weights={"AAA": 0.5, "BBB": 0.5},
+        views=[
+            BlackLittermanViewConfig(
+                name="AAA_over_BBB",
+                weights={"AAA": 1.0, "BBB": -1.0},
+                view_return=0.04,
+            )
+        ],
+    )
+
+    first_weights = _first_effective_weights(weights)
+    assert first_weights.loc["AAA"] == pytest.approx(0.75, abs=1e-3)
+    assert first_weights.loc["BBB"] == pytest.approx(0.25, abs=1e-3)
+    assert float(first_weights.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_black_litterman_method_is_executable_and_uses_expected_strategy_name(
+    tmp_path: Path,
+) -> None:
+    assert is_executable_method("black_litterman") is True
+    assert strategy_name_for_method("black_litterman") == "black_litterman"
+
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    weights = generate_weights(
+        panel,
+        symbols=["AAA", "BBB"],
+        method="black_litterman",
+        lookback_days=3,
+        covariance_estimator="external_csv",
+        external_covariance_path=covariance_path,
+        equilibrium_weights={"AAA": 0.5, "BBB": 0.5},
+        views=[
+            BlackLittermanViewConfig(
+                name="balanced_basket",
+                weights={"AAA": 1.0, "BBB": 1.0},
+                view_return=0.04,
+            )
+        ],
+    )
+
+    assert not weights.empty
+    assert set(weights["strategy"]) == {"black_litterman"}
+    first_weights = _first_effective_weights(weights)
+    assert float(first_weights.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_generate_cash_only_weights_supports_black_litterman_fallback() -> None:
+    weights = generate_cash_only_weights(
+        "black_litterman",
+        effective_date=pd.Timestamp("2024-01-08"),
+        symbols=["AAA", "BBB"],
+    )
+
+    assert set(weights["strategy"]) == {"black_litterman"}
+    assert list(weights["effective_date"]) == [pd.Timestamp("2024-01-08"), pd.Timestamp("2024-01-08")]
+    assert list(weights["symbol"]) == ["AAA", "BBB"]
+    assert list(weights["weight"]) == [0.0, 0.0]
+
+
+def test_generate_weights_rejects_external_expected_return_inputs_for_black_litterman(
+    tmp_path: Path,
+) -> None:
+    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
+    covariance = pd.DataFrame(
+        [[0.04, 0.0], [0.0, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_path = tmp_path / "covariance.csv"
+    _write_external_covariance(covariance_path, covariance)
+
+    with pytest.raises(
+        ValueError,
+        match="Black-Litterman optimized baseline does not use external expected returns",
+    ):
+        generate_weights(
+            panel,
+            symbols=["AAA", "BBB"],
+            method="black_litterman",
+            lookback_days=3,
+            covariance_estimator="external_csv",
+            external_covariance_path=covariance_path,
+            expected_return_source="external_csv",
+            external_expected_returns_path=tmp_path / "expected.csv",
+            equilibrium_weights={"AAA": 0.5, "BBB": 0.5},
+            views=[
+                BlackLittermanViewConfig(
+                    name="AAA_over_BBB",
+                    weights={"AAA": 1.0, "BBB": -1.0},
+                    view_return=0.04,
+                )
+            ],
+        )
+
+
 def test_generate_weights_produces_equal_risk_parity_solution(tmp_path: Path) -> None:
     panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
     covariance = pd.DataFrame(
@@ -685,19 +848,4 @@ def test_generate_weights_rejects_expected_return_inputs_for_risk_parity(
             external_covariance_path=covariance_path,
             expected_return_source="external_csv",
             external_expected_returns_path=tmp_path / "expected.csv",
-        )
-
-
-def test_generate_weights_rejects_unimplemented_methods() -> None:
-    panel = _build_optimizer_panel((("AAA", 100.0, 1.0), ("BBB", 120.0, 1.0)))
-
-    with pytest.raises(
-        RuntimeError,
-        match="baselines.optimized.method='black_litterman' is not implemented yet",
-    ):
-        generate_weights(
-            panel,
-            symbols=["AAA", "BBB"],
-            method="black_litterman",
-            lookback_days=3,
         )


### PR DESCRIPTION
## Summary
- make `baselines.optimized.method=black_litterman` executable with explicit equilibrium weights, signed views, and posterior-return construction on the existing optimized baseline seam
- persist reviewable `black_litterman_assumptions.csv` artifacts and report them without leaking pre-OOS windows into `run-experiment`
- document the new config and artifact surface and cover config, unit, and integration behavior for the Black-Litterman path

## Commit Stack
- `feat: implement black-litterman optimizer baseline`
- `feat: add black-litterman config surface`
- `docs: document black-litterman baseline semantics`

## Validation
- `python -m pytest -q tests/unit/test_config.py --basetemp .pytest_tmp_bl_config3`
- `python -m pytest -q tests/unit/test_optimized.py --basetemp .pytest_tmp_bl_opt_unit2`
- `python -m pytest -q tests/integration/test_optimized_scaffold.py --basetemp .pytest_tmp_bl_opt_integration2`
- `python -m pytest -q tests/unit/test_markdown_report.py --basetemp .pytest_tmp_bl_markdown2`
- `python -m ruff check src/marketlab/config.py src/marketlab/pipeline.py src/marketlab/reports/markdown.py src/marketlab/strategies/optimized.py tests/unit/test_config.py tests/unit/test_optimized.py tests/integration/test_optimized_scaffold.py README.md docs/architecture.md`
- `python -m mkdocs build --strict`

## Notes
- `py -3.12 -m tox -e preflight` could not run directly on this machine because that interpreter does not have `tox` installed.
- `tox -e preflight` and `tox -e preflight-fast` were both attempted locally and timed out before completion.