### PR TITLE
feat: add canonical Phase 5 scenario pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,39 @@ marketlab run-experiment --config weekly_rank.yaml
 
 `list-configs` shows the bundled example templates, and `write-config` exports one of those templates into your working directory. That keeps the installed package self-contained without requiring a checkout of this repository.
 
+## Canonical Phase 5 Scenario Pack
+
+MarketLab now ships a canonical Phase 5 scenario pack as both checked-in repo configs and installed-package templates.
+
+Repo configs:
+
+- `configs/experiment.phase5.allocation_equal.yaml`
+- `configs/experiment.phase5.allocation_group.yaml`
+- `configs/experiment.phase5.ranking_default.yaml`
+- `configs/experiment.phase5.ranking_capped.yaml`
+- `configs/experiment.phase5.mean_variance.yaml`
+- `configs/experiment.phase5.risk_parity.yaml`
+- `configs/experiment.phase5.black_litterman.yaml`
+
+Installed template names:
+
+- `phase5_allocation_equal`
+- `phase5_allocation_group`
+- `phase5_ranking_default`
+- `phase5_ranking_capped`
+- `phase5_mean_variance`
+- `phase5_risk_parity`
+- `phase5_black_litterman`
+
+Each scenario is still a single config run through `run-experiment`; there is no multi-scenario runner in this phase.
+
+```bash
+marketlab write-config --name phase5_black_litterman --output phase5_black_litterman.yaml
+marketlab run-experiment --config phase5_black_litterman.yaml
+```
+
+For the comparison rules and the recommended artifact fields to inspect, see [docs/phase5-scenarios.md](docs/phase5-scenarios.md).
+
 ## Local Validation
 
 ```bash

--- a/configs/experiment.phase5.allocation_equal.yaml
+++ b/configs/experiment.phase5.allocation_equal.yaml
@@ -1,0 +1,76 @@
+experiment_name: phase5_allocation_equal
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  allocation:
+    enabled: true
+    mode: "equal"
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.allocation_group.yaml
+++ b/configs/experiment.phase5.allocation_group.yaml
@@ -1,0 +1,80 @@
+experiment_name: phase5_allocation_group
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  allocation:
+    enabled: true
+    mode: "group_weights"
+    group_weights:
+      broad_market: 0.50
+      growth: 0.30
+      defensive: 0.20
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.black_litterman.yaml
+++ b/configs/experiment.phase5.black_litterman.yaml
@@ -1,0 +1,102 @@
+experiment_name: phase5_black_litterman
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "black_litterman"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+    equilibrium_weights:
+      VOO: 0.20
+      QQQ: 0.20
+      SMH: 0.20
+      XLV: 0.20
+      IEMG: 0.20
+    tau: 0.05
+    views:
+      - name: "growth_over_defensive"
+        weights:
+          QQQ: 1.0
+          SMH: 1.0
+          XLV: -1.0
+        view_return: 0.0010
+      - name: "core_over_international"
+        weights:
+          VOO: 1.0
+          IEMG: -1.0
+        view_return: 0.0005
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.mean_variance.yaml
+++ b/configs/experiment.phase5.mean_variance.yaml
@@ -1,0 +1,83 @@
+experiment_name: phase5_mean_variance
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "mean_variance"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.ranking_capped.yaml
+++ b/configs/experiment.phase5.ranking_capped.yaml
@@ -1,0 +1,78 @@
+experiment_name: phase5_ranking_capped
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  risk:
+    max_position_weight: 0.30
+    max_group_weight: 0.35
+    max_long_exposure: 0.60
+    max_short_exposure: 0.60
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.ranking_default.yaml
+++ b/configs/experiment.phase5.ranking_default.yaml
@@ -1,0 +1,73 @@
+experiment_name: phase5_ranking_default
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.phase5.risk_parity.yaml
+++ b/configs/experiment.phase5.risk_parity.yaml
@@ -1,0 +1,83 @@
+experiment_name: phase5_risk_parity
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "risk_parity"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ This site is the canonical home for MarketLab's public documentation.
 
 - [How It Works](how-it-works.md)
 - [Architecture](architecture.md)
+- [Phase 5 Scenario Pack](phase5-scenarios.md)
 - [Plan](PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/phase5-scenarios.md
+++ b/docs/phase5-scenarios.md
@@ -1,0 +1,68 @@
+# Phase 5 Scenario Pack
+
+The canonical Phase 5 scenario pack is a set of one-config-per-run comparisons built on the same universe, walk-forward frame, benchmark anchor, and implementation-cost assumptions.
+
+Every scenario in this pack runs through `run-experiment`. That keeps the output on the shared out-of-sample frame already used for baseline-plus-ML comparisons. There is still no multi-scenario runner in this phase; you run one config at a time and compare the resulting artifacts yourself.
+
+## Shared Comparison Frame
+
+All seven scenarios use:
+
+- `data.symbols: [VOO, QQQ, SMH, XLV, IEMG]`
+- `data.start_date: "2018-01-01"`
+- `data.end_date: "2025-12-31"`
+- `data.symbol_groups` with `broad_market`, `growth`, and `defensive` sleeves
+- the default six-model weekly comparison set
+- the default weekly walk-forward settings from `configs/experiment.weekly_rank.yaml`
+- `evaluation.benchmark_strategy: "buy_hold"`
+- `evaluation.cost_sensitivity_bps: [5.0, 25.0]`
+- `portfolio.costs.bps_per_trade: 10`
+
+## Scenario Table
+
+| Repo config | Packaged template | Primary strategy rows to inspect | What changes |
+| --- | --- | --- | --- |
+| `configs/experiment.phase5.allocation_equal.yaml` | `phase5_allocation_equal` | `allocation_equal` | Adds the periodic equal-weight allocation baseline. |
+| `configs/experiment.phase5.allocation_group.yaml` | `phase5_allocation_group` | `allocation_group_weights` | Adds a grouped allocation baseline with `broad_market: 0.50`, `growth: 0.30`, `defensive: 0.20`. |
+| `configs/experiment.phase5.ranking_default.yaml` | `phase5_ranking_default` | `buy_hold`, `sma`, `ml_*` | Uses the default weekly ranking comparison under the shared Phase 5 frame. |
+| `configs/experiment.phase5.ranking_capped.yaml` | `phase5_ranking_capped` | capped `ml_*` rows | Adds ranking caps: `max_position_weight=0.30`, `max_group_weight=0.35`, `max_long_exposure=0.60`, `max_short_exposure=0.60`. |
+| `configs/experiment.phase5.mean_variance.yaml` | `phase5_mean_variance` | `mean_variance` | Enables the long-only mean-variance optimized baseline. |
+| `configs/experiment.phase5.risk_parity.yaml` | `phase5_risk_parity` | `risk_parity` | Enables the long-only risk-parity optimized baseline. |
+| `configs/experiment.phase5.black_litterman.yaml` | `phase5_black_litterman` | `black_litterman` | Enables the Black-Litterman baseline with neutral equal equilibrium weights and two mild signed-basket views. |
+
+## What To Compare
+
+Start with `strategy_summary.csv`. Across scenarios, compare:
+
+- cumulative return, volatility, Sharpe, and max drawdown
+- exposure fields such as average gross exposure, cash weight, and max group weight
+- benchmark-relative fields when the strategy is measured against `buy_hold`
+- cost-drag differences in `cost_sensitivity.csv`
+
+When a scenario enables an optimized baseline, also inspect:
+
+- `covariance_diagnostics.csv` and the `Covariance Diagnostics` report section
+- `black_litterman_assumptions.csv` and the `Black-Litterman Assumptions` report section for the Black-Litterman scenario
+
+Interpretation rules:
+
+- lower risk can come from lower exposure or more cash, not better signal quality
+- benchmark-relative performance and absolute return answer different questions
+- factor and covariance diagnostics remain review artifacts, not scenario-selection inputs
+
+## Commands
+
+Repo checkout:
+
+```bash
+python scripts/run_marketlab.py run-experiment --config configs/experiment.phase5.mean_variance.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.phase5.ranking_capped.yaml
+```
+
+Installed package:
+
+```bash
+marketlab list-configs
+marketlab write-config --name phase5_risk_parity --output phase5_risk_parity.yaml
+marketlab run-experiment --config phase5_risk_parity.yaml
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Overview: index.md
   - How It Works: how-it-works.md
   - Architecture: architecture.md
