### PR TITLE
feat: add factor and covariance diagnostics for optimized runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Allocation semantics:
 - `allocation_symbol_weights` rebalances back to exact configured symbol weights.
 - `allocation_group_weights` rebalances back to configured group sleeves and splits each sleeve equally across the symbols in that group.
 
-This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Optimizer methods, factor diagnostics, and broader scenario comparisons remain later work.
+This first Phase 5 step stays narrow: allocation baselines are long-only, fully invested target-weight portfolios. Broader scenario comparisons remain later work.
 
 ## Optimized Baselines
 
@@ -242,6 +242,7 @@ Current Phase 5 behavior is intentionally narrow:
 - `mean_variance`, `risk_parity`, and `black_litterman` are executable optimized methods
 - `black_litterman` uses signed basket views as written, does not renormalize them, and defaults to the diagonal `Omega = diag(P * tau * Sigma * P^T)` uncertainty rule
 - successful Black-Litterman runs write `black_litterman_assumptions.csv` alongside the other run artifacts and reference it from `report.md`
+- optimized runs with real solver windows write `covariance_diagnostics.csv` and add a `Covariance Diagnostics` section to `report.md`
 - the optimizer uses trailing daily adjusted-close returns ending on the `signal_date` and applies the weights on the next market open
 - no allocation is emitted before the first rebalance window with a full optimizer lookback
 - `target_gross_exposure < 1.0` leaves the undeployed exposure in cash
@@ -255,8 +256,30 @@ External input rules:
 
 - covariance CSVs must be square daily-return covariance matrices keyed by the configured symbols
 - expected-return CSVs must contain exactly `symbol,expected_return`, where `expected_return` is a daily decimal return
+- factor CSVs must be local wide daily return files with a required `date` column plus one or more numeric factor columns
 - Black-Litterman views are signed basket weights over configured symbols; the loader rejects unknown symbols, empty views, and all-zero coefficients
 - both loaders reorder to `data.symbols` and reject missing, extra, or non-numeric values
+
+## Factor And Covariance Diagnostics
+
+`backtest` and `run-experiment` now also support optional factor attribution and additive covariance diagnostics under `evaluation`.
+
+Add to `evaluation`:
+
+- `factor_model_path`
+
+Diagnostics behavior:
+
+- when `evaluation.factor_model_path` is configured, MarketLab loads a local wide daily factor-return CSV, aligns it to the final persisted `PerformanceFrame`, and writes `factor_diagnostics.csv`
+- factor attribution runs on realized `net_return` for every strategy in the persisted run, including ML strategies in `run-experiment`
+- `report.md` adds a `Factor Attribution Diagnostics` section with a strategy-level summary, a full factor exposure table, and a link to `factor_diagnostics.csv`
+- covariance diagnostics reflect the regularized matrix actually used by the optimizer, not the pre-regularization estimate
+- covariance diagnostics remain optimized-baseline-only; `buy_hold`, `sma`, allocation baselines, and ML strategies do not emit covariance artifacts
+
+Interpretation rules:
+
+- factor attribution is descriptive only; it does not feed optimizer weights, model ranking, or scenario selection
+- covariance and factor diagnostics are review layers for the current run, not new strategy inputs
 
 ## Single-Symbol VOO Timing Example
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input and covariance scaffolding for later optimized baselines, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input scaffolding, additive factor-attribution and covariance diagnostics, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -19,7 +19,7 @@ This document ties the current pieces together and records the working rules tha
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
-  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance` and `risk_parity` optimized baselines, and optimizer input scaffolding for later optimized baselines
+  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance`, `risk_parity`, and `black_litterman` optimized baselines, plus additive factor and covariance diagnostics for review
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
@@ -76,9 +76,9 @@ flowchart TD
     Launcher --> Experiment[run-experiment]
 
     Prepare --> Panel[prepared panel cache]
-    Backtest --> BaselineArtifacts[metrics.csv performance.csv analytics report.md plots black_litterman_assumptions.csv when applicable]
+    Backtest --> BaselineArtifacts[metrics.csv performance.csv analytics report.md plots factor_diagnostics.csv covariance_diagnostics.csv black_litterman_assumptions.csv when applicable]
     Train --> TrainingArtifacts[folds.csv fold_diagnostics.csv ranking_diagnostics.csv calibration_diagnostics.csv score_histograms.csv threshold_diagnostics.csv manifest metrics predictions summaries plots models/]