+  - Phase 5 Scenarios: phase5-scenarios.md
   - Plan: PLAN.md
 plugins:
   - search

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -13,8 +13,15 @@ ROOT = Path(__file__).resolve().parents[1]
 DIST_DIR = ROOT / 'dist'
 SCRATCH_DIR = ROOT / '.package-smoke'
 EXPECTED_TEMPLATES = (
-    'weekly_rank.yaml',
-    'weekly_rank_smoke.yaml',
+    ('weekly_rank', 'weekly_rank.yaml'),
+    ('weekly_rank_smoke', 'weekly_rank_smoke.yaml'),
+    ('phase5_allocation_equal', 'phase5_allocation_equal.yaml'),
+    ('phase5_allocation_group', 'phase5_allocation_group.yaml'),
+    ('phase5_ranking_default', 'phase5_ranking_default.yaml'),
+    ('phase5_ranking_capped', 'phase5_ranking_capped.yaml'),
+    ('phase5_mean_variance', 'phase5_mean_variance.yaml'),
+    ('phase5_risk_parity', 'phase5_risk_parity.yaml'),
+    ('phase5_black_litterman', 'phase5_black_litterman.yaml'),
 )
 
 
@@ -62,7 +69,7 @@ def _assert_wheel_contents(wheel_path: Path) -> None:
     if not any(name.endswith('dist-info/licenses/LICENSE') for name in names):
         raise RuntimeError('Wheel is missing LICENSE')
 
-    for template_name in EXPECTED_TEMPLATES:
+    for _, template_name in EXPECTED_TEMPLATES:
         template_path = f'marketlab/resources/config_templates/{template_name}'
         if template_path not in names:
             raise RuntimeError(f'Wheel is missing packaged template {template_path}')
@@ -75,7 +82,7 @@ def _assert_sdist_contents(sdist_path: Path) -> None:
     if not any(name.endswith('/LICENSE') for name in names):
         raise RuntimeError('sdist is missing LICENSE')
 
-    for template_name in EXPECTED_TEMPLATES:
+    for _, template_name in EXPECTED_TEMPLATES:
         suffix = f'/src/marketlab/resources/config_templates/{template_name}'
         if not any(name.endswith(suffix) for name in names):
             raise RuntimeError(f'sdist is missing packaged template {template_name}')
@@ -116,7 +123,7 @@ def _assert_installed_cli(wheel_path: Path, temp_dir: Path, env: dict[str, str])
 
     templates_run = _run([str(marketlab_path), 'list-configs'], env=env)
     template_lines = templates_run.stdout.strip().splitlines()
-    if template_lines != ['weekly_rank', 'weekly_rank_smoke']:
+    if template_lines != [name for name, _ in EXPECTED_TEMPLATES]:
         raise RuntimeError(f'Installed CLI list-configs output was {template_lines}')
 
     output_path = temp_dir / 'weekly_rank.yaml'
@@ -135,6 +142,25 @@ def _assert_installed_cli(wheel_path: Path, temp_dir: Path, env: dict[str, str])
         raise RuntimeError('Installed CLI write-config did not print the resolved output path')
     if 'experiment_name: weekly_rank_v1' not in output_path.read_text(encoding='utf-8'):
         raise RuntimeError('Installed CLI write-config did not write the expected template')