-    Experiment --> ExperimentArtifacts[metrics.csv performance.csv analytics report.md strategy plots calibration plots diagnostics summaries optional models/black_litterman_assumptions.csv when applicable]
+    Experiment --> ExperimentArtifacts[metrics.csv performance.csv analytics report.md strategy plots calibration plots diagnostics summaries optional factor_diagnostics.csv covariance_diagnostics.csv black_litterman_assumptions.csv models/ when applicable]
 ```
 
 ## Automation Split
@@ -128,6 +128,8 @@ The required CI path stays offline and deterministic through tox. The Docker run
 - Black-Litterman views are signed basket weights over configured symbols; MarketLab uses them as written and does not renormalize them.
 - Black-Litterman posterior uncertainty defaults to the diagonal `Omega = diag(P * tau * Sigma * P^T)` rule.
 - Successful Black-Litterman runs persist `black_litterman_assumptions.csv` and reference it from `report.md`.
+- Optimized runs with real solver windows persist `covariance_diagnostics.csv` and reference it from `report.md`.
+- `evaluation.factor_model_path` enables local factor attribution over the final persisted strategy returns and writes `factor_diagnostics.csv`.
 - Trailing return windows are built from adjusted close data only, and the latest included return must end on the `signal_date`.
 - Optimized weights are applied on the next market open after the `signal_date`, and no allocation is emitted before the first full optimizer lookback window exists.
 - `target_gross_exposure` is a long-only invested-fraction request; any undeployed exposure remains cash in the backtest engine.
@@ -138,6 +140,8 @@ The required CI path stays offline and deterministic through tox. The Docker run
 - Binding position or group caps turn `risk_parity` into the best feasible approximation to equal risk contributions rather than exact parity.
 - External covariance inputs must be square daily-return covariance matrices keyed by the configured symbols.
 - External expected-return inputs must contain exactly `symbol,expected_return` in daily decimal units.
+- Factor-model inputs must be local wide daily return CSVs with a required `date` column plus one or more numeric factor columns.
+- Factor attribution is descriptive only; it must not feed optimizer weights, model selection, or scenario selection.
 
 ## System Map
 
@@ -163,6 +167,7 @@ flowchart TD
     Predictions --> Ranking[src/marketlab/strategies/ranking.py]
     Pipeline --> Summary[src/marketlab/reports/summary.py]
     Pipeline --> Analytics[src/marketlab/reports/analytics.py]
+    Pipeline --> RiskDiagnostics[src/marketlab/reports/risk_diagnostics.py]
     Pipeline --> BuyHold[src/marketlab/strategies/buy_hold.py]
     Pipeline --> Allocation[src/marketlab/strategies/allocation.py]
     Pipeline --> SMA[src/marketlab/strategies/sma.py]
@@ -179,6 +184,8 @@ flowchart TD
     Analytics --> CostSensitivityCsv[cost_sensitivity.csv]
     Analytics --> MonthlyReturnsCsv[monthly_returns.csv]
     Analytics --> TurnoverCostsCsv[turnover_costs.csv]
+    RiskDiagnostics --> FactorDiagnosticsCsv[factor_diagnostics.csv]
+    RiskDiagnostics --> CovarianceDiagnosticsCsv[covariance_diagnostics.csv]
     Pipeline --> Markdown[src/marketlab/reports/markdown.py]
     Pipeline --> Plots[src/marketlab/reports/plots.py]
 
@@ -738,6 +745,7 @@ Best practice:
 - Provides expected-return helpers for `historical_mean` and `external_csv` inputs.
 - Reorders and validates external covariance and expected-return files against `data.symbols`.
 - Provides the solver plumbing reused by the executable long-only optimized baselines, including the Black-Litterman posterior-return and assumptions builders.
+- Exposes the regularized covariance windows used by the solver so reporting can persist reviewable covariance diagnostics.
 
 Best practice:
 - Keep adjusted-close return windows and optimizer timing leakage-safe: signal on the close, execute on the next open.
@@ -803,11 +811,21 @@ Best practice:
 - Keep analytics builders pure and schema-stable.
 - Derive analytics from the existing `PerformanceFrame`, not from alternate portfolio state.
 
+### `src/marketlab/reports/risk_diagnostics.py`
+
+- Loads local factor-model CSV inputs and builds additive factor-attribution tables from realized strategy `net_return`.
+- Shapes optimizer covariance windows into detailed `covariance_diagnostics.csv` rows and compact strategy-level covariance summaries.
+- Keeps factor attribution and covariance review separate from portfolio construction, backtest execution, and model selection.
+
+Best practice:
+- Treat factor and covariance diagnostics as descriptive review layers, not optimizer inputs.
+- Keep factor CSV validation strict and keep covariance summaries derived from the same persisted long-form artifact.
+
 ### `src/marketlab/reports/markdown.py`
 
 - Produces a compact Markdown report for each run.
 - Derives the strategy list from the actual `PerformanceFrame`.
-- Adds strategy summary, monthly net return, turnover-and-cost, and cost-sensitivity sections when those analytics are available.
+- Adds strategy summary, factor attribution, covariance diagnostics, monthly net return, turnover-and-cost, and cost-sensitivity sections when those analytics are available.
 - Switches scope text when ML strategies are present.
 - Reports the best model by mean ROC AUC, mean top-bucket return, and mean top-bottom spread when those model-summary fields are available.
 - Adds a compact calibration-and-threshold section when calibration summaries or threshold diagnostics are available, including relative links to the diagnostic plots.

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -142,6 +142,7 @@ class EvaluationConfig:
     walk_forward: WalkForwardConfig = field(default_factory=WalkForwardConfig)
     benchmark_strategy: str = ""
     cost_sensitivity_bps: list[float] = field(default_factory=list)
+    factor_model_path: str = ""
 
 
 @dataclass(slots=True)
@@ -204,6 +205,13 @@ class ExperimentConfig:
             return None
         return self.resolve_path(path)
 
+    @property
+    def factor_model_path(self) -> Path | None:
+        path = self.evaluation.factor_model_path
+        if path == "":
+            return None
+        return self.resolve_path(path)
+
 
 def _section(cls: type[Any], data: dict[str, Any] | None) -> Any:
     values = data or {}
@@ -230,6 +238,8 @@ def _normalize_mapping_sections(config: ExperimentConfig) -> None:
 
     if config.evaluation.cost_sensitivity_bps is None:
         config.evaluation.cost_sensitivity_bps = []
+    if config.evaluation.factor_model_path is None:
+        config.evaluation.factor_model_path = ""
 
     optimized = config.baselines.optimized
     if optimized.external_covariance_path is None:
@@ -525,6 +535,7 @@ def load_config(path: str | Path) -> ExperimentConfig:
             ),
             benchmark_strategy=(payload.get("evaluation") or {}).get("benchmark_strategy", ""),
             cost_sensitivity_bps=(payload.get("evaluation") or {}).get("cost_sensitivity_bps", []),
+            factor_model_path=(payload.get("evaluation") or {}).get("factor_model_path", ""),
         ),
         artifacts=_section(ArtifactsConfig, payload.get("artifacts")),
         base_dir=_config_base_dir(config_path),

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -39,10 +39,18 @@ from marketlab.reports.plots import (
     plot_threshold_sweeps,
     plot_turnover,
 )
+from marketlab.reports.risk_diagnostics import (
+    build_covariance_diagnostics,
+    build_factor_diagnostics,
+    load_factor_returns,
+)
 from marketlab.reports.summary import build_fold_summary, build_model_summary
 from marketlab.strategies.allocation import generate_weights as allocation_weights
 from marketlab.strategies.buy_hold import generate_weights as buy_hold_weights
-from marketlab.strategies.optimized import generate_black_litterman_output
+from marketlab.strategies.optimized import (
+    generate_black_litterman_output,
+    generate_covariance_diagnostic_windows,
+)
 from marketlab.strategies.optimized import (
     generate_cash_only_weights as optimized_cash_only_weights,
 )
@@ -86,6 +94,8 @@ class ExperimentArtifacts:
     threshold_diagnostics_path: Path | None
     fold_summary_path: Path | None
     model_summary_path: Path | None
+    factor_diagnostics_path: Path | None = None
+    covariance_diagnostics_path: Path | None = None
     black_litterman_assumptions_path: Path | None = None
 
 
@@ -151,6 +161,23 @@ def _slice_black_litterman_assumptions(
         return None
     return sliced.reset_index(drop=True)
 
+
+def _slice_covariance_diagnostics(
+    diagnostics: pd.DataFrame | None,
+    oos_dates: pd.Index,
+) -> pd.DataFrame | None:
+    if diagnostics is None:
+        return None
+    if diagnostics.empty:
+        return None
+
+    sliced = diagnostics.loc[
+        pd.to_datetime(diagnostics["effective_date"]).isin(oos_dates)
+    ].copy()
+    if sliced.empty:
+        return None
+    return sliced.reset_index(drop=True)
+
 def prepare_data(config: ExperimentConfig) -> tuple[pd.DataFrame, Path]:
     config.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -198,6 +225,7 @@ def _persist_experiment_outputs(
     score_histograms_path: Path | None = None,
     threshold_diagnostics: pd.DataFrame | None = None,
     threshold_diagnostics_path: Path | None = None,
+    covariance_diagnostics: pd.DataFrame | None = None,
     black_litterman_assumptions: pd.DataFrame | None = None,
 ) -> ExperimentArtifacts:
     artifact_run_dir = run_dir or _run_dir(config)
@@ -222,6 +250,12 @@ def _persist_experiment_outputs(
         base_cost_bps=config.portfolio.costs.bps_per_trade,
         sensitivity_bps=config.evaluation.cost_sensitivity_bps,
     )
+    factor_diagnostics: pd.DataFrame | None = None
+    if config.factor_model_path is not None:
+        factor_diagnostics = build_factor_diagnostics(
+            performance,
+            load_factor_returns(config.factor_model_path),
+        )
 
     metrics_path = artifact_run_dir / "metrics.csv"
     performance_path = artifact_run_dir / "performance.csv"
@@ -274,6 +308,24 @@ def _persist_experiment_outputs(
     if threshold_diagnostics is not None and persisted_threshold_diagnostics_path is None:
         persisted_threshold_diagnostics_path = artifact_run_dir / "threshold_diagnostics.csv"
         threshold_diagnostics.to_csv(persisted_threshold_diagnostics_path, index=False)
+
+    factor_diagnostics_path: Path | None = None
+    if factor_diagnostics is not None and not factor_diagnostics.empty:
+        factor_diagnostics_path = artifact_run_dir / "factor_diagnostics.csv"
+        factor_diagnostics.to_csv(
+            factor_diagnostics_path,
+            index=False,
+            date_format="%Y-%m-%d",
+        )
+
+    covariance_diagnostics_path: Path | None = None
+    if covariance_diagnostics is not None and not covariance_diagnostics.empty:
+        covariance_diagnostics_path = artifact_run_dir / "covariance_diagnostics.csv"
+        covariance_diagnostics.to_csv(
+            covariance_diagnostics_path,
+            index=False,
+            date_format="%Y-%m-%d",
+        )
 
     black_litterman_assumptions_path: Path | None = None
     if black_litterman_assumptions is not None:
@@ -347,6 +399,10 @@ def _persist_experiment_outputs(
             calibration_curves_plot_path=calibration_curves_plot_path,
             score_histograms_plot_path=score_histograms_plot_path,
             threshold_sweeps_plot_path=threshold_sweeps_plot_path,
+            factor_diagnostics=factor_diagnostics,
+            factor_diagnostics_path=factor_diagnostics_path,
+            covariance_diagnostics=covariance_diagnostics,
+            covariance_diagnostics_path=covariance_diagnostics_path,
             black_litterman_assumptions_path=black_litterman_assumptions_path,
         )
 
@@ -376,6 +432,8 @@ def _persist_experiment_outputs(
         threshold_diagnostics_path=persisted_threshold_diagnostics_path,
         fold_summary_path=fold_summary_path,
         model_summary_path=model_summary_path,
+        factor_diagnostics_path=factor_diagnostics_path,
+        covariance_diagnostics_path=covariance_diagnostics_path,
         black_litterman_assumptions_path=black_litterman_assumptions_path,
     )
 
@@ -420,7 +478,7 @@ def _run_black_litterman_baseline(
 def run_baselines(
     config: ExperimentConfig,
     panel: pd.DataFrame,
-) -> tuple[BacktestResult, pd.DataFrame | None]:
+) -> tuple[BacktestResult, pd.DataFrame | None, pd.DataFrame | None]:
     featured = add_feature_set(
         panel=panel,
         return_windows=config.features.return_windows,
@@ -459,6 +517,7 @@ def run_baselines(
             )
 
     black_litterman_assumptions: pd.DataFrame | None = None
+    covariance_diagnostics: pd.DataFrame | None = None
     if config.baselines.optimized.enabled:
         optimized_method = config.baselines.optimized.method
         if optimized_method == "black_litterman":
@@ -496,6 +555,19 @@ def run_baselines(
                 max_position_weight=config.portfolio.risk.max_position_weight,
                 max_group_weight=config.portfolio.risk.max_group_weight,
             )
+        if optimized_method_is_executable(optimized_method):
+            covariance_windows = generate_covariance_diagnostic_windows(
+                featured,
+                symbols=config.data.symbols,
+                method=optimized_method,
+                lookback_days=config.baselines.optimized.lookback_days,
+                frequency=config.baselines.optimized.rebalance_frequency,
+                covariance_estimator=config.baselines.optimized.covariance_estimator,
+                external_covariance_path=config.optimized_external_covariance_path,
+            )
+            covariance_diagnostics = build_covariance_diagnostics(covariance_windows)
+            if covariance_diagnostics.empty:
+                covariance_diagnostics = None
         if weights.empty and optimized_method_is_executable(optimized_method):
             if optimized_method == "black_litterman":
                 black_litterman_assumptions = None
@@ -528,7 +600,7 @@ def run_baselines(
                 )
             )
 
-    return _concat_backtest_results(backtest_results), black_litterman_assumptions
+    return _concat_backtest_results(backtest_results), black_litterman_assumptions, covariance_diagnostics
 
 def _shared_oos_dates(
     panel: pd.DataFrame,
@@ -728,7 +800,10 @@ def train_models(config: ExperimentConfig) -> TrainModelsArtifacts:
 
 def backtest(config: ExperimentConfig) -> ExperimentArtifacts:
     panel, panel_path = prepare_data(config)
-    baseline_outputs, black_litterman_assumptions = run_baselines(config, panel)
+    baseline_outputs, black_litterman_assumptions, covariance_diagnostics = run_baselines(
+        config,
+        panel,
+    )
     return _persist_experiment_outputs(
         config=config,
         panel_path=panel_path,
@@ -736,13 +811,17 @@ def backtest(config: ExperimentConfig) -> ExperimentArtifacts:
         daily_holdings=baseline_outputs.daily_holdings,
         daily_cash=baseline_outputs.daily_cash,
         symbol_groups=config.data.symbol_groups,
+        covariance_diagnostics=covariance_diagnostics,
         black_litterman_assumptions=black_litterman_assumptions,
     )
 
 
 def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
     panel, panel_path = prepare_data(config)
-    baseline_outputs, black_litterman_assumptions = run_baselines(config, panel)
+    baseline_outputs, black_litterman_assumptions, covariance_diagnostics = run_baselines(
+        config,
+        panel,
+    )
 
     if not config.models:
         return _persist_experiment_outputs(
@@ -752,6 +831,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
             daily_holdings=baseline_outputs.daily_holdings,
             daily_cash=baseline_outputs.daily_cash,
             symbol_groups=config.data.symbol_groups,
+            covariance_diagnostics=covariance_diagnostics,
             black_litterman_assumptions=black_litterman_assumptions,
         )
 
@@ -807,6 +887,10 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         black_litterman_assumptions,
         oos_dates,
     )
+    covariance_diagnostics = _slice_covariance_diagnostics(
+        covariance_diagnostics,
+        oos_dates,
+    )
     model_summary = build_model_summary(
         model_metrics=training_outputs.metrics,
         model_manifest=training_outputs.manifest,
@@ -832,6 +916,7 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
         calibration_diagnostics=training_outputs.calibration_diagnostics,
         score_histograms=training_outputs.score_histograms,
         threshold_diagnostics=training_outputs.threshold_diagnostics,
+        covariance_diagnostics=covariance_diagnostics,
         black_litterman_assumptions=black_litterman_assumptions,
     )
 

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -171,9 +171,28 @@ def _slice_covariance_diagnostics(
     if diagnostics.empty:
         return None
 
-    sliced = diagnostics.loc[
-        pd.to_datetime(diagnostics["effective_date"]).isin(oos_dates)
-    ].copy()
+    oos_index = pd.Index(pd.to_datetime(oos_dates)).sort_values()
+    if oos_index.empty:
+        return None
+
+    effective_dates = pd.to_datetime(diagnostics["effective_date"])
+    keep_mask = effective_dates.isin(oos_index)
+    first_oos_date = pd.Timestamp(oos_index.min())
+
+    # Keep the latest pre-OOS covariance window per strategy so the first
+    # shared OOS returns still have the active optimizer matrix in diagnostics.
+    for strategy, strategy_rows in diagnostics.groupby("strategy", sort=False):
+        strategy_dates = pd.to_datetime(strategy_rows["effective_date"])
+        prior_dates = strategy_dates.loc[strategy_dates < first_oos_date]
+        if prior_dates.empty:
+            continue
+        active_date = pd.Timestamp(prior_dates.max())
+        keep_mask = keep_mask | (
+            (diagnostics["strategy"] == strategy)
+            & (effective_dates == active_date)
+        )
+
+    sliced = diagnostics.loc[keep_mask].copy()
     if sliced.empty:
         return None
     return sliced.reset_index(drop=True)

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -6,6 +6,10 @@ from pathlib import Path
 import pandas as pd
 
 from marketlab.config import ExperimentConfig
+from marketlab.reports.risk_diagnostics import (
+    build_covariance_summary,
+    build_factor_summary,
+)
 
 EXPOSURE_SUMMARY_COLUMNS = [
     "strategy",
@@ -39,6 +43,17 @@ COST_SENSITIVITY_SUMMARY_COLUMNS = [
     "annualized_return",
     "max_drawdown",
     "cost_drag",
+]
+FACTOR_DIAGNOSTICS_DISPLAY_COLUMNS = [
+    "strategy",
+    "factor",
+    "beta_like_exposure",
+    "mean_factor_return",
+    "mean_factor_contribution",
+    "alpha_like_intercept",
+    "mean_strategy_return",
+    "modeled_mean_return",
+    "r_squared",
 ]
 
 
@@ -289,6 +304,55 @@ def _benchmark_summary_lines(strategy_summary: pd.DataFrame) -> list[str]:
     return lines
 
 
+def _factor_diagnostics_lines(
+    report_path: Path,
+    factor_diagnostics: pd.DataFrame | None,
+    factor_diagnostics_path: Path | None,
+) -> list[str]:
+    if (
+        factor_diagnostics is None
+        or factor_diagnostics.empty
+        or factor_diagnostics_path is None
+    ):
+        return []
+
+    factor_summary = build_factor_summary(factor_diagnostics)
+    detail_frame = factor_diagnostics.loc[:, FACTOR_DIAGNOSTICS_DISPLAY_COLUMNS]
+    relative_path = os.path.relpath(factor_diagnostics_path, start=report_path.parent)
+    return [
+        _markdown_table(_display_frame(factor_summary)),
+        "",
+        _markdown_table(_display_frame(detail_frame)),
+        "",
+        "- Factor attribution is descriptive and uses realized net returns plus local factor inputs only.",
+        "- These diagnostics do not feed optimizer weights, scenario selection, or model ranking.",
+        f"- Factor diagnostics artifact: [{factor_diagnostics_path.name}]({relative_path})",
+    ]
+
+
+def _covariance_diagnostics_lines(
+    report_path: Path,
+    covariance_diagnostics: pd.DataFrame | None,
+    covariance_diagnostics_path: Path | None,
+) -> list[str]:
+    if (
+        covariance_diagnostics is None
+        or covariance_diagnostics.empty
+        or covariance_diagnostics_path is None
+    ):
+        return []
+
+    covariance_summary = build_covariance_summary(covariance_diagnostics)
+    relative_path = os.path.relpath(covariance_diagnostics_path, start=report_path.parent)
+    return [
+        _markdown_table(_display_frame(covariance_summary)),
+        "",
+        "- Covariance diagnostics reflect the regularized matrix used by the optimizer at each rebalance window.",
+        "- Pairwise correlation summaries exclude the diagonal and aggregate across optimizer windows.",
+        f"- Covariance diagnostics artifact: [{covariance_diagnostics_path.name}]({relative_path})",
+    ]
+
+
 def _black_litterman_view_lines(
     config: ExperimentConfig,
     report_path: Path,
@@ -367,6 +431,10 @@ def write_markdown_report(
     calibration_curves_plot_path: Path | None = None,
     score_histograms_plot_path: Path | None = None,
     threshold_sweeps_plot_path: Path | None = None,
+    factor_diagnostics: pd.DataFrame | None = None,
+    factor_diagnostics_path: Path | None = None,
+    covariance_diagnostics: pd.DataFrame | None = None,
+    covariance_diagnostics_path: Path | None = None,
     black_litterman_assumptions_path: Path | None = None,
 ) -> Path:
     output_path = Path(path)
@@ -410,6 +478,22 @@ def write_markdown_report(
         benchmark_lines = _benchmark_summary_lines(strategy_summary)
         if benchmark_lines:
             content_lines.extend(_section("Benchmark-Relative Summary", benchmark_lines))
+
+    factor_lines = _factor_diagnostics_lines(
+        output_path,
+        factor_diagnostics,
+        factor_diagnostics_path,
+    )
+    if factor_lines:
+        content_lines.extend(_section("Factor Attribution Diagnostics", factor_lines))
+
+    covariance_lines = _covariance_diagnostics_lines(
+        output_path,
+        covariance_diagnostics,
+        covariance_diagnostics_path,
+    )
+    if covariance_lines:
+        content_lines.extend(_section("Covariance Diagnostics", covariance_lines))
 
     black_litterman_lines = _black_litterman_view_lines(
         config,

--- a/src/marketlab/reports/risk_diagnostics.py
+++ b/src/marketlab/reports/risk_diagnostics.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from marketlab.strategies.optimized import CovarianceDiagnosticWindow
+
+FACTOR_DIAGNOSTICS_COLUMNS = [
+    "strategy",
+    "start_date",
+    "end_date",
+    "observations",
+    "factor",
+    "beta_like_exposure",
+    "mean_factor_return",
+    "mean_factor_contribution",
+    "alpha_like_intercept",
+    "mean_strategy_return",
+    "modeled_mean_return",
+    "r_squared",
+]
+FACTOR_SUMMARY_COLUMNS = [
+    "strategy",
+    "start_date",
+    "end_date",
+    "observations",
+    "alpha_like_intercept",
+    "total_mean_factor_contribution",
+    "mean_strategy_return",
+    "modeled_mean_return",
+    "r_squared",
+]
+COVARIANCE_DIAGNOSTICS_COLUMNS = [
+    "strategy",
+    "signal_date",
+    "effective_date",
+    "row_symbol",
+    "column_symbol",
+    "covariance",
+    "correlation",
+]
+COVARIANCE_SUMMARY_COLUMNS = [
+    "strategy",
+    "rebalance_windows",
+    "avg_variance",
+    "avg_pairwise_correlation",
+    "max_pairwise_correlation",
+    "min_eigenvalue",
+    "worst_condition_number",
+]
+FACTOR_REGRESSION_EPSILON = 1e-12
+
+
+def _empty_factor_diagnostics() -> pd.DataFrame:
+    return pd.DataFrame(columns=FACTOR_DIAGNOSTICS_COLUMNS)
+
+
+def _empty_factor_summary() -> pd.DataFrame:
+    return pd.DataFrame(columns=FACTOR_SUMMARY_COLUMNS)
+
+
+def _empty_covariance_diagnostics() -> pd.DataFrame:
+    return pd.DataFrame(columns=COVARIANCE_DIAGNOSTICS_COLUMNS)
+
+
+def _empty_covariance_summary() -> pd.DataFrame:
+    return pd.DataFrame(columns=COVARIANCE_SUMMARY_COLUMNS)
+
+
+def _factor_header(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration as exc:
+            raise ValueError("Factor model CSV must contain a header row.") from exc
+    return [str(value) for value in header]
+
+
+def load_factor_returns(path: Path | str) -> pd.DataFrame:
+    factor_path = Path(path)
+    header = _factor_header(factor_path)
+    if not header:
+        raise ValueError("Factor model CSV must contain a header row.")
+    if len(header) != len(set(header)):
+        raise ValueError("Factor model CSV must not contain duplicate column names.")
+    if "date" not in header:
+        raise ValueError("Factor model CSV must contain a 'date' column.")
+
+    factor_columns = [column for column in header if column != "date"]
+    if not factor_columns:
+        raise ValueError("Factor model CSV must contain at least one factor column.")
+
+    frame = pd.read_csv(factor_path)
+    frame.columns = [str(column) for column in frame.columns]
+    frame["date"] = pd.to_datetime(frame["date"], errors="raise")
+    if frame["date"].isna().any():
+        raise ValueError("Factor model CSV must contain only valid dates.")
+    if frame["date"].duplicated().any():
+        raise ValueError("Factor model CSV must not contain duplicate dates.")
+
+    for column in factor_columns:
+        numeric = pd.to_numeric(frame[column], errors="raise")
+        if not np.isfinite(numeric.to_numpy(dtype=float)).all():
+            raise ValueError("Factor model CSV must contain only finite numeric factor values.")
+        frame.loc[:, column] = numeric.astype(float)
+
+    if frame.loc[:, factor_columns].isna().any().any():
+        raise ValueError("Factor model CSV must not contain missing factor values.")
+
+    return (
+        frame.loc[:, ["date", *factor_columns]]
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+
+
+def build_factor_diagnostics(
+    performance: pd.DataFrame,
+    factor_returns: pd.DataFrame,
+) -> pd.DataFrame:
+    if performance.empty:
+        return _empty_factor_diagnostics()
+    if factor_returns.empty:
+        raise ValueError("Factor model CSV must contain at least one factor row.")
+
+    factor_columns = [column for column in factor_returns.columns if column != "date"]
+    factor_frame = factor_returns.copy()
+    factor_frame["date"] = pd.to_datetime(factor_frame["date"])
+
+    rows: list[dict[str, object]] = []
+    for strategy, strategy_rows in performance.groupby("strategy", sort=True):
+        aligned = strategy_rows.loc[:, ["date", "net_return"]].copy()
+        aligned["date"] = pd.to_datetime(aligned["date"])
+        aligned = aligned.merge(factor_frame, on="date", how="inner")
+        if aligned.empty:
+            raise ValueError(
+                f"Factor model CSV has no overlapping dates with strategy '{strategy}'."
+            )
+
+        design_factors = aligned.loc[:, factor_columns].to_numpy(dtype=float)
+        design_matrix = np.column_stack([np.ones(len(aligned), dtype=float), design_factors])
+        if design_matrix.shape[0] < design_matrix.shape[1]:
+            raise ValueError(
+                f"Factor model regression is underdetermined for strategy '{strategy}'."
+            )
+        if np.linalg.matrix_rank(design_matrix) < design_matrix.shape[1]:
+            raise ValueError(
+                f"Factor model regression is rank-deficient for strategy '{strategy}'."
+            )
+
+        response = aligned["net_return"].to_numpy(dtype=float)
+        coefficients, *_ = np.linalg.lstsq(design_matrix, response, rcond=None)
+        intercept = float(coefficients[0])
+        betas = coefficients[1:]
+        modeled_returns = design_matrix @ coefficients
+        mean_strategy_return = float(response.mean())
+        modeled_mean_return = float(modeled_returns.mean())
+        residuals = response - modeled_returns
+        total_sum_squares = float(np.square(response - mean_strategy_return).sum())
+        residual_sum_squares = float(np.square(residuals).sum())
+        if abs(total_sum_squares) <= FACTOR_REGRESSION_EPSILON:
+            r_squared = float("nan")
+        else:
+            r_squared = float(1.0 - (residual_sum_squares / total_sum_squares))
+
+        mean_factor_returns = aligned.loc[:, factor_columns].mean()
+        start_date = pd.Timestamp(aligned["date"].min())
+        end_date = pd.Timestamp(aligned["date"].max())
+        observations = int(len(aligned))
+        for index, factor in enumerate(factor_columns):
+            beta = float(betas[index])
+            mean_factor_return = float(mean_factor_returns.loc[factor])
+            rows.append(
+                {
+                    "strategy": strategy,
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    "observations": observations,
+                    "factor": factor,
+                    "beta_like_exposure": beta,
+                    "mean_factor_return": mean_factor_return,
+                    "mean_factor_contribution": float(beta * mean_factor_return),
+                    "alpha_like_intercept": intercept,
+                    "mean_strategy_return": mean_strategy_return,
+                    "modeled_mean_return": modeled_mean_return,
+                    "r_squared": r_squared,
+                }
+            )
+
+    diagnostics = pd.DataFrame(rows, columns=FACTOR_DIAGNOSTICS_COLUMNS)
+    if diagnostics.empty:
+        return _empty_factor_diagnostics()
+    return diagnostics.sort_values(["strategy", "factor"]).reset_index(drop=True)
+
+
+def build_factor_summary(factor_diagnostics: pd.DataFrame) -> pd.DataFrame:
+    if factor_diagnostics.empty:
+        return _empty_factor_summary()
+
+    summary = (
+        factor_diagnostics.groupby("strategy", as_index=False)
+        .agg(
+            start_date=("start_date", "first"),
+            end_date=("end_date", "first"),
+            observations=("observations", "first"),
+            alpha_like_intercept=("alpha_like_intercept", "first"),
+            total_mean_factor_contribution=("mean_factor_contribution", "sum"),
+            mean_strategy_return=("mean_strategy_return", "first"),
+            modeled_mean_return=("modeled_mean_return", "first"),
+            r_squared=("r_squared", "first"),
+        )
+        .sort_values("strategy")
+        .reset_index(drop=True)
+    )
+    return summary.loc[:, FACTOR_SUMMARY_COLUMNS]
+
+
+def build_covariance_diagnostics(
+    windows: list[CovarianceDiagnosticWindow],
+) -> pd.DataFrame:
+    if not windows:
+        return _empty_covariance_diagnostics()
+
+    rows: list[dict[str, object]] = []
+    for window in windows:
+        covariance = window.covariance.loc[window.symbols, window.symbols].astype(float)
+        covariance_values = covariance.to_numpy(dtype=float)
+        volatility = np.sqrt(np.diag(covariance_values))
+        denominator = np.outer(volatility, volatility)
+        correlation = np.divide(
+            covariance_values,
+            denominator,
+            out=np.full_like(covariance_values, np.nan, dtype=float),
+            where=denominator > 0.0,
+        )
+        correlation = np.clip(correlation, -1.0, 1.0)
+
+        for row_index, row_symbol in enumerate(window.symbols):
+            for column_index, column_symbol in enumerate(window.symbols):
+                rows.append(
+                    {
+                        "strategy": window.strategy,
+                        "signal_date": pd.Timestamp(window.signal_date),
+                        "effective_date": pd.Timestamp(window.effective_date),
+                        "row_symbol": row_symbol,
+                        "column_symbol": column_symbol,
+                        "covariance": float(covariance_values[row_index, column_index]),
+                        "correlation": float(correlation[row_index, column_index]),
+                    }
+                )
+
+    diagnostics = pd.DataFrame(rows, columns=COVARIANCE_DIAGNOSTICS_COLUMNS)
+    if diagnostics.empty:
+        return _empty_covariance_diagnostics()
+    return diagnostics.sort_values(
+        ["strategy", "effective_date", "signal_date", "row_symbol", "column_symbol"]
+    ).reset_index(drop=True)
+
+
+def build_covariance_summary(covariance_diagnostics: pd.DataFrame) -> pd.DataFrame:
+    if covariance_diagnostics.empty:
+        return _empty_covariance_summary()
+
+    per_window_rows: list[dict[str, object]] = []
+    grouped = covariance_diagnostics.groupby(
+        ["strategy", "signal_date", "effective_date"],
+        sort=True,
+        dropna=False,
+    )
+    for (strategy, signal_date, effective_date), frame in grouped:
+        covariance_matrix = (
+            frame.pivot(index="row_symbol", columns="column_symbol", values="covariance")
+            .sort_index(axis=0)
+            .sort_index(axis=1)
+        )
+        correlation_matrix = (
+            frame.pivot(index="row_symbol", columns="column_symbol", values="correlation")
+            .sort_index(axis=0)
+            .sort_index(axis=1)
+        )
+        covariance_values = covariance_matrix.to_numpy(dtype=float)
+        correlation_values = correlation_matrix.to_numpy(dtype=float)
+        upper_triangle_indices = np.triu_indices_from(correlation_values, k=1)
+        pairwise = correlation_values[upper_triangle_indices]
+        eigenvalues = np.linalg.eigvalsh(covariance_values)
+        per_window_rows.append(
+            {
+                "strategy": strategy,
+                "signal_date": pd.Timestamp(signal_date),
+                "effective_date": pd.Timestamp(effective_date),
+                "avg_variance": float(np.diag(covariance_values).mean()),
+                "avg_pairwise_correlation": float(pairwise.mean()) if len(pairwise) > 0 else float("nan"),
+                "max_pairwise_correlation": float(pairwise.max()) if len(pairwise) > 0 else float("nan"),
+                "min_eigenvalue": float(eigenvalues.min()),
+                "condition_number": float(np.linalg.cond(covariance_values)),
+            }
+        )
+
+    per_window = pd.DataFrame(per_window_rows)
+    summary = (
+        per_window.groupby("strategy", as_index=False)
+        .agg(
+            rebalance_windows=("effective_date", "size"),
+            avg_variance=("avg_variance", "mean"),
+            avg_pairwise_correlation=("avg_pairwise_correlation", "mean"),
+            max_pairwise_correlation=("max_pairwise_correlation", "max"),
+            min_eigenvalue=("min_eigenvalue", "min"),
+            worst_condition_number=("condition_number", "max"),
+        )
+        .sort_values("strategy")
+        .reset_index(drop=True)
+    )
+    return summary.loc[:, COVARIANCE_SUMMARY_COLUMNS]

--- a/src/marketlab/strategies/optimized.py
+++ b/src/marketlab/strategies/optimized.py
@@ -70,6 +70,15 @@ class BlackLittermanOutput:
     assumptions: pd.DataFrame
 
 
+@dataclass(slots=True)
+class CovarianceDiagnosticWindow:
+    strategy: str
+    signal_date: pd.Timestamp
+    effective_date: pd.Timestamp
+    symbols: list[str]
+    covariance: pd.DataFrame
+
+
 def _empty_weights_frame() -> pd.DataFrame:
     return pd.DataFrame(columns=WEIGHTS_COLUMNS)
 
@@ -1303,3 +1312,53 @@ def generate_weights(
     return pd.concat(weight_frames, ignore_index=True).sort_values(["effective_date", "symbol"]).reset_index(
         drop=True
     )
+
+
+def generate_covariance_diagnostic_windows(
+    panel: pd.DataFrame,
+    *,
+    symbols: list[str],
+    method: str,
+    lookback_days: int,
+    frequency: str = "W-FRI",
+    covariance_estimator: str = "sample",
+    external_covariance_path: Path | str | None = None,
+) -> list[CovarianceDiagnosticWindow]:
+    if method not in EXECUTABLE_METHODS:
+        raise _unsupported_method_error(method)
+    if panel.empty:
+        return []
+
+    optimizer_inputs = build_covariance_inputs(
+        panel,
+        symbols=list(symbols),
+        lookback_days=lookback_days,
+        frequency=frequency,
+        covariance_estimator=covariance_estimator,
+        external_covariance_path=external_covariance_path,
+    )
+    if not optimizer_inputs:
+        return []
+
+    strategy_name = strategy_name_for_method(method)
+    windows: list[CovarianceDiagnosticWindow] = []
+    for optimizer_input in optimizer_inputs:
+        covariance = _regularized_covariance_matrix(
+            optimizer_input,
+            method=method,
+        )
+        windows.append(
+            CovarianceDiagnosticWindow(
+                strategy=strategy_name,
+                signal_date=pd.Timestamp(optimizer_input.signal_date),
+                effective_date=pd.Timestamp(optimizer_input.effective_date),
+                symbols=list(optimizer_input.symbols),
+                covariance=pd.DataFrame(
+                    covariance,
+                    index=optimizer_input.symbols,
+                    columns=optimizer_input.symbols,
+                    dtype=float,
+                ),
+            )
+        )
+    return windows

--- a/tests/integration/_cli_harness.py
+++ b/tests/integration/_cli_harness.py
@@ -44,6 +44,12 @@ from marketlab.reports.analytics import (
 from marketlab.reports.analytics import (
     TURNOVER_COSTS_COLUMNS as _TURNOVER_COSTS_COLUMNS,
 )
+from marketlab.reports.risk_diagnostics import (
+    COVARIANCE_DIAGNOSTICS_COLUMNS as _COVARIANCE_DIAGNOSTICS_COLUMNS,
+)
+from marketlab.reports.risk_diagnostics import (
+    FACTOR_DIAGNOSTICS_COLUMNS as _FACTOR_DIAGNOSTICS_COLUMNS,
+)
 from marketlab.reports.summary import (
     FOLD_SUMMARY_COLUMNS as _FOLD_SUMMARY_COLUMNS,
 )
@@ -69,6 +75,8 @@ GROUP_EXPOSURE_COLUMNS = list(_GROUP_EXPOSURE_COLUMNS)
 MONTHLY_RETURNS_COLUMNS = list(_MONTHLY_RETURNS_COLUMNS)
 STRATEGY_SUMMARY_COLUMNS = list(_STRATEGY_SUMMARY_COLUMNS)
 TURNOVER_COSTS_COLUMNS = list(_TURNOVER_COSTS_COLUMNS)
+FACTOR_DIAGNOSTICS_COLUMNS = list(_FACTOR_DIAGNOSTICS_COLUMNS)
+COVARIANCE_DIAGNOSTICS_COLUMNS = list(_COVARIANCE_DIAGNOSTICS_COLUMNS)
 FOLD_DIAGNOSTICS_COLUMNS = [
     "candidate_id",
     "fold_id",
@@ -187,6 +195,12 @@ def write_raw_symbol_cache(
 def write_yaml_config(path: Path, payload: dict) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def write_factor_model_csv(path: Path, frame: pd.DataFrame) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(path, index=False, date_format="%Y-%m-%d")
     return path
 
 

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -196,6 +196,9 @@ def test_backtest_supports_mean_variance_optimized_baseline(tmp_path: Path) -> N
     ].iloc[0]
     assert mean_variance_row["avg_gross_exposure"] <= 0.6 + 1e-6
     assert "mean_variance" in report_text
+    assert "Covariance Diagnostics" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+    assert (run_dir / "covariance_diagnostics.csv").exists()
     assert not (run_dir / "black_litterman_assumptions.csv").exists()
 
 
@@ -229,6 +232,7 @@ def test_backtest_keeps_mean_variance_as_cash_when_no_windows_exist(tmp_path: Pa
     ].iloc[0]
     assert mean_variance_row["avg_gross_exposure"] == 0.0
     assert mean_variance_row["avg_cash_weight"] == 1.0
+    assert not (run_dir / "covariance_diagnostics.csv").exists()
 
 
 def test_backtest_supports_risk_parity_optimized_baseline(tmp_path: Path) -> None:
@@ -258,6 +262,9 @@ def test_backtest_supports_risk_parity_optimized_baseline(tmp_path: Path) -> Non
     ].iloc[0]
     assert risk_parity_row["avg_gross_exposure"] <= 0.6 + 1e-6
     assert "risk_parity" in report_text
+    assert "Covariance Diagnostics" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+    assert (run_dir / "covariance_diagnostics.csv").exists()
 
 
 def test_backtest_keeps_risk_parity_as_cash_when_no_windows_exist(tmp_path: Path) -> None:
@@ -288,6 +295,7 @@ def test_backtest_keeps_risk_parity_as_cash_when_no_windows_exist(tmp_path: Path
     ].iloc[0]
     assert risk_parity_row["avg_gross_exposure"] == 0.0
     assert risk_parity_row["avg_cash_weight"] == 1.0
+    assert not (run_dir / "covariance_diagnostics.csv").exists()
 
 
 def test_backtest_supports_black_litterman_optimized_baseline(tmp_path: Path) -> None:
@@ -319,9 +327,12 @@ def test_backtest_supports_black_litterman_optimized_baseline(tmp_path: Path) ->
         "tau",
     }
     assert assumptions["tau"].eq(0.05).all()
+    assert (run_dir / "covariance_diagnostics.csv").exists()
     assert "Black-Litterman Assumptions" in report_text
+    assert "Covariance Diagnostics" in report_text
     assert "growth_over_defensive" in report_text
     assert "black_litterman_assumptions.csv" in report_text
+    assert "covariance_diagnostics.csv" in report_text
 
 
 def test_backtest_black_litterman_cash_fallback_skips_assumptions_artifact(tmp_path: Path) -> None:
@@ -351,7 +362,9 @@ def test_backtest_black_litterman_cash_fallback_skips_assumptions_artifact(tmp_p
     assert black_litterman_row["avg_gross_exposure"] == 0.0
     assert black_litterman_row["avg_cash_weight"] == 1.0
     assert not (run_dir / "black_litterman_assumptions.csv").exists()
+    assert not (run_dir / "covariance_diagnostics.csv").exists()
     assert "Black-Litterman Assumptions" not in report_text
+    assert "Covariance Diagnostics" not in report_text
 
 
 def test_run_experiment_supports_black_litterman_optimized_baseline(tmp_path: Path) -> None:
@@ -382,6 +395,17 @@ def test_run_experiment_supports_black_litterman_optimized_baseline(tmp_path: Pa
     assert assumptions["effective_date"].min() >= performance["date"].min()
     assert assumptions["effective_date"].max() <= performance["date"].max()
     assert set(assumptions["effective_date"]) <= set(performance["date"])
+    covariance = pd.read_csv(
+        run_dir / "covariance_diagnostics.csv",
+        parse_dates=["signal_date", "effective_date"],
+    )
+    assert not covariance.empty
+    assert set(covariance["strategy"]) == {"black_litterman"}
+    assert covariance["effective_date"].min() >= performance["date"].min()
+    assert covariance["effective_date"].max() <= performance["date"].max()
+    assert set(covariance["effective_date"]) <= set(performance["date"])
     assert "Black-Litterman Assumptions" in report_text
+    assert "Covariance Diagnostics" in report_text
     assert "core_over_tail" in report_text
     assert "black_litterman_assumptions.csv" in report_text
+    assert "covariance_diagnostics.csv" in report_text

--- a/tests/integration/test_optimized_scaffold.py
+++ b/tests/integration/test_optimized_scaffold.py
@@ -399,11 +399,20 @@ def test_run_experiment_supports_black_litterman_optimized_baseline(tmp_path: Pa
         run_dir / "covariance_diagnostics.csv",
         parse_dates=["signal_date", "effective_date"],
     )
+    performance_dates = pd.Index(performance["date"]).sort_values()
+    covariance_effective_dates = pd.Index(
+        pd.to_datetime(covariance["effective_date"]).drop_duplicates()
+    ).sort_values()
+    pre_oos_dates = covariance_effective_dates[covariance_effective_dates < performance_dates.min()]
+    in_window_dates = covariance_effective_dates[covariance_effective_dates >= performance_dates.min()]
+
     assert not covariance.empty
     assert set(covariance["strategy"]) == {"black_litterman"}
-    assert covariance["effective_date"].min() >= performance["date"].min()
-    assert covariance["effective_date"].max() <= performance["date"].max()
-    assert set(covariance["effective_date"]) <= set(performance["date"])
+    assert len(pre_oos_dates) == 1
+    assert (covariance["effective_date"] == pre_oos_dates[0]).sum() == 16
+    assert len(in_window_dates) > 0
+    assert in_window_dates.max() <= performance_dates.max()
+    assert set(in_window_dates) <= set(performance_dates)
     assert "Black-Litterman Assumptions" in report_text
     assert "Covariance Diagnostics" in report_text
     assert "core_over_tail" in report_text

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -622,6 +622,7 @@ def test_run_experiment_adds_factor_diagnostics_for_all_strategies_and_covarianc
             "enabled": True,
             "method": "mean_variance",
             "lookback_days": 5,
+            "rebalance_frequency": "W-MON",
             "target_gross_exposure": 0.7,
             "risk_aversion": 1.0,
         },
@@ -645,13 +646,22 @@ def test_run_experiment_adds_factor_diagnostics_for_all_strategies_and_covarianc
     report_text = (run_dir / "report.md").read_text(encoding="utf-8")
 
     expected_strategies = {"buy_hold", "sma", "mean_variance", "ml_logistic_regression"}
+    performance_dates = pd.Index(performance["date"]).sort_values()
+    covariance_effective_dates = pd.Index(
+        pd.to_datetime(covariance_diagnostics["effective_date"]).drop_duplicates()
+    ).sort_values()
+    pre_oos_dates = covariance_effective_dates[covariance_effective_dates < performance_dates.min()]
+    in_window_dates = covariance_effective_dates[covariance_effective_dates >= performance_dates.min()]
+
     assert list(factor_diagnostics.columns) == FACTOR_DIAGNOSTICS_COLUMNS
     assert list(covariance_diagnostics.columns) == COVARIANCE_DIAGNOSTICS_COLUMNS
     assert set(factor_diagnostics["strategy"]) == expected_strategies
     assert set(covariance_diagnostics["strategy"]) == {"mean_variance"}
-    assert covariance_diagnostics["effective_date"].min() >= performance["date"].min()
-    assert covariance_diagnostics["effective_date"].max() <= performance["date"].max()
-    assert set(covariance_diagnostics["effective_date"]) <= set(performance["date"])
+    assert len(pre_oos_dates) == 1
+    assert (covariance_diagnostics["effective_date"] == pre_oos_dates[0]).sum() == 16
+    assert len(in_window_dates) > 0
+    assert in_window_dates.max() <= performance_dates.max()
+    assert set(in_window_dates) <= set(performance_dates)
     assert "## Factor Attribution Diagnostics" in report_text
     assert "## Covariance Diagnostics" in report_text
     assert "factor_diagnostics.csv" in report_text

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -20,10 +20,13 @@ STRATEGY_SUMMARY_COLUMNS = _cli_harness.STRATEGY_SUMMARY_COLUMNS
 MONTHLY_RETURNS_COLUMNS = _cli_harness.MONTHLY_RETURNS_COLUMNS
 TURNOVER_COSTS_COLUMNS = _cli_harness.TURNOVER_COSTS_COLUMNS
 COST_SENSITIVITY_COLUMNS = _cli_harness.COST_SENSITIVITY_COLUMNS
+FACTOR_DIAGNOSTICS_COLUMNS = _cli_harness.FACTOR_DIAGNOSTICS_COLUMNS
+COVARIANCE_DIAGNOSTICS_COLUMNS = _cli_harness.COVARIANCE_DIAGNOSTICS_COLUMNS
 assert_command_ok = _cli_harness.assert_command_ok
 build_synthetic_panel = _cli_harness.build_synthetic_panel
 latest_run_dir = _cli_harness.latest_run_dir
 load_fixture_panel = _cli_harness.load_fixture_panel
+write_factor_model_csv = _cli_harness.write_factor_model_csv
 write_yaml_config = _cli_harness.write_yaml_config
 run_marketlab_cli = getattr(
     _cli_harness,
@@ -53,6 +56,21 @@ DEFAULT_MODEL_NAMES = {
     "logistic_regression",
     "random_forest",
 }
+
+
+def _write_factor_model(
+    tmp_path: Path,
+    dates: pd.Series | pd.Index | list[pd.Timestamp],
+) -> Path:
+    ordered_dates = pd.Index(pd.to_datetime(dates)).drop_duplicates().sort_values()
+    frame = pd.DataFrame(
+        {
+            "date": ordered_dates,
+            "MKT": [0.001 + (0.0002 * index) for index in range(len(ordered_dates))],
+            "VALUE": [0.0005 * ((-1) ** index) for index in range(len(ordered_dates))],
+        }
+    )
+    return write_factor_model_csv(tmp_path / "inputs" / "factor_returns.csv", frame)
 
 
 def _write_run_experiment_config(
@@ -432,6 +450,8 @@ def test_backtest_remains_baseline_only(tmp_path: Path) -> None:
     assert not (run_dir / "calibration_curves.png").exists()
     assert not (run_dir / "score_histograms.png").exists()
     assert not (run_dir / "threshold_sweeps.png").exists()
+    assert not (run_dir / "factor_diagnostics.csv").exists()
+    assert not (run_dir / "covariance_diagnostics.csv").exists()
 
 
 def test_backtest_supports_config_defined_allocation_baseline(tmp_path: Path) -> None:
@@ -468,6 +488,50 @@ def test_backtest_supports_config_defined_allocation_baseline(tmp_path: Path) ->
     assert "allocation_equal" in report_text
 
 
+def test_backtest_supports_factor_and_covariance_diagnostics_for_optimized_baseline(
+    tmp_path: Path,
+) -> None:
+    factor_model_path = _write_factor_model(
+        tmp_path,
+        pd.bdate_range("2024-01-01", "2024-01-31"),
+    )
+    config_path = _write_backtest_config(
+        tmp_path,
+        optimized={
+            "enabled": True,
+            "method": "mean_variance",
+            "lookback_days": 3,
+            "target_gross_exposure": 0.7,
+            "risk_aversion": 1.0,
+        },
+        evaluation={"factor_model_path": str(factor_model_path)},
+    )
+
+    result = run_marketlab_cli("backtest", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_backtest_fixture"
+    run_dir = latest_run_dir(run_root)
+    factor_diagnostics = pd.read_csv(
+        run_dir / "factor_diagnostics.csv",
+        parse_dates=["start_date", "end_date"],
+    )
+    covariance_diagnostics = pd.read_csv(
+        run_dir / "covariance_diagnostics.csv",
+        parse_dates=["signal_date", "effective_date"],
+    )
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert list(factor_diagnostics.columns) == FACTOR_DIAGNOSTICS_COLUMNS
+    assert list(covariance_diagnostics.columns) == COVARIANCE_DIAGNOSTICS_COLUMNS
+    assert set(factor_diagnostics["strategy"]) == {"buy_hold", "sma", "mean_variance"}
+    assert set(covariance_diagnostics["strategy"]) == {"mean_variance"}
+    assert "## Factor Attribution Diagnostics" in report_text
+    assert "## Covariance Diagnostics" in report_text
+    assert "factor_diagnostics.csv" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+
+
 
 def test_run_experiment_supports_mean_variance_baseline(tmp_path: Path) -> None:
     config_path = _write_run_experiment_config(
@@ -501,6 +565,10 @@ def test_run_experiment_supports_mean_variance_baseline(tmp_path: Path) -> None:
     ].iloc[0]
     assert mean_variance_row["avg_gross_exposure"] <= 0.7 + 1e-6
     assert "mean_variance" in report_text
+    assert "Covariance Diagnostics" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+    assert (run_dir / "covariance_diagnostics.csv").exists()
+    assert not (run_dir / "factor_diagnostics.csv").exists()
 
 
 def test_run_experiment_supports_risk_parity_baseline(tmp_path: Path) -> None:
@@ -534,6 +602,60 @@ def test_run_experiment_supports_risk_parity_baseline(tmp_path: Path) -> None:
     ].iloc[0]
     assert risk_parity_row["avg_gross_exposure"] <= 0.71
     assert "risk_parity" in report_text
+    assert "Covariance Diagnostics" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+    assert (run_dir / "covariance_diagnostics.csv").exists()
+    assert not (run_dir / "factor_diagnostics.csv").exists()
+
+
+def test_run_experiment_adds_factor_diagnostics_for_all_strategies_and_covariance_for_optimized_only(
+    tmp_path: Path,
+) -> None:
+    factor_model_path = _write_factor_model(
+        tmp_path,
+        pd.bdate_range("2020-01-01", "2024-12-31"),
+    )
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        optimized={
+            "enabled": True,
+            "method": "mean_variance",
+            "lookback_days": 5,
+            "target_gross_exposure": 0.7,
+            "risk_aversion": 1.0,
+        },
+        evaluation={"factor_model_path": str(factor_model_path)},
+    )
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    performance = pd.read_csv(run_dir / "performance.csv", parse_dates=["date"])
+    factor_diagnostics = pd.read_csv(
+        run_dir / "factor_diagnostics.csv",
+        parse_dates=["start_date", "end_date"],
+    )
+    covariance_diagnostics = pd.read_csv(
+        run_dir / "covariance_diagnostics.csv",
+        parse_dates=["signal_date", "effective_date"],
+    )
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    expected_strategies = {"buy_hold", "sma", "mean_variance", "ml_logistic_regression"}
+    assert list(factor_diagnostics.columns) == FACTOR_DIAGNOSTICS_COLUMNS
+    assert list(covariance_diagnostics.columns) == COVARIANCE_DIAGNOSTICS_COLUMNS
+    assert set(factor_diagnostics["strategy"]) == expected_strategies
+    assert set(covariance_diagnostics["strategy"]) == {"mean_variance"}
+    assert covariance_diagnostics["effective_date"].min() >= performance["date"].min()
+    assert covariance_diagnostics["effective_date"].max() <= performance["date"].max()
+    assert set(covariance_diagnostics["effective_date"]) <= set(performance["date"])
+    assert "## Factor Attribution Diagnostics" in report_text
+    assert "## Covariance Diagnostics" in report_text
+    assert "factor_diagnostics.csv" in report_text
+    assert "covariance_diagnostics.csv" in report_text
 
 
 def test_run_experiment_supports_group_weight_allocation_baseline(tmp_path: Path) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -70,6 +70,8 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
     assert config.portfolio.risk.max_long_exposure is None
     assert config.portfolio.risk.max_short_exposure is None
     assert config.evaluation.cost_sensitivity_bps == []
+    assert config.evaluation.factor_model_path == ""
+    assert config.factor_model_path is None
 
 
 def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> None:
@@ -89,7 +91,7 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
                 "views": None,
             },
         },
-        evaluation={"cost_sensitivity_bps": None},
+        evaluation={"cost_sensitivity_bps": None, "factor_model_path": None},
     )
 
     config = load_config(config_path)
@@ -102,6 +104,24 @@ def test_load_config_normalizes_nullable_mapping_sections(tmp_path: Path) -> Non
     assert config.baselines.optimized.equilibrium_weights == {}
     assert config.baselines.optimized.views == []
     assert config.evaluation.cost_sensitivity_bps == []
+    assert config.evaluation.factor_model_path == ""
+    assert config.factor_model_path is None
+
+
+def test_load_config_resolves_factor_model_path_relative_to_config(tmp_path: Path) -> None:
+    config_dir = tmp_path / "configs"
+    factors_path = tmp_path / "inputs" / "factor_returns.csv"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    factors_path.parent.mkdir(parents=True, exist_ok=True)
+    factors_path.write_text("date,MKT\n2024-01-02,0.01\n", encoding="utf-8")
+    config_path = _write_config(
+        config_dir / "config.yaml",
+        evaluation={"factor_model_path": "inputs/factor_returns.csv"},
+    )
+
+    config = load_config(config_path)
+
+    assert config.factor_model_path == factors_path.resolve()
 
 
 def test_load_config_rejects_unknown_symbol_group_entries(tmp_path: Path) -> None:

--- a/tests/unit/test_markdown_report.py
+++ b/tests/unit/test_markdown_report.py
@@ -101,6 +101,43 @@ def _cost_sensitivity() -> pd.DataFrame:
     )
 
 
+def _factor_diagnostics() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": ["alpha", "alpha", "beta"],
+            "start_date": pd.to_datetime(["2024-01-02", "2024-01-02", "2024-01-02"]),
+            "end_date": pd.to_datetime(["2024-01-03", "2024-01-03", "2024-01-03"]),
+            "observations": [2, 2, 2],
+            "factor": ["MKT", "SMB", "MKT"],
+            "beta_like_exposure": [1.2, -0.3, 0.8],
+            "mean_factor_return": [0.01, -0.005, 0.01],
+            "mean_factor_contribution": [0.012, 0.0015, 0.008],
+            "alpha_like_intercept": [0.001, 0.001, 0.002],
+            "mean_strategy_return": [0.0135, 0.0135, 0.01],
+            "modeled_mean_return": [0.0145, 0.0145, 0.01],
+            "r_squared": [0.95, 0.95, 0.90],
+        }
+    )
+
+
+def _covariance_diagnostics() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": ["mean_variance"] * 8,
+            "signal_date": pd.to_datetime(
+                ["2024-01-05"] * 4 + ["2024-01-12"] * 4
+            ),
+            "effective_date": pd.to_datetime(
+                ["2024-01-08"] * 4 + ["2024-01-15"] * 4
+            ),
+            "row_symbol": ["AAA", "AAA", "BBB", "BBB"] * 2,
+            "column_symbol": ["AAA", "BBB", "AAA", "BBB"] * 2,
+            "covariance": [0.04, 0.01, 0.01, 0.09, 0.01, 0.002, 0.002, 0.04],
+            "correlation": [1.0, 0.166667, 0.166667, 1.0, 1.0, 0.1, 0.1, 1.0],
+        }
+    )
+
+
 def test_write_markdown_report_turnover_section_uses_turnover_costs_input(tmp_path: Path) -> None:
     config = ExperimentConfig(experiment_name="markdown_fixture")
     turnover_costs = pd.DataFrame(
@@ -340,3 +377,34 @@ def test_write_markdown_report_adds_benchmark_relative_summary_section(
     )
     assert "benchmark_relative.csv" in report_text
     assert "active risk" in report_text
+
+
+def test_write_markdown_report_adds_factor_and_covariance_sections(tmp_path: Path) -> None:
+    config = ExperimentConfig(experiment_name="markdown_fixture")
+    factor_path = tmp_path / "factor_diagnostics.csv"
+    covariance_path = tmp_path / "covariance_diagnostics.csv"
+    factor_path.write_text("placeholder", encoding="utf-8")
+    covariance_path.write_text("placeholder", encoding="utf-8")
+
+    report_path = write_markdown_report(
+        config=config,
+        metrics=_base_metrics(),
+        performance=_base_performance(),
+        path=tmp_path / "report.md",
+        factor_diagnostics=_factor_diagnostics(),
+        factor_diagnostics_path=factor_path,
+        covariance_diagnostics=_covariance_diagnostics(),
+        covariance_diagnostics_path=covariance_path,
+    )
+
+    report_text = report_path.read_text(encoding="utf-8")
+
+    assert "## Factor Attribution Diagnostics" in report_text
+    assert "| strategy | start_date | end_date | observations | alpha_like_intercept | total_mean_factor_contribution | mean_strategy_return | modeled_mean_return | r_squared |" in report_text
+    assert "| strategy | factor | beta_like_exposure | mean_factor_return | mean_factor_contribution | alpha_like_intercept | mean_strategy_return | modeled_mean_return | r_squared |" in report_text
+    assert "factor_diagnostics.csv" in report_text
+    assert "These diagnostics do not feed optimizer weights" in report_text
+    assert "## Covariance Diagnostics" in report_text
+    assert "| strategy | rebalance_windows | avg_variance | avg_pairwise_correlation | max_pairwise_correlation | min_eigenvalue | worst_condition_number |" in report_text
+    assert "covariance_diagnostics.csv" in report_text
+    assert "regularized matrix used by the optimizer" in report_text

--- a/tests/unit/test_optimized.py
+++ b/tests/unit/test_optimized.py
@@ -16,6 +16,7 @@ from marketlab.strategies.optimized import (
     estimate_covariance_matrix,
     estimate_expected_returns,
     generate_cash_only_weights,
+    generate_covariance_diagnostic_windows,
     generate_weights,
     is_executable_method,
     load_external_covariance,
@@ -643,6 +644,30 @@ def test_generate_cash_only_weights_supports_black_litterman_fallback() -> None:
     assert list(weights["effective_date"]) == [pd.Timestamp("2024-01-08"), pd.Timestamp("2024-01-08")]
     assert list(weights["symbol"]) == ["AAA", "BBB"]
     assert list(weights["weight"]) == [0.0, 0.0]
+
+
+def test_generate_covariance_diagnostic_windows_use_regularized_optimizer_covariance() -> None:
+    windows = generate_covariance_diagnostic_windows(
+        _build_panel(),
+        symbols=["AAA", "BBB"],
+        method="risk_parity",
+        lookback_days=3,
+        frequency="W-FRI",
+    )
+
+    assert windows
+    first_window = windows[0]
+    assert first_window.strategy == "risk_parity"
+    assert first_window.signal_date == pd.Timestamp("2024-01-05")
+    assert first_window.effective_date == pd.Timestamp("2024-01-08")
+    assert list(first_window.covariance.index) == ["AAA", "BBB"]
+    assert list(first_window.covariance.columns) == ["AAA", "BBB"]
+    assert np.isfinite(first_window.covariance.to_numpy(dtype=float)).all()
+    assert np.allclose(
+        first_window.covariance.to_numpy(dtype=float),
+        first_window.covariance.to_numpy(dtype=float).T,
+    )
+    assert (np.diag(first_window.covariance.to_numpy(dtype=float)) > 0.0).all()
 
 
 def test_generate_weights_rejects_external_expected_return_inputs_for_black_litterman(

--- a/tests/unit/test_risk_diagnostics.py
+++ b/tests/unit/test_risk_diagnostics.py
@@ -1,0 +1,191 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marketlab.reports.risk_diagnostics import (
+    COVARIANCE_DIAGNOSTICS_COLUMNS,
+    FACTOR_DIAGNOSTICS_COLUMNS,
+    build_covariance_diagnostics,
+    build_covariance_summary,
+    build_factor_diagnostics,
+    build_factor_summary,
+    load_factor_returns,
+)
+from marketlab.strategies.optimized import CovarianceDiagnosticWindow
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        ("MKT,SMB\n0.01,0.02\n", "Factor model CSV must contain a 'date' column."),
+        ("date\n2024-01-02\n", "Factor model CSV must contain at least one factor column."),
+        (
+            "date,MKT,MKT\n2024-01-02,0.01,0.02\n",
+            "Factor model CSV must not contain duplicate column names.",
+        ),
+        (
+            "date,MKT\n2024-01-02,0.01\n2024-01-02,0.02\n",
+            "Factor model CSV must not contain duplicate dates.",
+        ),
+        (
+            "date,MKT\n2024-01-02,\n",
+            "Factor model CSV must contain only finite numeric factor values.",
+        ),
+    ],
+)
+def test_load_factor_returns_rejects_invalid_contract(
+    tmp_path: Path,
+    contents: str,
+    message: str,
+) -> None:
+    factor_path = tmp_path / "factor_returns.csv"
+    factor_path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_factor_returns(factor_path)
+
+
+def test_build_factor_diagnostics_matches_known_factor_regression() -> None:
+    factor_returns = pd.DataFrame(
+        {
+            "date": pd.to_datetime(
+                ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"]
+            ),
+            "MKT": [0.01, -0.02, 0.03, -0.01],
+        }
+    )
+    performance = pd.DataFrame(
+        {
+            "date": list(factor_returns["date"]) * 2,
+            "strategy": ["alpha"] * 4 + ["beta"] * 4,
+            "net_return": [
+                0.001 + (1.5 * value) for value in factor_returns["MKT"]
+            ]
+            + [0.002 + (-0.5 * value) for value in factor_returns["MKT"]],
+        }
+    )
+
+    diagnostics = build_factor_diagnostics(performance, factor_returns)
+    summary = build_factor_summary(diagnostics)
+
+    assert list(diagnostics.columns) == FACTOR_DIAGNOSTICS_COLUMNS
+    assert set(diagnostics["strategy"]) == {"alpha", "beta"}
+    assert len(diagnostics) == 2
+
+    alpha_row = diagnostics.loc[diagnostics["strategy"] == "alpha"].iloc[0]
+    beta_row = diagnostics.loc[diagnostics["strategy"] == "beta"].iloc[0]
+    assert alpha_row["beta_like_exposure"] == pytest.approx(1.5)
+    assert alpha_row["alpha_like_intercept"] == pytest.approx(0.001)
+    assert alpha_row["r_squared"] == pytest.approx(1.0)
+    assert beta_row["beta_like_exposure"] == pytest.approx(-0.5)
+    assert beta_row["alpha_like_intercept"] == pytest.approx(0.002)
+    assert beta_row["r_squared"] == pytest.approx(1.0)
+
+    summary = summary.set_index("strategy")
+    assert summary.loc["alpha", "total_mean_factor_contribution"] == pytest.approx(
+        alpha_row["mean_factor_contribution"]
+    )
+    assert summary.loc["beta", "modeled_mean_return"] == pytest.approx(
+        beta_row["modeled_mean_return"]
+    )
+
+
+def test_build_factor_diagnostics_rejects_underdetermined_regression() -> None:
+    factor_returns = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-02", "2024-01-03"]),
+            "MKT": [0.01, 0.02],
+            "SMB": [0.00, 0.01],
+        }
+    )
+    performance = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-02", "2024-01-03"]),
+            "strategy": ["alpha", "alpha"],
+            "net_return": [0.01, 0.02],
+        }
+    )
+
+    with pytest.raises(ValueError, match="underdetermined"):
+        build_factor_diagnostics(performance, factor_returns)
+
+
+def test_build_covariance_diagnostics_and_summary_match_known_windows() -> None:
+    covariance_one = pd.DataFrame(
+        [[0.04, 0.01], [0.01, 0.09]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    covariance_two = pd.DataFrame(
+        [[0.01, 0.002], [0.002, 0.04]],
+        index=["AAA", "BBB"],
+        columns=["AAA", "BBB"],
+        dtype=float,
+    )
+    windows = [
+        CovarianceDiagnosticWindow(
+            strategy="mean_variance",
+            signal_date=pd.Timestamp("2024-01-05"),
+            effective_date=pd.Timestamp("2024-01-08"),
+            symbols=["AAA", "BBB"],
+            covariance=covariance_one,
+        ),
+        CovarianceDiagnosticWindow(
+            strategy="mean_variance",
+            signal_date=pd.Timestamp("2024-01-12"),
+            effective_date=pd.Timestamp("2024-01-15"),
+            symbols=["AAA", "BBB"],
+            covariance=covariance_two,
+        ),
+    ]
+
+    diagnostics = build_covariance_diagnostics(windows)
+    summary = build_covariance_summary(diagnostics)
+
+    assert list(diagnostics.columns) == COVARIANCE_DIAGNOSTICS_COLUMNS
+    assert len(diagnostics) == 8
+
+    first_pair = diagnostics.loc[
+        (diagnostics["effective_date"] == pd.Timestamp("2024-01-08"))
+        & (diagnostics["row_symbol"] == "AAA")
+        & (diagnostics["column_symbol"] == "BBB")
+    ].iloc[0]
+    assert first_pair["covariance"] == pytest.approx(0.01)
+    assert first_pair["correlation"] == pytest.approx(0.01 / np.sqrt(0.04 * 0.09))
+
+    expected_avg_variance = np.mean(
+        [
+            np.mean(np.diag(covariance_one.to_numpy(dtype=float))),
+            np.mean(np.diag(covariance_two.to_numpy(dtype=float))),
+        ]
+    )
+    expected_avg_pairwise = np.mean(
+        [
+            0.01 / np.sqrt(0.04 * 0.09),
+            0.002 / np.sqrt(0.01 * 0.04),
+        ]
+    )
+    expected_max_pairwise = max(
+        0.01 / np.sqrt(0.04 * 0.09),
+        0.002 / np.sqrt(0.01 * 0.04),
+    )
+    expected_min_eigenvalue = min(
+        np.linalg.eigvalsh(covariance_one.to_numpy(dtype=float)).min(),
+        np.linalg.eigvalsh(covariance_two.to_numpy(dtype=float)).min(),
+    )
+    expected_worst_condition = max(
+        np.linalg.cond(covariance_one.to_numpy(dtype=float)),
+        np.linalg.cond(covariance_two.to_numpy(dtype=float)),
+    )
+
+    summary_row = summary.iloc[0]
+    assert summary_row["strategy"] == "mean_variance"
+    assert summary_row["rebalance_windows"] == 2
+    assert summary_row["avg_variance"] == pytest.approx(expected_avg_variance)
+    assert summary_row["avg_pairwise_correlation"] == pytest.approx(expected_avg_pairwise)
+    assert summary_row["max_pairwise_correlation"] == pytest.approx(expected_max_pairwise)
+    assert summary_row["min_eigenvalue"] == pytest.approx(expected_min_eigenvalue)
+    assert summary_row["worst_condition_number"] == pytest.approx(expected_worst_condition)


### PR DESCRIPTION
## Summary
- add optional local factor-model loading and realized-return attribution diagnostics
- persist covariance diagnostics for executable optimized baselines and report both diagnostics in markdown
- cover the new contracts in unit and integration tests and document the feature

## Validation
- `python -m pytest -q tests/unit/test_config.py tests/unit/test_markdown_report.py tests/unit/test_optimized.py tests/unit/test_risk_diagnostics.py --basetemp .pytest_tmp_issue43_unit_push`
- `python -m pytest -q tests/integration/test_optimized_scaffold.py --basetemp .pytest_tmp_issue43_opt_scaffold_push`
- `python -m pytest -x -vv tests/integration/test_run_experiment.py --basetemp .pytest_tmp_issue43_run_experiment_push`
- `python -m ruff check src tests README.md docs`
- `python -m mkdocs build --strict`
- `py -3.12 -m tox -e preflight` *(fails locally because that interpreter does not have `tox` installed)*