+
+    scenario_output_path = temp_dir / 'phase5_black_litterman.yaml'
+    scenario_write_run = _run(
+        [
+            str(marketlab_path),
+            'write-config',
+            '--name',
+            'phase5_black_litterman',
+            '--output',
+            str(scenario_output_path),
+        ],
+        env=env,
+    )
+    if scenario_output_path.resolve() != Path(scenario_write_run.stdout.strip()):
+        raise RuntimeError('Installed CLI phase5 write-config did not print the resolved output path')
+    if 'experiment_name: phase5_black_litterman' not in scenario_output_path.read_text(
+        encoding='utf-8'
+    ):
+        raise RuntimeError('Installed CLI phase5 write-config did not write the expected template')
 
 
 def main() -> int:

--- a/src/marketlab/resources/config_templates/phase5_allocation_equal.yaml
+++ b/src/marketlab/resources/config_templates/phase5_allocation_equal.yaml
@@ -1,0 +1,76 @@
+experiment_name: phase5_allocation_equal
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  allocation:
+    enabled: true
+    mode: "equal"
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_allocation_group.yaml
+++ b/src/marketlab/resources/config_templates/phase5_allocation_group.yaml
@@ -1,0 +1,80 @@
+experiment_name: phase5_allocation_group
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  allocation:
+    enabled: true
+    mode: "group_weights"
+    group_weights:
+      broad_market: 0.50
+      growth: 0.30
+      defensive: 0.20
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_black_litterman.yaml
+++ b/src/marketlab/resources/config_templates/phase5_black_litterman.yaml
@@ -1,0 +1,102 @@
+experiment_name: phase5_black_litterman
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "black_litterman"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+    equilibrium_weights:
+      VOO: 0.20
+      QQQ: 0.20
+      SMH: 0.20
+      XLV: 0.20
+      IEMG: 0.20
+    tau: 0.05
+    views:
+      - name: "growth_over_defensive"
+        weights:
+          QQQ: 1.0
+          SMH: 1.0
+          XLV: -1.0
+        view_return: 0.0010
+      - name: "core_over_international"
+        weights:
+          VOO: 1.0
+          IEMG: -1.0
+        view_return: 0.0005
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_mean_variance.yaml
+++ b/src/marketlab/resources/config_templates/phase5_mean_variance.yaml
@@ -1,0 +1,83 @@
+experiment_name: phase5_mean_variance
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "mean_variance"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_ranking_capped.yaml
+++ b/src/marketlab/resources/config_templates/phase5_ranking_capped.yaml
@@ -1,0 +1,78 @@
+experiment_name: phase5_ranking_capped
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  risk:
+    max_position_weight: 0.30
+    max_group_weight: 0.35
+    max_long_exposure: 0.60
+    max_short_exposure: 0.60
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_ranking_default.yaml
+++ b/src/marketlab/resources/config_templates/phase5_ranking_default.yaml
@@ -1,0 +1,73 @@
+experiment_name: phase5_ranking_default
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/config_templates/phase5_risk_parity.yaml
+++ b/src/marketlab/resources/config_templates/phase5_risk_parity.yaml
@@ -1,0 +1,83 @@
+experiment_name: phase5_risk_parity
+
+data:
+  symbols: [VOO, QQQ, SMH, XLV, IEMG]
+  start_date: "2018-01-01"
+  end_date: "2025-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data"
+  prepared_panel_filename: "panel.csv"
+  symbol_groups:
+    VOO: broad_market
+    QQQ: growth
+    SMH: growth
+    XLV: defensive
+    IEMG: broad_market
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 5
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 2
+    short_n: 2
+    rebalance_frequency: "W-FRI"
+    weighting: "equal"
+    mode: "long_short"
+    min_score_threshold: 0.0
+    cash_when_underfilled: false
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+  optimized:
+    enabled: true
+    method: "risk_parity"
+    lookback_days: 252
+    rebalance_frequency: "W-FRI"
+    covariance_estimator: "sample"
+    expected_return_source: "historical_mean"
+    long_only: true
+    target_gross_exposure: 1.0
+    risk_aversion: 1.0
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 3
+    step_months: 3
+    min_train_rows: 100
+    min_test_rows: 20
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+  benchmark_strategy: "buy_hold"
+  cost_sensitivity_bps: [5.0, 25.0]
+  factor_model_path: ""
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/src/marketlab/resources/templates.py
+++ b/src/marketlab/resources/templates.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 
-CONFIG_TEMPLATE_NAMES: tuple[str, ...] = ("weekly_rank", "weekly_rank_smoke")
+CONFIG_TEMPLATE_NAMES: tuple[str, ...] = (
+    "weekly_rank",
+    "weekly_rank_smoke",
+    "phase5_allocation_equal",
+    "phase5_allocation_group",
+    "phase5_ranking_default",
+    "phase5_ranking_capped",
+    "phase5_mean_variance",
+    "phase5_risk_parity",
+    "phase5_black_litterman",
+)
 _TEMPLATE_PACKAGE = "marketlab.resources.config_templates"
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -42,18 +42,39 @@ def test_list_configs_prints_packaged_templates(capsys: pytest.CaptureFixture[st
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert captured.out.splitlines() == ["weekly_rank", "weekly_rank_smoke"]
+    assert captured.out.splitlines() == [
+        "weekly_rank",
+        "weekly_rank_smoke",
+        "phase5_allocation_equal",
+        "phase5_allocation_group",
+        "phase5_ranking_default",
+        "phase5_ranking_capped",
+        "phase5_mean_variance",
+        "phase5_risk_parity",
+        "phase5_black_litterman",
+    ]
 
 
-def test_write_config_copies_the_selected_template(capsys: pytest.CaptureFixture[str]) -> None:
+@pytest.mark.parametrize(
+    ("template_name", "output_name"),
+    [
+        ("weekly_rank", "weekly_rank.yaml"),
+        ("phase5_black_litterman", "phase5_black_litterman.yaml"),
+    ],
+)
+def test_write_config_copies_the_selected_template(
+    capsys: pytest.CaptureFixture[str],
+    template_name: str,
+    output_name: str,
+) -> None:
     with repo_scratch_dir("write_config") as root:
-        output_path = root / "nested" / "weekly_rank.yaml"
+        output_path = root / "nested" / output_name
 
         exit_code = cli.main(
             [
                 "write-config",
                 "--name",
-                "weekly_rank",
+                template_name,
                 "--output",
                 str(output_path),
             ]
@@ -64,7 +85,7 @@ def test_write_config_copies_the_selected_template(capsys: pytest.CaptureFixture
         assert exit_code == 0
         assert expected_path.exists()
         assert expected_path.read_text(encoding="utf-8") == get_config_template_text(
-            "weekly_rank"
+            template_name
         )
         assert captured.out.strip() == str(expected_path)
 

--- a/tests/unit/test_package_resources.py
+++ b/tests/unit/test_package_resources.py
@@ -31,7 +31,17 @@ def test_public_package_version_matches_version_helper() -> None:
 
 
 def test_template_registry_exposes_expected_names() -> None:
-    assert CONFIG_TEMPLATE_NAMES == ('weekly_rank', 'weekly_rank_smoke')
+    assert CONFIG_TEMPLATE_NAMES == (
+        'weekly_rank',
+        'weekly_rank_smoke',
+        'phase5_allocation_equal',
+        'phase5_allocation_group',
+        'phase5_ranking_default',
+        'phase5_ranking_capped',
+        'phase5_mean_variance',
+        'phase5_risk_parity',
+        'phase5_black_litterman',
+    )
     assert iter_config_template_names() == CONFIG_TEMPLATE_NAMES
 
 
@@ -40,6 +50,13 @@ def test_template_registry_exposes_expected_names() -> None:
     [
         ('weekly_rank', Path('configs/experiment.weekly_rank.yaml')),
         ('weekly_rank_smoke', Path('configs/experiment.weekly_rank.smoke.yaml')),
+        ('phase5_allocation_equal', Path('configs/experiment.phase5.allocation_equal.yaml')),
+        ('phase5_allocation_group', Path('configs/experiment.phase5.allocation_group.yaml')),
+        ('phase5_ranking_default', Path('configs/experiment.phase5.ranking_default.yaml')),
+        ('phase5_ranking_capped', Path('configs/experiment.phase5.ranking_capped.yaml')),
+        ('phase5_mean_variance', Path('configs/experiment.phase5.mean_variance.yaml')),
+        ('phase5_risk_parity', Path('configs/experiment.phase5.risk_parity.yaml')),
+        ('phase5_black_litterman', Path('configs/experiment.phase5.black_litterman.yaml')),
     ],
 )
 def test_packaged_templates_match_repo_config_sources(
@@ -61,3 +78,20 @@ def test_write_config_template_resolves_relative_output_paths(
 
     assert written_path == (tmp_path / 'nested' / 'template.yaml').resolve()
     assert written_path.read_text(encoding='utf-8').startswith('experiment_name: weekly_rank_v1')
+
+
+def test_write_config_template_supports_phase5_templates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    written_path = write_config_template(
+        'phase5_black_litterman',
+        Path('nested') / 'phase5_black_litterman.yaml',
+    )
+
+    assert written_path == (tmp_path / 'nested' / 'phase5_black_litterman.yaml').resolve()
+    assert written_path.read_text(encoding='utf-8').startswith(
+        'experiment_name: phase5_black_litterman'
+    )

--- a/tests/unit/test_scenario_configs.py
+++ b/tests/unit/test_scenario_configs.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from marketlab.config import load_config
+
+SCENARIO_CONFIG_PATHS = {
+    "phase5_allocation_equal": Path("configs/experiment.phase5.allocation_equal.yaml"),
+    "phase5_allocation_group": Path("configs/experiment.phase5.allocation_group.yaml"),
+    "phase5_ranking_default": Path("configs/experiment.phase5.ranking_default.yaml"),
+    "phase5_ranking_capped": Path("configs/experiment.phase5.ranking_capped.yaml"),
+    "phase5_mean_variance": Path("configs/experiment.phase5.mean_variance.yaml"),
+    "phase5_risk_parity": Path("configs/experiment.phase5.risk_parity.yaml"),
+    "phase5_black_litterman": Path("configs/experiment.phase5.black_litterman.yaml"),
+}
+SHARED_SYMBOLS = ["VOO", "QQQ", "SMH", "XLV", "IEMG"]
+SHARED_SYMBOL_GROUPS = {
+    "VOO": "broad_market",
+    "QQQ": "growth",
+    "SMH": "growth",
+    "XLV": "defensive",
+    "IEMG": "broad_market",
+}
+SHARED_MODEL_NAMES = [
+    "logistic_regression",
+    "logistic_l1",
+    "random_forest",
+    "extra_trees",
+    "gradient_boosting",
+    "hist_gradient_boosting",
+]
+
+
+def _load_scenario(name: str):
+    return load_config(SCENARIO_CONFIG_PATHS[name])
+
+
+def _assert_shared_phase5_frame(config) -> None:
+    assert config.data.symbols == SHARED_SYMBOLS
+    assert config.data.start_date == "2018-01-01"
+    assert config.data.end_date == "2025-12-31"
+    assert config.data.interval == "1d"
+    assert config.data.cache_dir == "artifacts/data"
+    assert config.data.prepared_panel_filename == "panel.csv"
+    assert config.data.symbol_groups == SHARED_SYMBOL_GROUPS
+
+    assert config.features.return_windows == [5, 10, 20, 40]
+    assert config.features.ma_windows == [10, 20, 50]
+    assert config.features.vol_windows == [10, 20]
+    assert config.features.momentum_window == 20
+
+    assert config.target.horizon_days == 5
+    assert config.target.type == "direction"
+
+    ranking = config.portfolio.ranking
+    assert ranking.long_n == 2
+    assert ranking.short_n == 2
+    assert ranking.rebalance_frequency == "W-FRI"
+    assert ranking.weighting == "equal"
+    assert ranking.mode == "long_short"
+    assert ranking.min_score_threshold == pytest.approx(0.0)
+    assert ranking.cash_when_underfilled is False
+
+    assert config.portfolio.costs.bps_per_trade == pytest.approx(10.0)
+    assert config.baselines.buy_hold is True
+    assert config.baselines.sma.enabled is True
+    assert config.baselines.sma.fast_window == 20
+    assert config.baselines.sma.slow_window == 50
+    assert [model.name for model in config.models] == SHARED_MODEL_NAMES
+
+    walk_forward = config.evaluation.walk_forward
+    assert walk_forward.train_years == 3
+    assert walk_forward.test_months == 3
+    assert walk_forward.step_months == 3
+    assert walk_forward.min_train_rows == 100
+    assert walk_forward.min_test_rows == 20
+    assert walk_forward.min_train_positive_rate == pytest.approx(0.05)
+    assert walk_forward.min_test_positive_rate == pytest.approx(0.05)
+    assert walk_forward.embargo_periods == 1
+    assert config.evaluation.benchmark_strategy == "buy_hold"
+    assert config.evaluation.cost_sensitivity_bps == [5.0, 25.0]
+    assert config.evaluation.factor_model_path == ""
+    assert config.factor_model_path is None
+
+    assert config.artifacts.output_dir == "artifacts/runs"
+    assert config.artifacts.save_predictions is True
+    assert config.artifacts.save_metrics_csv is True
+    assert config.artifacts.save_report_md is True
+    assert config.artifacts.save_plots is True
+
+
+@pytest.mark.parametrize("scenario_name", list(SCENARIO_CONFIG_PATHS))
+def test_phase5_scenario_configs_share_the_same_comparison_frame(scenario_name: str) -> None:
+    config = _load_scenario(scenario_name)
+
+    assert config.experiment_name == scenario_name
+    _assert_shared_phase5_frame(config)
+
+
+def test_phase5_ranking_scenarios_define_only_the_intended_risk_delta() -> None:
+    default = _load_scenario("phase5_ranking_default")
+    capped = _load_scenario("phase5_ranking_capped")
+
+    assert default.baselines.allocation.enabled is False
+    assert default.baselines.optimized.enabled is False
+    assert default.portfolio.risk.max_position_weight is None
+    assert default.portfolio.risk.max_group_weight is None
+    assert default.portfolio.risk.max_long_exposure is None
+    assert default.portfolio.risk.max_short_exposure is None
+
+    assert capped.baselines.allocation.enabled is False
+    assert capped.baselines.optimized.enabled is False
+    assert capped.portfolio.risk.max_position_weight == pytest.approx(0.30)
+    assert capped.portfolio.risk.max_group_weight == pytest.approx(0.35)
+    assert capped.portfolio.risk.max_long_exposure == pytest.approx(0.60)
+    assert capped.portfolio.risk.max_short_exposure == pytest.approx(0.60)
+
+
+def test_phase5_allocation_scenarios_enable_the_expected_baselines() -> None:
+    equal = _load_scenario("phase5_allocation_equal")
+    grouped = _load_scenario("phase5_allocation_group")
+
+    assert equal.baselines.allocation.enabled is True
+    assert equal.baselines.allocation.mode == "equal"
+    assert equal.baselines.allocation.symbol_weights == {}
+    assert equal.baselines.allocation.group_weights == {}
+    assert equal.baselines.optimized.enabled is False
+
+    assert grouped.baselines.allocation.enabled is True
+    assert grouped.baselines.allocation.mode == "group_weights"
+    assert grouped.baselines.allocation.symbol_weights == {}
+    assert grouped.baselines.allocation.group_weights == {
+        "broad_market": pytest.approx(0.50),
+        "growth": pytest.approx(0.30),
+        "defensive": pytest.approx(0.20),
+    }
+    assert grouped.baselines.optimized.enabled is False
+
+
+def test_phase5_optimized_scenarios_enable_the_expected_methods() -> None:
+    mean_variance = _load_scenario("phase5_mean_variance")
+    risk_parity = _load_scenario("phase5_risk_parity")
+    black_litterman = _load_scenario("phase5_black_litterman")
+
+    for config, method in (
+        (mean_variance, "mean_variance"),
+        (risk_parity, "risk_parity"),
+        (black_litterman, "black_litterman"),
+    ):
+        optimized = config.baselines.optimized
+        assert config.baselines.allocation.enabled is False
+        assert optimized.enabled is True
+        assert optimized.method == method
+        assert optimized.lookback_days == 252
+        assert optimized.rebalance_frequency == "W-FRI"
+        assert optimized.covariance_estimator == "sample"
+        assert optimized.expected_return_source == "historical_mean"
+        assert optimized.long_only is True
+        assert optimized.target_gross_exposure == pytest.approx(1.0)
+        assert optimized.risk_aversion == pytest.approx(1.0)
+
+    assert mean_variance.baselines.optimized.equilibrium_weights == {}
+    assert mean_variance.baselines.optimized.views == []
+    assert risk_parity.baselines.optimized.equilibrium_weights == {}
+    assert risk_parity.baselines.optimized.views == []
+
+    optimized = black_litterman.baselines.optimized
+    assert optimized.equilibrium_weights == {
+        "VOO": pytest.approx(0.20),
+        "QQQ": pytest.approx(0.20),
+        "SMH": pytest.approx(0.20),
+        "XLV": pytest.approx(0.20),
+        "IEMG": pytest.approx(0.20),
+    }
+    assert optimized.tau == pytest.approx(0.05)
+    assert len(optimized.views) == 2
+    assert optimized.views[0].name == "growth_over_defensive"
+    assert optimized.views[0].weights == {
+        "QQQ": pytest.approx(1.0),
+        "SMH": pytest.approx(1.0),
+        "XLV": pytest.approx(-1.0),
+    }
+    assert optimized.views[0].view_return == pytest.approx(0.0010)
+    assert optimized.views[1].name == "core_over_international"
+    assert optimized.views[1].weights == {
+        "VOO": pytest.approx(1.0),
+        "IEMG": pytest.approx(-1.0),
+    }
+    assert optimized.views[1].view_return == pytest.approx(0.0005)


### PR DESCRIPTION
## Summary
- add the canonical Phase 5 scenario pack as seven checked-in experiment configs under `configs/`
- expose the same scenarios through packaged config templates for `marketlab list-configs` and `marketlab write-config`
- add scenario-pack coverage, package smoke coverage, and docs for fair one-config-at-a-time comparisons

## Validation
- `python -m pytest -q tests/unit/test_config.py tests/unit/test_scenario_configs.py tests/unit/test_package_resources.py tests/unit/test_cli.py --basetemp .pytest_tmp_issue44_unit_push`
- `python -m ruff check .`
- `python -m mkdocs build --strict`
- `python -m build --no-isolation`
- `python scripts/check_package.py`
- `py -3.12 -m tox -e package` *(fails locally because that interpreter does not have `tox` installed)*
