### PR TITLE
feat: add MarketLab MCP server and Docker sidecar

### DIFF
--- a/.github/issue-seeds/phase6-mcp.json
+++ b/.github/issue-seeds/phase6-mcp.json
@@ -1,0 +1,69 @@
+{
+  "project": {
+    "number": 3
+  },
+  "labels": [
+    {
+      "name": "phase-6",
+      "color": "1d76db",
+      "description": "Phase 6 roadmap work for the MCP server and Docker LLM interface."
+    },
+    {
+      "name": "track:platform",
+      "color": "5319e7",
+      "description": "Platform, runtime, packaging, and container integration work."
+    },
+    {
+      "name": "priority:p0",
+      "color": "b60205",
+      "description": "Highest-priority roadmap work for the current phase."
+    },
+    {
+      "name": "priority:p1",
+      "color": "d93f0b",
+      "description": "Important follow-on work for the current phase."
+    },
+    {
+      "name": "track:docs",
+      "color": "0e8a16",
+      "description": "Documentation, guides, and developer-experience work."
+    },
+    {
+      "name": "track:reporting",
+      "color": "fbca04",
+      "description": "Reporting, artifact inspection, and review-surface work."
+    }
+  ],
+  "issues": [
+    {
+      "title": "Phase 6: MCP server and docker-deployable LLM interface for MarketLab",
+      "labels": ["phase-6", "priority:p0", "track:platform"],
+      "body": "## Summary\nAdd a standard Model Context Protocol server so an LLM can use MarketLab through a Docker sidecar and a generic stdio bridge.\n\n## Scope\n- standard MCP stdio server\n- sandboxed workspace, artifact, and optional read-only repo mounts\n- config authoring, queued job control, and artifact inspection tools\n- Docker deployment docs and required CI coverage\n\n## Non-goals\n- no HTTP or SSE transport in v1\n- no multi-user session management\n- no arbitrary repo edits\n- no model-binary management\n- no time-series comparison surface in v1\n"
+    },
+    {
+      "title": "Add MarketLab MCP server scaffold, packaging, and workspace sandbox",
+      "labels": ["phase-6", "priority:p0", "track:platform"],
+      "body": "## Scope\n- add the `marketlab[mcp]` optional dependency group\n- add the `marketlab-mcp` entrypoint\n- bootstrap the stdio MCP server\n- add workspace and artifact sandbox rules\n- add read-only repo import rules\n- add CLI-subprocess execution foundation\n- keep one active job plus a FIFO queue per session\n- add a reusable stdio MCP test harness\n\n## Review\n- critic\n- qa\n"
+    },
+    {
+      "title": "Add template and full-schema config authoring tools to the MarketLab MCP server",
+      "labels": ["phase-6", "priority:p0", "track:platform"],
+      "body": "## Scope\n- template listing\n- template export into the workspace\n- repo config copy into the workspace\n- structured config reads\n- recursive persisted-YAML patch operations\n- validation through the existing MarketLab loader\n\n## Depends on\n- Add MarketLab MCP server scaffold, packaging, and workspace sandbox\n\n## Review\n- qa\n"
+    },
+    {
+      "title": "Add async workflow execution, confirmation gates, and job logs to the MarketLab MCP server",
+      "labels": ["phase-6", "priority:p0", "track:platform"],
+      "body": "## Scope\n- implement `marketlab_plan_run` and `marketlab_start_job`\n- queued execution for `prepare-data`, `backtest`, `train-models`, and `run-experiment`\n- offline gating when cache or panel data is missing\n- status inspection, log tails, and cancel behavior\n\n## Depends on\n- Add MarketLab MCP server scaffold, packaging, and workspace sandbox\n- Add template and full-schema config authoring tools to the MarketLab MCP server\n\n## Review\n- financial-expert\n- critic\n- qa\n"
+    },
+    {
+      "title": "Add artifact inspection, plot retrieval, and run comparison tools to the MarketLab MCP server",
+      "labels": ["phase-6", "priority:p1", "track:platform", "track:reporting"],
+      "body": "## Scope\n- run listing and run summaries\n- artifact catalog tools\n- structured CSV and Markdown readers\n- plot retrieval for review images\n- compact summary-table comparison across runs\n\n## Depends on\n- Add async workflow execution, confirmation gates, and job logs to the MarketLab MCP server\n\n## Review\n- qa\n"
+    },
+    {
+      "title": "Add Docker sidecar deployment docs, compose example, and required MCP CI",
+      "labels": ["phase-6", "priority:p1", "track:platform", "track:docs"],
+      "body": "## Scope\n- install `marketlab[mcp]` in the Docker image\n- add a compose example for the MCP sidecar container\n- document the generic `docker exec -i` bridge\n- verify the installed `marketlab-mcp` entrypoint in package smoke\n- add a required Dockerized MCP CI lane\n\n## Depends on\n- Add MarketLab MCP server scaffold, packaging, and workspace sandbox\n\n## Review\n- critic\n- qa\n"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,29 @@ jobs:
         run: uv sync --group dev
       - name: Run offline integration suite
         run: uv run tox -e integration
+
+  mcp-docker:
+    name: mcp-docker
+    runs-on: ubuntu-latest
+    env:
+      RUNNER_PYTHON: python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            tox.ini
+            mkdocs.yml
+            Dockerfile
+      - name: Sync development dependencies
+        run: uv sync --group dev
+      - name: Run Dockerized MCP smoke
+        run: uv run tox -e mcp-docker

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pycache__/
 build/
 dist/
 site/
+.vscode/mcp.json
+workspace/
 pytest-cache-files-*/
 *.egg-info/
 artifacts/*

--- a/.vscode/mcp.json.example
+++ b/.vscode/mcp.json.example
@@ -1,0 +1,37 @@
+{
+  "servers": {
+    "marketlab-docker-offline": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/artifacts",
+        "--repo-root",
+        "/app/repo"
+      ]
+    },
+    "marketlab-docker-online": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/artifacts",
+        "--repo-root",
+        "/app/repo",
+        "--allow-network"
+      ]
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY pyproject.toml README.md ./
 COPY src ./src
 
 RUN python -m pip install --no-cache-dir --upgrade pip \
-    && python -m pip install --no-cache-dir .
+    && python -m pip install --no-cache-dir ".[mcp]"
 
 
 FROM python:3.12-slim AS runtime
@@ -33,7 +33,7 @@ WORKDIR /app
 COPY --from=builder /opt/venv /opt/venv
 COPY configs ./configs
 
-RUN mkdir -p /app/artifacts \
+RUN mkdir -p /app/artifacts /app/workspace \
     && chown -R appuser:appuser /app
 
 USER appuser

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # MarketLab
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow: weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, and reviewable artifact summaries.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, and reviewable artifact summaries.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
-See [docs/PLAN.md](docs/PLAN.md) for the current project status and Phase 5 direction.
+See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.
+See [docs/codex-mcp.md](docs/codex-mcp.md) for attaching the Docker-packaged MCP server to a new Codex session.
+See [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md) for the VS Code stable + GitHub Copilot connection path.
+See [docs/PLAN.md](docs/PLAN.md) for the current project status and Phase 6 direction.
 
 ## Current Commands
 
@@ -16,6 +19,12 @@ python scripts/run_marketlab.py run-experiment --config configs/experiment.weekl
 ```
 
 `python scripts/run_marketlab.py ...` is the canonical local invocation path because it always resolves to the source tree under `src/`.
+
+For LLM-driven use, the packaged MCP entrypoint is:
+
+```bash
+marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-root .
+```
 
 ## What Each Command Does
 
@@ -332,6 +341,17 @@ marketlab run-experiment --config weekly_rank.yaml
 
 `list-configs` shows the bundled example templates, and `write-config` exports one of those templates into your working directory. That keeps the installed package self-contained without requiring a checkout of this repository.
 
+## MCP Quickstart
+
+Install the optional MCP surface:
+
+```bash
+python -m pip install "marketlab[mcp]"
+marketlab-mcp --help
+```
+
+The MCP server is stdio-only in Phase 6. It exposes sandboxed config authoring, queued workflow execution, and artifact inspection tools for generic MCP clients.
+
 ## Canonical Phase 5 Scenario Pack
 
 MarketLab now ships a canonical Phase 5 scenario pack as both checked-in repo configs and installed-package templates.
@@ -381,13 +401,14 @@ py -3.12 -m tox -e docs
 py -3.12 -m tox -e py312
 py -3.12 -m tox -e package
 py -3.12 -m tox -e integration
+py -3.12 -m tox -e mcp-docker
 py -3.12 -m tox -e preflight-fast
 py -3.12 -m tox -e preflight-slow
 py -3.12 -m tox -e preflight
 py -3.12 scripts/profile_validation.py --env package --env integration
 ```
 
-Use `py -3.12 -m tox -e preflight` as the canonical local pre-push gate so local validation matches the Python version used in GitHub Actions. For normal iteration, prefer the specific lane you touched or `preflight-fast`; leave `preflight-slow` and the full `preflight` run for packaging, artifact, or final push checks.
+Use `py -3.12 -m tox -e preflight` as the canonical local pre-push gate so local validation matches the Python version used in GitHub Actions. For normal iteration, prefer the specific lane you touched or `preflight-fast`; leave `preflight-slow` and the full `preflight` run for packaging, artifact, or final push checks. Run `py -3.12 -m tox -e mcp-docker` separately when Docker is available and the change touches the MCP container path.
 
 Current measured local Windows budgets are roughly:
 
@@ -442,6 +463,55 @@ docker run --rm marketlab-cli backtest --config configs/experiment.weekly_rank.s
 ```
 
 The container uses the installed `marketlab` console script as its entrypoint. Keep using `python scripts/run_marketlab.py ...` for local source-tree development; the Docker image exists to validate the installed package path and to support manual GitHub Actions runs.
+
+## Dockerized MCP Sidecar
+
+The same image now also installs the MCP extra, so `marketlab-mcp` is available inside the container.
+
+Start a long-lived container:
+
+```bash
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
+Then launch one stdio session through `docker exec -i`:
+
+```bash
+docker exec -i marketlab-mcp \
+  marketlab-mcp \
+  --workspace-root /app/workspace \
+  --artifact-root /app/artifacts \
+  --repo-root /app/repo
+```
+
+This keeps the repo mount read-only and makes the workspace and artifact mounts the only writable roots.
+
+## VS Code Copilot MCP Setup
+
+The supported editor path is VS Code stable with GitHub Copilot Chat using workspace-level `mcp.json`.
+
+The repo includes a checked-in sample:
+
+- `.vscode/mcp.json.example`
+
+Copy it to `.vscode/mcp.json`, start the MCP sidecar with `docker compose -f docker/compose.mcp.yml up -d --build`, then connect Copilot to either:
+
+- `marketlab-docker-offline`
+- `marketlab-docker-online`
+
+The offline entry is the default review path. The online entry adds `--allow-network` for live data downloads. For the full setup flow and manual verification checklist, see [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md).
+
+## Codex MCP Setup
+
+Codex reads MCP server definitions from user-local `~/.codex/config.toml`.
+
+The repo includes a checked-in example snippet:
+
+- `docs/codex.config.toml.example`
+
+Copy the `mcp_servers` entries into your user-local Codex config, start the MCP sidecar with `docker compose -f docker/compose.mcp.yml up -d --build`, then start a new Codex session and verify the attachment with `/mcp`, `/debug-config`, and `marketlab_server_info`.
+
+Use `marketlab` as the default offline entry. `marketlab_online` adds `--allow-network` for live data downloads. For the full setup flow and troubleshooting notes, see [docs/codex-mcp.md](docs/codex-mcp.md).
 
 ## Manual Docker Runner Workflow
 

--- a/docker/compose.mcp.yml
+++ b/docker/compose.mcp.yml
@@ -1,0 +1,14 @@
+services:
+  marketlab-mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: marketlab-mcp:local
+    container_name: marketlab-mcp
+    restart: unless-stopped
+    entrypoint: ["sleep", "infinity"]
+    working_dir: /app
+    volumes:
+      - ../workspace:/app/workspace
+      - ../artifacts:/app/artifacts
+      - ..:/app/repo:ro

--- a/docker/compose.mcp.yml
+++ b/docker/compose.mcp.yml
@@ -6,6 +6,7 @@ services:
     image: marketlab-mcp:local
     container_name: marketlab-mcp
     restart: unless-stopped
+    user: "${MARKETLAB_UID:-1000}:${MARKETLAB_GID:-1000}"
     entrypoint: ["sleep", "infinity"]
     working_dir: /app
     volumes:

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,15 +2,16 @@
 
 ## Current State
 
-Phases 1 through 4 are complete.
+Phases 1 through 5 are complete.
 
 MarketLab is a public research MVP with:
 
 - an installable Python package and packaged CLI
+- a Docker-deployable MCP server surface for LLM-driven workflow access
 - reproducible local and CI validation
 - a Dockerized manual runner workflow
 - release automation and a batched release path
-- Phase 4 evaluation, diagnostics, and strategy-surface improvements
+- richer Phase 5 baseline, diagnostics, and scenario-pack coverage
 
 The project now supports a small, reviewable end-to-end research workflow rather than a local-only scaffold.
 
@@ -22,17 +23,20 @@ The project now supports a small, reviewable end-to-end research workflow rather
 - `marketlab run-experiment --config ...`
 - `marketlab list-configs`
 - `marketlab write-config --name ... --output ...`
+- `marketlab-mcp --workspace-root ... --artifact-root ...`
 
 Current workflow surface:
 
 - repo-local execution through `python scripts/run_marketlab.py ...`
 - installed-package execution through the packaged `marketlab` CLI
+- generic stdio MCP execution through the packaged `marketlab-mcp` server
 - baseline and ML strategy comparison on the same shared out-of-sample window
 - walk-forward fold diagnostics for accepted and skipped candidates
 - ranking-aware, downside-aware, calibration, and threshold review artifacts
 - long-short, long-only, and confidence-gated cash-underfilled execution modes
 - lightweight sklearn comparison baseline
 - CSV, plot, and Markdown reporting artifacts
+- sandboxed config authoring, async job control, and run-artifact inspection for MCP clients
 
 ## Phase 4 Outcomes Worth Keeping
 
@@ -46,23 +50,24 @@ The most important Phase 4 outcomes were about research quality rather than head
 
 The key lesson from Phase 4 is that score quality, realized strategy outcomes, and overall research robustness are separate questions. Phase 4 improved how clearly the repo answers those questions; it did not, by itself, establish durable trading edge.
 
-## Phase 5 Direction
+## Phase 6 Direction
 
-Phase 5 should focus on richer portfolio risk controls and exposure-aware comparisons.
+Phase 6 should productize the current workflow for LLM-driven use through a Docker-friendly MCP server.
 
 Priority direction:
 
-- add risk-aware portfolio controls on top of the current strategy modes
-- compare strategies with explicit attention to exposure differences
-- keep the current lightweight dependency posture
-- avoid starting with another round of model expansion
+- keep the protocol surface tools-first and generic-client-friendly
+- make config authoring and execution safe through workspace sandboxing and confirmation gates
+- preserve the installed CLI as the execution backend so MCP behavior matches the packaged product
+- keep Docker as the deployment wrapper instead of introducing a second runtime architecture
 
-## Phase 5 Candidate Workstreams
+## Phase 6 Candidate Workstreams
 
-- risk controls in portfolio construction rather than only score gating
-- exposure-aware reporting and comparisons across long-short, long-only, and cash-heavy variants
-- turnover and cost sensitivity as first-class parts of strategy interpretation
-- scenario configs that compare the same strategy ideas under a common risk framing
+- MCP server scaffold and workspace sandboxing
+- template-driven config authoring and validation tools
+- async job planning, queued execution, and log tails
+- artifact inspection, plot retrieval, and compact run comparison
+- Docker sidecar docs and required MCP CI
 
 ## Deferred
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input scaffolding, additive factor-attribution and covariance diagnostics, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input scaffolding, additive factor-attribution and covariance diagnostics, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, a Docker-deployable MCP server surface, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -25,6 +25,7 @@ This document ties the current pieces together and records the working rules tha
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
   - required PR CI for lint, docs, packaging, unit tests, and offline integration tests
   - Docker packaging for the installed CLI plus a manual GitHub Actions Docker runner
+  - a stdio MCP server with sandboxed config authoring, queued workflow control, and artifact inspection
   - release automation with a monthly-batching Release PR and a PyPI publish path
   - fixture-backed tests and a real-data E2E runner that validates baseline, training, experiment, and analytics artifact sets
 - Deferred to later sprints:
@@ -41,6 +42,14 @@ This document ties the current pieces together and records the working rules tha
   - `marketlab list-configs`
   - `marketlab write-config --name weekly_rank --output weekly_rank.yaml`
   - `marketlab run-experiment --config weekly_rank.yaml`
+- MCP bootstrap:
+  - `marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-root .`
+- Dockerized MCP sidecar:
+  - `docker compose -f docker/compose.mcp.yml up -d --build`
+  - `docker exec -i marketlab-mcp marketlab-mcp --workspace-root /app/workspace --artifact-root /app/artifacts --repo-root /app/repo`
+  - Codex helper snippet: `docs/codex.config.toml.example`
+  - workspace helper file: `.vscode/mcp.json.example`
+  - documented clients: Codex and VS Code stable with GitHub Copilot Chat
 - Local Docker validation:
   - `docker build -t marketlab-cli .`
   - `docker run --rm marketlab-cli --help`
@@ -62,7 +71,7 @@ The repo uses a `src/` layout. That means `python -m marketlab.cli ...` is not a
 
 The installed package uses bundled example config templates so a pip-installed user can bootstrap a working run config without needing the repository checkout. That keeps the distribution self-contained while preserving the repo-local launcher as the default development path.
 
-The Docker image deliberately uses the installed `marketlab` console script instead of the repo-local launcher. That split keeps local development pointed at the source tree while the container validates the packaged CLI path.
+The Docker image deliberately uses the installed package entrypoints instead of the repo-local launcher. That split keeps local development pointed at the source tree while the container validates the packaged CLI and MCP paths.
 
 ## Validation Flow
 

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -25,6 +25,14 @@ From the repo root:
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
+On Linux, export the host UID/GID before starting the sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container:
+
+```bash
+export MARKETLAB_UID="$(id -u)"
+export MARKETLAB_GID="$(id -g)"
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
 This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
 
 If Docker access fails on Windows with a named-pipe permission error, fix Docker Desktop / daemon access first. Codex cannot attach the MCP server until `docker ps` works for the current user.
@@ -94,6 +102,7 @@ After updating `~/.codex/config.toml`, start a new Codex session in this repo an
 - If `/debug-config` does not show the new server, check for a syntax error in `config.toml`.
 - If Codex cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
 - If Docker access fails with a Windows named-pipe permission error, fix Docker daemon access for the current user before retrying.
+- If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If job planning says network is required, switch to `marketlab_online` or preload the raw cache / prepared panel.
 - If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
 - If the repo copy tool fails, verify the repo mount is present at `/app/repo`.

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -1,0 +1,105 @@
+# Codex MCP Setup
+
+This guide documents the Codex path for attaching the Docker-packaged `marketlab-mcp` server to a new Codex session.
+
+The server contract stays the same as the VS Code Copilot path:
+
+- the server is still `marketlab-mcp`
+- transport is still stdio only
+- the Docker container is still the packaging and volume boundary
+- Codex attaches the server through `mcp_servers` in `config.toml`
+
+## Supported Shape
+
+- Codex CLI / Chat session with MCP support enabled
+- one MCP session per `docker exec -i` process
+- writable `/app/workspace` and `/app/artifacts`
+- read-only `/app/repo`
+- offline-safe by default, with an explicit network-enabled alternative
+
+## Start The Container
+
+From the repo root:
+
+```bash
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
+This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
+
+If Docker access fails on Windows with a named-pipe permission error, fix Docker Desktop / daemon access first. Codex cannot attach the MCP server until `docker ps` works for the current user.
+
+## Add The Codex MCP Config
+
+Codex reads MCP server definitions from `~/.codex/config.toml`. The repo includes a checked-in example snippet:
+
+- `docs/codex.config.toml.example`
+
+Copy the `mcp_servers` entries from that file into your user-level Codex config. Keep this in user-local Codex config rather than committing a repo-local `.codex/config.toml`.
+
+The example defines two servers:
+
+- `marketlab`: offline default, no `--allow-network`
+- `marketlab_online`: adds `--allow-network` for live data fetches
+
+The offline entry should be your default for cached-panel or cached-raw workflows. Use the online entry only when you intend to let Codex trigger data downloads.
+
+## Sample Config Contract
+
+The checked-in example uses Codex `config.toml` `mcp_servers` entries with the same Docker foreground stdio rule:
+
+```toml
+[mcp_servers.marketlab]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/artifacts",
+  "--repo-root",
+  "/app/repo",
+]
+```
+
+Do not use `docker exec -d`. Codex MCP stdio servers must stay attached to the foreground process.
+
+## Workspace Rules
+
+- Keep the repo mount read-only.
+- Create and patch configs inside `/app/workspace`.
+- Write all run outputs under `/app/artifacts`.
+- Use `marketlab_copy_repo_config` when you want to start from a tracked repo config.
+- Do not point Codex at a repo-writable container flow by default.
+
+## Manual Verification Checklist
+
+After updating `~/.codex/config.toml`, start a new Codex session in this repo and verify:
+
+1. Type `/mcp` and confirm the `marketlab` server is available.
+2. Type `/debug-config` and verify the active config includes the `mcp_servers.marketlab` entry you added.
+3. Call `marketlab_server_info` and verify the response reports `transport=stdio` and `allow_network=false`.
+4. Call `marketlab_workspace_info` and verify the mounted workspace and artifact roots match `/app/workspace` and `/app/artifacts`.
+5. Create one config from a template with `marketlab_create_config_from_template`.
+6. Validate that config with `marketlab_validate_config`.
+7. Run one offline-safe job from cached data through `marketlab_plan_run` and `marketlab_start_job`.
+8. Inspect the finished run with `marketlab_get_run_summary` and one of the artifact readers.
+
+## Troubleshooting
+
+- If Codex does not show the server in `/mcp`, restart Codex after editing `~/.codex/config.toml`.
+- If `/debug-config` does not show the new server, check for a syntax error in `config.toml`.
+- If Codex cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
+- If Docker access fails with a Windows named-pipe permission error, fix Docker daemon access for the current user before retrying.
+- If job planning says network is required, switch to `marketlab_online` or preload the raw cache / prepared panel.
+- If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
+- If the repo copy tool fails, verify the repo mount is present at `/app/repo`.
+
+## Operational Defaults
+
+- Use `marketlab` as the default offline Codex attachment.
+- Keep credentials on the host side; do not bake secrets into the image or into repo-tracked config files.
+- Treat the Docker stdio command as the single source of truth across Codex and VS Code clients.

--- a/docs/codex.config.toml.example
+++ b/docs/codex.config.toml.example
@@ -1,0 +1,36 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+[mcp_servers.marketlab]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/artifacts",
+  "--repo-root",
+  "/app/repo",
+]
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+
+[mcp_servers.marketlab_online]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/artifacts",
+  "--repo-root",
+  "/app/repo",
+  "--allow-network",
+]
+startup_timeout_sec = 20
+tool_timeout_sec = 120

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -77,6 +77,14 @@ Start the container:
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
+On Linux, export the host UID/GID first so the container can write to the bind-mounted `workspace/` and `artifacts/` directories:
+
+```bash
+export MARKETLAB_UID="$(id -u)"
+export MARKETLAB_GID="$(id -g)"
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
 Then launch one MCP stdio session through `docker exec -i`:
 
 ```bash
@@ -91,6 +99,8 @@ This is the intended bridge for generic MCP clients. The client owns the stdio s
 
 For the Codex setup flow, see [Codex MCP Setup](codex-mcp.md).
 For the supported VS Code stable + GitHub Copilot setup, see [VS Code Copilot MCP Setup](mcp-vscode-copilot.md).
+
+The checked-in compose example runs the container as `MARKETLAB_UID:MARKETLAB_GID` so Linux bind mounts stay writable. Docker Desktop on Windows usually does not need those variables.
 
 ## Offline And Network Rules
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,143 @@
+# MCP Server
+
+MarketLab now includes a stdio Model Context Protocol server exposed by the `marketlab-mcp` entrypoint.
+
+Phase 6 keeps the server deliberately narrow:
+
+- stdio transport only
+- one user session per server process
+- tools only, with no MCP resources or prompts
+- repo mounts are read-only
+- workspace and artifact mounts are the only writable roots
+- long-running workflows execute through the installed `marketlab` CLI in subprocesses
+
+## Tool Surface
+
+Admin:
+
+- `marketlab_server_info`
+- `marketlab_workspace_info`
+
+Configs:
+
+- `marketlab_list_templates`
+- `marketlab_create_config_from_template`
+- `marketlab_copy_repo_config`
+- `marketlab_read_config`
+- `marketlab_patch_config`
+- `marketlab_validate_config`
+
+Jobs:
+
+- `marketlab_plan_run`
+- `marketlab_start_job`
+- `marketlab_list_jobs`
+- `marketlab_get_job_status`
+- `marketlab_tail_job_logs`
+- `marketlab_cancel_job`
+
+Artifacts:
+
+- `marketlab_list_runs`
+- `marketlab_get_run_summary`
+- `marketlab_list_artifacts`
+- `marketlab_read_table_artifact`
+- `marketlab_read_text_artifact`
+- `marketlab_get_plot_artifact`
+- `marketlab_compare_runs`
+
+## Local Install
+
+Install the MCP extra:
+
+```bash
+python -m pip install -e ".[dev]"
+marketlab-mcp --help
+```
+
+For a minimal local source-tree session:
+
+```bash
+marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-root .
+```
+
+## Docker Sidecar
+
+The generic deployment shape is a long-lived container plus one `docker exec -i` process per LLM session. The container does not keep a shared MCP daemon running.
+
+Example helper files:
+
+- `docker/compose.mcp.yml`
+- `docs/codex.config.toml.example`
+- `.vscode/mcp.json.example`
+
+Start the container:
+
+```bash
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
+Then launch one MCP stdio session through `docker exec -i`:
+
+```bash
+docker exec -i marketlab-mcp \
+  marketlab-mcp \
+  --workspace-root /app/workspace \
+  --artifact-root /app/artifacts \
+  --repo-root /app/repo
+```
+
+This is the intended bridge for generic MCP clients. The client owns the stdio session lifetime; the container just provides the packaged `marketlab-mcp` executable plus the mounted workspace and artifact volumes.
+
+For the Codex setup flow, see [Codex MCP Setup](codex-mcp.md).
+For the supported VS Code stable + GitHub Copilot setup, see [VS Code Copilot MCP Setup](mcp-vscode-copilot.md).
+
+## Offline And Network Rules
+
+`marketlab_plan_run` is the confirmation gate before execution.
+
+- A plan is required before `marketlab_start_job`.
+- The server allows one active job plus a FIFO queue for the session.
+- When `--allow-network` is not set, plans that would require data downloads are rejected.
+- If a prepared panel or raw symbol cache is already available inside the workspace, offline execution is allowed.
+
+## Config Authoring Rules
+
+- Configs are always persisted as real YAML files in the workspace.
+- Repo configs can be copied into the workspace, but they are never edited in place.
+- Validation reuses the existing MarketLab config loader and adds sandbox checks for writable and readable paths.
+
+## VS Code Copilot Contract
+
+The checked-in VS Code helper file is `.vscode/mcp.json.example`. Copy it to `.vscode/mcp.json` in your local checkout and reload VS Code.
+
+The sample exposes two Docker-backed stdio entries:
+
+- `marketlab-docker-offline`
+- `marketlab-docker-online`
+
+The only difference is whether the server process receives `--allow-network`.
+
+## Codex Contract
+
+Codex reads MCP server definitions from `~/.codex/config.toml`.
+
+The checked-in Codex helper snippet is `docs/codex.config.toml.example`. Copy its `mcp_servers` entries into your user-local Codex config and start a new session after the `marketlab-mcp` container is running.
+
+The sample exposes two Docker-backed stdio entries:
+
+- `marketlab`
+- `marketlab_online`
+
+The only difference is whether the server process receives `--allow-network`.
+
+## Comparison Scope
+
+`marketlab_compare_runs` stays intentionally compact in v1. It compares:
+
+- `metrics.csv`
+- `strategy_summary.csv`
+- `model_summary.csv`
+- Markdown section headings from `report.md`
+
+Time-series comparisons, model binaries, and arbitrary file diffs remain out of scope.

--- a/docs/mcp-vscode-copilot.md
+++ b/docs/mcp-vscode-copilot.md
@@ -1,0 +1,111 @@
+# VS Code Copilot MCP Setup
+
+This guide documents the supported VS Code stable path for connecting GitHub Copilot Chat to the Docker-packaged `marketlab-mcp` server.
+
+The design stays generic-MCP-first:
+
+- the server is still `marketlab-mcp`
+- transport is still stdio only
+- the Docker container is just a packaging and volume boundary
+- VS Code Copilot is a documented client, not a special server mode
+
+## Supported Shape
+
+- VS Code stable with GitHub Copilot Chat
+- one MCP session per `docker exec -i` process
+- writable `/app/workspace` and `/app/artifacts`
+- optional read-only `/app/repo`
+- offline-safe by default, with an explicit network-enabled alternative
+
+## Start The Container
+
+From the repo root:
+
+```bash
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
+This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
+
+## Add The VS Code MCP Config
+
+Copy the checked-in sample file:
+
+```bash
+cp .vscode/mcp.json.example .vscode/mcp.json
+```
+
+On Windows PowerShell:
+
+```powershell
+Copy-Item .vscode\mcp.json.example .vscode\mcp.json
+```
+
+The sample defines two servers:
+
+- `marketlab-docker-offline`: no `--allow-network` flag
+- `marketlab-docker-online`: adds `--allow-network` for live data fetches
+
+The offline entry should be your default for cached-panel or cached-raw workflows. Use the online entry only when you intend to let Copilot trigger data downloads.
+
+## Sample Config Contract
+
+The checked-in sample uses the current VS Code `mcp.json` workspace format and the Docker foreground stdio rule:
+
+```json
+{
+  "servers": {
+    "marketlab-docker-offline": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/artifacts",
+        "--repo-root",
+        "/app/repo"
+      ]
+    }
+  }
+}
+```
+
+Do not use `docker exec -d`. VS Code MCP stdio servers must stay attached to the foreground process.
+
+## Workspace Rules
+
+- Keep the repo mount read-only.
+- Create and patch configs inside `/app/workspace`.
+- Write all run outputs under `/app/artifacts`.
+- Use `marketlab_copy_repo_config` when you want to start from a tracked repo config.
+- Do not point Copilot at a repo-writable container flow by default.
+
+## Manual Verification Checklist
+
+After copying `.vscode/mcp.json` and reloading VS Code:
+
+1. Open Copilot Chat in agent mode and confirm the `marketlab-docker-offline` server is available.
+2. Call `marketlab_server_info` and verify the response reports `transport=stdio`.
+3. Call `marketlab_workspace_info` and verify the mounted workspace and artifact roots match `/app/workspace` and `/app/artifacts`.
+4. Create one config from a template with `marketlab_create_config_from_template`.
+5. Validate that config with `marketlab_validate_config`.
+6. Run one offline-safe job from cached data through `marketlab_plan_run` and `marketlab_start_job`.
+7. Inspect the finished run with `marketlab_get_run_summary` and one of the artifact readers.
+
+## Troubleshooting
+
+- If VS Code cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
+- If Copilot connects but job planning says network is required, switch to the online server or preload the raw cache / prepared panel.
+- If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
+- If the repo copy tool fails, verify the repo mount is present at `/app/repo`.
+
+## Operational Defaults
+
+- Use `marketlab-docker-offline` for normal review and cached-run flows.
+- Keep credentials on the host side; do not bake secrets into the image or commit them into `.vscode/mcp.json`.
+- Treat this as the supported VS Code stable path. Other MCP clients can still reuse the same `docker exec -i marketlab-mcp ...` contract.

--- a/docs/mcp-vscode-copilot.md
+++ b/docs/mcp-vscode-copilot.md
@@ -25,6 +25,14 @@ From the repo root:
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
+On Linux, export the host UID/GID before starting the sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container:
+
+```bash
+export MARKETLAB_UID="$(id -u)"
+export MARKETLAB_GID="$(id -g)"
+docker compose -f docker/compose.mcp.yml up -d --build
+```
+
 This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
 
 ## Add The VS Code MCP Config
@@ -101,6 +109,7 @@ After copying `.vscode/mcp.json` and reloading VS Code:
 
 - If VS Code cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
 - If Copilot connects but job planning says network is required, switch to the online server or preload the raw cache / prepared panel.
+- If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
 - If the repo copy tool fails, verify the repo mount is present at `/app/repo`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,9 @@ nav:
   - How It Works: how-it-works.md
   - Architecture: architecture.md
   - Phase 5 Scenarios: phase5-scenarios.md
+  - MCP Server: mcp-server.md
+  - Codex MCP: codex-mcp.md
+  - VS Code Copilot MCP: mcp-vscode-copilot.md
   - Plan: PLAN.md
 plugins:
   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,14 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "build>=1.2",
+  "mcp>=1.27,<2",
   "mkdocs>=1.6",
   "pytest>=8.0",
   "ruff>=0.11",
   "tox>=4.0",
+]
+mcp = [
+  "mcp>=1.27,<2",
 ]
 
 [project.urls]
@@ -46,6 +50,7 @@ Issues = "https://github.com/ricardogr07/market-lab/issues"
 [dependency-groups]
 dev = [
   "build>=1.2",
+  "mcp>=1.27,<2",
   "mkdocs>=1.6",
   "pytest>=8.0",
   "ruff>=0.11",
@@ -54,6 +59,7 @@ dev = [
 
 [project.scripts]
 marketlab = "marketlab.cli:main"
+marketlab-mcp = "marketlab.mcp.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/scripts/check_mcp_docker.py
+++ b/scripts/check_mcp_docker.py
@@ -50,6 +50,14 @@ def _call_docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[
     return _run(["docker", *args], cwd=ROOT, check=check)
 
 
+def _docker_user_args() -> list[str]:
+    if os.name == "nt":
+        return []
+    if not hasattr(os, "getuid") or not hasattr(os, "getgid"):
+        return []
+    return ["--user", f"{os.getuid()}:{os.getgid()}"]
+
+
 def _load_vscode_server_config(server_name: str) -> dict[str, object]:
     document = json.loads(VSCODE_SAMPLE_PATH.read_text(encoding="utf-8"))
     return document["servers"][server_name]
@@ -237,6 +245,7 @@ def main() -> int:
             "--rm",
             "--name",
             CONTAINER_NAME,
+            *_docker_user_args(),
             "-v",
             f"{workspace.resolve()}:/app/workspace",
             "-v",

--- a/scripts/check_mcp_docker.py
+++ b/scripts/check_mcp_docker.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+import anyio
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRATCH_DIR = ROOT / ".mcp-docker-smoke"
+IMAGE_TAG = "marketlab-mcp:smoke"
+CONTAINER_NAME = "marketlab-mcp-smoke"
+VSCODE_SAMPLE_PATH = ROOT / ".vscode" / "mcp.json.example"
+
+
+def _fixture_helpers():
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    module = importlib.import_module("tests.integration._cli_harness")
+
+    return module.build_synthetic_panel, module.write_raw_symbol_cache
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=check,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+    )
+
+
+def _call_docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return _run(["docker", *args], cwd=ROOT, check=check)
+
+
+def _load_vscode_server_config(server_name: str) -> dict[str, object]:
+    document = json.loads(VSCODE_SAMPLE_PATH.read_text(encoding="utf-8"))
+    return document["servers"][server_name]
+
+
+async def _call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: dict | None = None,
+) -> dict:
+    result = await session.call_tool(name, arguments or {})
+    if result.isError:
+        raise RuntimeError(f"{name} returned an MCP error: {result}")
+    if result.structuredContent is None:
+        raise RuntimeError(f"{name} did not return structured content.")
+    return result.structuredContent
+
+
+async def _exercise_container_mcp() -> None:
+    env = os.environ.copy()
+    server_config = _load_vscode_server_config("marketlab-docker-offline")
+    server_args = list(server_config["args"])
+    server_args[2] = CONTAINER_NAME
+    server = StdioServerParameters(
+        command=server_config["command"],
+        args=server_args,
+        cwd=ROOT,
+        env=env,
+    )
+
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            created = await _call_tool(
+                session,
+                "marketlab_create_config_from_template",
+                {
+                    "template_name": "weekly_rank_smoke",
+                    "destination": "configs/docker_mcp_smoke.yaml",
+                },
+            )
+            config_path = "configs/docker_mcp_smoke.yaml"
+            assert Path(created["config_path"]).name == "docker_mcp_smoke.yaml"
+
+            await _call_tool(
+                session,
+                "marketlab_patch_config",
+                {
+                    "config_path": config_path,
+                    "patch": {
+                        "data": {
+                            "cache_dir": "/app/workspace/cache",
+                            "start_date": "2024-01-02",
+                            "end_date": "2024-05-31",
+                        },
+                        "baselines": {
+                            "sma": {"enabled": False},
+                        },
+                        "artifacts": {
+                            "save_plots": False,
+                            "save_report_md": True,
+                        },
+                    },
+                },
+            )
+
+            validated = await _call_tool(
+                session,
+                "marketlab_validate_config",
+                {"config_path": config_path},
+            )
+            if validated["summary"]["output_dir"] != "/app/artifacts":
+                raise RuntimeError("Validated MCP config did not normalize to /app/artifacts.")
+
+            plan = await _call_tool(
+                session,
+                "marketlab_plan_run",
+                {
+                    "command": "backtest",
+                    "config_path": config_path,
+                },
+            )
+            if plan["network_required"]:
+                raise RuntimeError("Docker MCP smoke unexpectedly requires network access.")
+
+            job = await _call_tool(
+                session,
+                "marketlab_start_job",
+                {"plan_id": plan["id"]},
+            )
+
+            for _ in range(300):
+                status = await _call_tool(
+                    session,
+                    "marketlab_get_job_status",
+                    {"job_id": job["id"]},
+                )
+                if status["status"] in {"succeeded", "failed", "cancelled"}:
+                    break
+                await anyio.sleep(0.1)
+            else:
+                raise RuntimeError("Timed out waiting for Docker MCP smoke job completion.")
+
+            if status["status"] != "succeeded":
+                logs = await _call_tool(
+                    session,
+                    "marketlab_tail_job_logs",
+                    {"job_id": job["id"], "lines": 80},
+                )
+                raise RuntimeError(
+                    f"Docker MCP smoke job failed with status={status['status']}.\n{logs['log_tail']}"
+                )
+
+            run_summary = await _call_tool(
+                session,
+                "marketlab_get_run_summary",
+                {"run_path": status["result_path"]},
+            )
+            run_path = PurePosixPath(status["result_path"])
+
+            metrics_preview = await _call_tool(
+                session,
+                "marketlab_read_table_artifact",
+                {
+                    "path": str(run_path / "metrics.csv"),
+                    "max_rows": 10,
+                },
+            )
+            report_preview = await _call_tool(
+                session,
+                "marketlab_read_text_artifact",
+                {
+                    "path": str(run_path / "report.md"),
+                    "max_chars": 2000,
+                },
+            )
+
+            if "metrics.csv" not in run_summary["available_artifacts"]:
+                raise RuntimeError("Docker MCP smoke run did not produce metrics.csv.")
+            if metrics_preview["row_count"] < 1:
+                raise RuntimeError("Docker MCP smoke metrics preview was empty.")
+            if "Strategy Summary" not in report_preview["content"]:
+                raise RuntimeError("Docker MCP smoke report preview did not include Strategy Summary.")
+
+            print(
+                "Verified Docker MCP smoke run:",
+                status["result_path"],
+                f"artifacts={len(run_summary['available_artifacts'])}",
+            )
+
+
+def main() -> int:
+    if shutil.which("docker") is None:
+        raise RuntimeError("Docker is required for the mcp-docker validation lane.")
+    build_synthetic_panel, write_raw_symbol_cache = _fixture_helpers()
+
+    workspace = SCRATCH_DIR / "workspace"
+    artifacts = SCRATCH_DIR / "artifacts"
+
+    shutil.rmtree(SCRATCH_DIR, ignore_errors=True)
+    workspace.mkdir(parents=True, exist_ok=True)
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    panel = build_synthetic_panel(
+        (
+            ("VOO", 100.0, 0.9),
+            ("QQQ", 120.0, 1.0),
+            ("SMH", 80.0, 1.2),
+            ("XLV", 70.0, 0.6),
+            ("IEMG", 60.0, 0.7),
+        ),
+        start_date="2024-01-02",
+        end_date="2024-05-31",
+    )
+    write_raw_symbol_cache(workspace / "cache", panel=panel)
+
+    try:
+        _call_docker("version")
+        _call_docker("build", "-t", IMAGE_TAG, ".")
+        _call_docker("rm", "-f", CONTAINER_NAME, check=False)
+        _call_docker(
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            CONTAINER_NAME,
+            "-v",
+            f"{workspace.resolve()}:/app/workspace",
+            "-v",
+            f"{artifacts.resolve()}:/app/artifacts",
+            "-v",
+            f"{ROOT.resolve()}:/app/repo:ro",
+            "--entrypoint",
+            "sleep",
+            IMAGE_TAG,
+            "infinity",
+        )
+        anyio.run(_exercise_container_mcp)
+        return 0
+    finally:
+        _call_docker("rm", "-f", CONTAINER_NAME, check=False)
+        shutil.rmtree(SCRATCH_DIR, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -10,8 +10,8 @@ import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-DIST_DIR = ROOT / 'dist'
-SCRATCH_DIR = ROOT / '.package-smoke'
+DIST_DIR = Path(os.environ.get('MARKETLAB_DIST_DIR', ROOT / 'dist')).resolve()
+SCRATCH_DIR = Path(os.environ.get('MARKETLAB_PACKAGE_SMOKE_DIR', ROOT / '.package-smoke')).resolve()
 EXPECTED_TEMPLATES = (
     ('weekly_rank', 'weekly_rank.yaml'),
     ('weekly_rank_smoke', 'weekly_rank_smoke.yaml'),
@@ -88,10 +88,18 @@ def _assert_sdist_contents(sdist_path: Path) -> None:
             raise RuntimeError(f'sdist is missing packaged template {template_name}')
 
 
-def _venv_paths(venv_dir: Path) -> tuple[Path, Path]:
+def _venv_paths(venv_dir: Path) -> tuple[Path, Path, Path]:
     if os.name == 'nt':
-        return venv_dir / 'Scripts' / 'python.exe', venv_dir / 'Scripts' / 'marketlab.exe'
-    return venv_dir / 'bin' / 'python', venv_dir / 'bin' / 'marketlab'
+        return (
+            venv_dir / 'Scripts' / 'python.exe',
+            venv_dir / 'Scripts' / 'marketlab.exe',
+            venv_dir / 'Scripts' / 'marketlab-mcp.exe',
+        )
+    return (
+        venv_dir / 'bin' / 'python',
+        venv_dir / 'bin' / 'marketlab',
+        venv_dir / 'bin' / 'marketlab-mcp',
+    )
 
 
 def _run(
@@ -113,9 +121,13 @@ def _run(
 def _assert_installed_cli(wheel_path: Path, temp_dir: Path, env: dict[str, str]) -> None:
     venv_dir = temp_dir / 'venv'
     venv.EnvBuilder(with_pip=True).create(venv_dir)
-    python_path, marketlab_path = _venv_paths(venv_dir)
+    python_path, marketlab_path, marketlab_mcp_path = _venv_paths(venv_dir)
 
-    _run([str(python_path), '-m', 'pip', 'install', str(wheel_path)], env=env)
+    wheel_uri = wheel_path.resolve().as_uri()
+    _run(
+        [str(python_path), '-m', 'pip', 'install', f'marketlab[mcp] @ {wheel_uri}'],
+        env=env,
+    )
 
     version_run = _run([str(marketlab_path), '--version'], env=env)
     if not version_run.stdout.strip().startswith('marketlab '):
@@ -161,6 +173,10 @@ def _assert_installed_cli(wheel_path: Path, temp_dir: Path, env: dict[str, str])
         encoding='utf-8'
     ):
         raise RuntimeError('Installed CLI phase5 write-config did not write the expected template')
+
+    mcp_help_run = _run([str(marketlab_mcp_path), '--help'], env=env)
+    if '--workspace-root' not in mcp_help_run.stdout or '--artifact-root' not in mcp_help_run.stdout:
+        raise RuntimeError('Installed marketlab-mcp --help output did not include the expected flags')
 
 
 def main() -> int:

--- a/scripts/profile_validation.py
+++ b/scripts/profile_validation.py
@@ -7,8 +7,8 @@ import time
 from dataclasses import dataclass
 from typing import Callable
 
-VALID_ENVS = ("lint", "docs", "py312", "package", "integration")
-DEFAULT_ENVS = VALID_ENVS
+VALID_ENVS = ("lint", "docs", "py312", "package", "integration", "mcp-docker")
+DEFAULT_ENVS = ("lint", "docs", "py312", "package", "integration")
 CI_PYTHON = (3, 12)
 
 

--- a/scripts/run_marketlab_mcp.py
+++ b/scripts/run_marketlab_mcp.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _repo_src_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "src"
+
+
+def main(argv: list[str] | None = None) -> int:
+    src_path = str(_repo_src_path())
+    if src_path in sys.path:
+        sys.path.remove(src_path)
+    sys.path.insert(0, src_path)
+
+    from marketlab.mcp.cli import main as cli_main
+
+    return cli_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/marketlab/mcp/__init__.py
+++ b/src/marketlab/mcp/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from marketlab.mcp.server import create_server
+
+__all__ = ["create_server"]

--- a/src/marketlab/mcp/cli.py
+++ b/src/marketlab/mcp/cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="marketlab-mcp")
+    parser.add_argument("--workspace-root", default="/app/workspace")
+    parser.add_argument("--artifact-root", default="/app/artifacts")
+    parser.add_argument("--repo-root", default="")
+    parser.add_argument("--allow-network", action="store_true")
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from marketlab.mcp.server import create_server
+    except RuntimeError as exc:
+        parser.error(str(exc))
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else None
+    server = create_server(
+        workspace_root=Path(args.workspace_root),
+        artifact_root=Path(args.artifact_root),
+        repo_root=repo_root,
+        allow_network=args.allow_network,
+        log_level=args.log_level.upper(),
+    )
+    server.run(transport="stdio")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/marketlab/mcp/jobs.py
+++ b/src/marketlab/mcp/jobs.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from collections import deque
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+from marketlab.config import ExperimentConfig, load_config
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+ALLOWED_COMMANDS = ("prepare-data", "backtest", "train-models", "run-experiment")
+FINAL_JOB_STATES = {"succeeded", "failed", "cancelled"}
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _last_non_empty_line(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def _network_required(config: ExperimentConfig) -> bool:
+    if config.prepared_panel_path.exists():
+        return False
+    raw_symbol_paths = [config.cache_dir / f"{symbol}.csv" for symbol in config.data.symbols]
+    return not all(path.exists() for path in raw_symbol_paths)
+
+
+def _command_builder(command: str, config_path: Path) -> list[str]:
+    return [sys.executable, "-m", "marketlab.cli", command, "--config", str(config_path)]
+
+
+@dataclass(slots=True)
+class RunPlan:
+    id: str
+    command: str
+    config_path: str
+    created_at: str
+    network_required: bool
+    summary: dict[str, Any]
+    started: bool = False
+
+
+@dataclass(slots=True)
+class JobRecord:
+    id: str
+    plan_id: str
+    command: str
+    config_path: str
+    status: str
+    created_at: str
+    log_path: str
+    network_required: bool
+    started_at: str | None = None
+    finished_at: str | None = None
+    return_code: int | None = None
+    result_path: str | None = None
+    result_kind: str | None = None
+    error_message: str | None = None
+    cancel_requested: bool = False
+
+
+class MarketLabJobManager:
+    def __init__(
+        self,
+        *,
+        sandbox: WorkspaceSandbox,
+        allow_network: bool,
+        process_factory: Callable[..., subprocess.Popen[str]] | None = None,
+        command_builder: Callable[[str, Path], list[str]] | None = None,
+    ) -> None:
+        self._sandbox = sandbox
+        self._allow_network = allow_network
+        self._process_factory = process_factory or subprocess.Popen
+        self._command_builder = command_builder or _command_builder
+        self._plans: dict[str, RunPlan] = {}
+        self._jobs: dict[str, JobRecord] = {}
+        self._queue: deque[str] = deque()
+        self._lock = threading.RLock()
+        self._wake_event = threading.Event()
+        self._shutdown_event = threading.Event()
+        self._active_job_id: str | None = None
+        self._active_process: subprocess.Popen[str] | None = None
+        self._worker = threading.Thread(
+            target=self._run_worker,
+            name="marketlab-mcp-job-worker",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def create_plan(self, *, command: str, config_path: str | Path) -> dict[str, Any]:
+        if command not in ALLOWED_COMMANDS:
+            allowed = ", ".join(ALLOWED_COMMANDS)
+            raise ValueError(f"Unsupported command {command!r}. Expected one of: {allowed}")
+
+        resolved_config = self._sandbox.resolve_workspace_path(config_path)
+        config = load_config(resolved_config)
+        self._sandbox.validate_execution_paths(config)
+        network_required = _network_required(config)
+        if network_required and not self._allow_network:
+            raise ValueError(
+                f"{command} requires network access because the prepared panel or raw symbol cache is not available."
+            )
+
+        plan = RunPlan(
+            id=uuid4().hex,
+            command=command,
+            config_path=str(resolved_config),
+            created_at=_utc_now(),
+            network_required=network_required,
+            summary={
+                "experiment_name": config.experiment_name,
+                "output_dir": str(config.output_dir),
+                "prepared_panel_path": str(config.prepared_panel_path),
+                "symbol_count": len(config.data.symbols),
+            },
+        )
+        with self._lock:
+            self._plans[plan.id] = plan
+        return asdict(plan)
+
+    def start_job(self, plan_id: str) -> dict[str, Any]:
+        with self._lock:
+            plan = self._plans.get(plan_id)
+            if plan is None:
+                raise KeyError(f"Unknown plan_id: {plan_id}")
+            if plan.started:
+                raise ValueError(f"Plan {plan_id} has already been started.")
+
+            job = JobRecord(
+                id=uuid4().hex,
+                plan_id=plan.id,
+                command=plan.command,
+                config_path=plan.config_path,
+                status="queued",
+                created_at=_utc_now(),
+                log_path=str(self._sandbox.logs_root / f"{plan.id}.log"),
+                network_required=plan.network_required,
+            )
+            plan.started = True
+            self._jobs[job.id] = job
+            self._queue.append(job.id)
+            self._wake_event.set()
+            return self._serialize_job(job)
+
+    def list_jobs(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "active_job_id": self._active_job_id,
+                "queued_job_ids": list(self._queue),
+                "jobs": [self._serialize_job(job) for job in self._jobs.values()],
+            }
+
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                raise KeyError(f"Unknown job_id: {job_id}")
+            return self._serialize_job(job)
+
+    def cancel_job(self, job_id: str) -> dict[str, Any]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                raise KeyError(f"Unknown job_id: {job_id}")
+            if job.status in FINAL_JOB_STATES:
+                return self._serialize_job(job)
+            if job.status == "queued":
+                job.status = "cancelled"
+                job.finished_at = _utc_now()
+                job.error_message = "Cancelled before execution."
+                return self._serialize_job(job)
+            if job.status == "running" and self._active_process is not None:
+                job.cancel_requested = True
+                job.status = "cancelling"
+                self._active_process.terminate()
+                return self._serialize_job(job)
+            return self._serialize_job(job)
+
+    def tail_logs(self, job_id: str, lines: int = 40) -> dict[str, Any]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                raise KeyError(f"Unknown job_id: {job_id}")
+            log_path = Path(job.log_path)
+            content = ""
+            if log_path.exists():
+                log_lines = log_path.read_text(encoding="utf-8").splitlines()
+                content = "\n".join(log_lines[-max(lines, 1) :])
+            return {
+                "job_id": job_id,
+                "status": job.status,
+                "log_path": job.log_path,
+                "log_tail": content,
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            active_process = self._active_process
+        if active_process is not None and active_process.poll() is None:
+            active_process.terminate()
+        self._shutdown_event.set()
+        self._wake_event.set()
+        self._worker.join(timeout=5.0)
+
+    def _run_worker(self) -> None:
+        while not self._shutdown_event.is_set():
+            self._wake_event.wait(timeout=0.1)
+            job_id = self._next_job_id()
+            if job_id is None:
+                self._wake_event.clear()
+                continue
+            self._execute_job(job_id)
+
+    def _next_job_id(self) -> str | None:
+        with self._lock:
+            while self._queue:
+                job_id = self._queue.popleft()
+                job = self._jobs[job_id]
+                if job.status == "cancelled":
+                    continue
+                self._active_job_id = job_id
+                return job_id
+        return None
+
+    def _execute_job(self, job_id: str) -> None:
+        with self._lock:
+            job = self._jobs[job_id]
+            job.status = "running"
+            job.started_at = _utc_now()
+            log_path = Path(job.log_path)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        command = self._command_builder(job.command, Path(job.config_path))
+        env = os.environ.copy()
+        try:
+            with Path(job.log_path).open("w", encoding="utf-8") as log_handle:
+                process = self._process_factory(
+                    command,
+                    cwd=self._sandbox.workspace_root,
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    env=env,
+                )
+                with self._lock:
+                    self._active_process = process
+                return_code = process.wait()
+        except Exception as exc:
+            with self._lock:
+                job.return_code = -1
+                job.finished_at = _utc_now()
+                job.status = "failed"
+                job.error_message = str(exc)
+                self._active_process = None
+                self._active_job_id = None
+                if self._queue:
+                    self._wake_event.set()
+            return
+
+        last_line = _last_non_empty_line(Path(job.log_path))
+        with self._lock:
+            job.return_code = return_code
+            job.finished_at = _utc_now()
+            if job.cancel_requested:
+                job.status = "cancelled"
+                job.error_message = "Cancelled while running."
+            elif return_code == 0:
+                job.status = "succeeded"
+                if last_line:
+                    job.result_path = last_line
+                    job.result_kind = "panel_path" if job.command == "prepare-data" else "run_dir"
+            else:
+                job.status = "failed"
+                job.error_message = last_line or f"Command exited with status {return_code}."
+            self._active_process = None
+            self._active_job_id = None
+            if self._queue:
+                self._wake_event.set()
+
+    def _serialize_job(self, job: JobRecord) -> dict[str, Any]:
+        queued_position = None
+        if job.status == "queued":
+            with self._lock:
+                try:
+                    queued_position = list(self._queue).index(job.id) + 1
+                except ValueError:
+                    queued_position = None
+        payload = asdict(job)
+        payload["queued_position"] = queued_position
+        return payload

--- a/src/marketlab/mcp/server.py
+++ b/src/marketlab/mcp/server.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from marketlab.mcp.jobs import MarketLabJobManager
+from marketlab.mcp.tools_admin import register_admin_tools
+from marketlab.mcp.tools_artifacts import register_artifact_tools
+from marketlab.mcp.tools_configs import register_config_tools
+from marketlab.mcp.tools_jobs import register_job_tools
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+
+def _require_mcp() -> Any:
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised by CLI error path
+        if exc.name == "mcp":
+            raise RuntimeError(
+                "MarketLab MCP support requires the optional dependency group. Install it with "
+                "`pip install marketlab[mcp]`."
+            ) from exc
+        raise
+    return FastMCP
+
+
+class MarketLabMCPServer:
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        artifact_root: Path,
+        repo_root: Path | None,
+        allow_network: bool,
+        log_level: str = "INFO",
+    ) -> None:
+        FastMCP = _require_mcp()
+        self._sandbox = WorkspaceSandbox(
+            workspace_root=workspace_root,
+            artifact_root=artifact_root,
+            repo_root=repo_root,
+        )
+        self._jobs = MarketLabJobManager(
+            sandbox=self._sandbox,
+            allow_network=allow_network,
+        )
+
+        @asynccontextmanager
+        async def lifespan(_: Any):
+            try:
+                yield
+            finally:
+                self._jobs.close()
+
+        self._mcp = FastMCP(
+            name="marketlab",
+            instructions=(
+                "MarketLab MCP exposes sandboxed config authoring, async workflow execution, "
+                "artifact inspection, and run comparison for the installed MarketLab package."
+            ),
+            log_level=log_level,
+            dependencies=["marketlab[mcp]"],
+            lifespan=lifespan,
+        )
+        register_admin_tools(
+            self._mcp,
+            sandbox=self._sandbox,
+            allow_network=allow_network,
+        )
+        register_config_tools(self._mcp, sandbox=self._sandbox)
+        register_job_tools(self._mcp, jobs=self._jobs)
+        register_artifact_tools(self._mcp, sandbox=self._sandbox)
+
+    @property
+    def app(self) -> Any:
+        return self._mcp
+
+    def close(self) -> None:
+        self._jobs.close()
+
+    def run(self, transport: str = "stdio") -> None:
+        self._mcp.run(transport=transport)
+
+
+def create_server(
+    *,
+    workspace_root: Path,
+    artifact_root: Path,
+    repo_root: Path | None,
+    allow_network: bool,
+    log_level: str = "INFO",
+) -> MarketLabMCPServer:
+    return MarketLabMCPServer(
+        workspace_root=workspace_root,
+        artifact_root=artifact_root,
+        repo_root=repo_root,
+        allow_network=allow_network,
+        log_level=log_level,
+    )

--- a/src/marketlab/mcp/tools_admin.py
+++ b/src/marketlab/mcp/tools_admin.py
@@ -14,7 +14,14 @@ CONFIG_TOOLS = [
     "marketlab_patch_config",
     "marketlab_validate_config",
 ]
-JOB_TOOLS: list[str] = []
+JOB_TOOLS = [
+    "marketlab_plan_run",
+    "marketlab_start_job",
+    "marketlab_list_jobs",
+    "marketlab_get_job_status",
+    "marketlab_tail_job_logs",
+    "marketlab_cancel_job",
+]
 ARTIFACT_TOOLS: list[str] = []
 
 

--- a/src/marketlab/mcp/tools_admin.py
+++ b/src/marketlab/mcp/tools_admin.py
@@ -22,7 +22,15 @@ JOB_TOOLS = [
     "marketlab_tail_job_logs",
     "marketlab_cancel_job",
 ]
-ARTIFACT_TOOLS: list[str] = []
+ARTIFACT_TOOLS = [
+    "marketlab_list_runs",
+    "marketlab_get_run_summary",
+    "marketlab_list_artifacts",
+    "marketlab_read_table_artifact",
+    "marketlab_read_text_artifact",
+    "marketlab_get_plot_artifact",
+    "marketlab_compare_runs",
+]
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:

--- a/src/marketlab/mcp/tools_admin.py
+++ b/src/marketlab/mcp/tools_admin.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from marketlab._version import get_version
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+CONFIG_TOOLS: list[str] = []
+JOB_TOOLS: list[str] = []
+ARTIFACT_TOOLS: list[str] = []
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def register_admin_tools(
+    mcp: Any,
+    *,
+    sandbox: WorkspaceSandbox,
+    allow_network: bool,
+) -> None:
+    @mcp.tool(
+        name="marketlab_server_info",
+        description="Describe the MarketLab MCP server, installed version, and runtime defaults.",
+        structured_output=True,
+    )
+    def marketlab_server_info() -> dict[str, Any]:
+        return {
+            "server_name": "marketlab",
+            "version": get_version(),
+            "allow_network": allow_network,
+            "transport": "stdio",
+            "tool_groups": {
+                "admin": ["marketlab_server_info", "marketlab_workspace_info"],
+                "configs": CONFIG_TOOLS,
+                "jobs": JOB_TOOLS,
+                "artifacts": ARTIFACT_TOOLS,
+            },
+        }
+
+    @mcp.tool(
+        name="marketlab_workspace_info",
+        description="Describe writable and readable roots managed by the MarketLab MCP server.",
+        structured_output=True,
+    )
+    def marketlab_workspace_info() -> dict[str, Any]:
+        workspace_config_files = sorted(
+            str(path.relative_to(sandbox.workspace_root))
+            for path in sandbox.workspace_root.rglob("*.yaml")
+            if _is_relative_to(path, sandbox.workspace_root)
+        )
+        return {
+            **sandbox.describe(),
+            "workspace_yaml_files": workspace_config_files,
+        }

--- a/src/marketlab/mcp/tools_admin.py
+++ b/src/marketlab/mcp/tools_admin.py
@@ -6,7 +6,14 @@ from typing import Any
 from marketlab._version import get_version
 from marketlab.mcp.workspace import WorkspaceSandbox
 
-CONFIG_TOOLS: list[str] = []
+CONFIG_TOOLS = [
+    "marketlab_list_templates",
+    "marketlab_create_config_from_template",
+    "marketlab_copy_repo_config",
+    "marketlab_read_config",
+    "marketlab_patch_config",
+    "marketlab_validate_config",
+]
 JOB_TOOLS: list[str] = []
 ARTIFACT_TOOLS: list[str] = []
 

--- a/src/marketlab/mcp/tools_artifacts.py
+++ b/src/marketlab/mcp/tools_artifacts.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import base64
+from pathlib import Path
 from typing import Any
+
+import pandas as pd
+
 from marketlab.mcp.workspace import WorkspaceSandbox
 
 
@@ -9,5 +14,233 @@ def register_artifact_tools(
     *,
     sandbox: WorkspaceSandbox,
 ) -> None:
-    del mcp
-    del sandbox
+    @mcp.tool(
+        name="marketlab_list_runs",
+        description="List completed MarketLab run directories under the configured artifact root.",
+        structured_output=True,
+    )
+    def marketlab_list_runs(limit: int = 20) -> dict[str, Any]:
+        runs: list[dict[str, Any]] = []
+        for metrics_path in sorted(
+            sandbox.artifact_root.rglob("metrics.csv"),
+            key=lambda path: path.stat().st_mtime_ns,
+            reverse=True,
+        ):
+            run_dir = metrics_path.parent
+            report_path = run_dir / "report.md"
+            runs.append(
+                {
+                    "run_path": str(run_dir),
+                    "experiment_name": run_dir.parent.name
+                    if run_dir.parent != sandbox.artifact_root
+                    else run_dir.name,
+                    "timestamp_dir": run_dir.name,
+                    "has_report": report_path.exists(),
+                    "available_artifacts": sorted(path.name for path in run_dir.iterdir()),
+                }
+            )
+            if len(runs) >= max(limit, 1):
+                break
+        return {"runs": runs}
+
+    @mcp.tool(
+        name="marketlab_get_run_summary",
+        description="Read compact run-level summaries from a completed MarketLab run directory.",
+        structured_output=True,
+    )
+    def marketlab_get_run_summary(run_path: str) -> dict[str, Any]:
+        resolved_run = sandbox.resolve_artifact_path(run_path)
+        summary: dict[str, Any] = {
+            "run_path": str(resolved_run),
+            "available_artifacts": sorted(path.name for path in resolved_run.iterdir()),
+        }
+        metrics_path = resolved_run / "metrics.csv"
+        strategy_summary_path = resolved_run / "strategy_summary.csv"
+        model_summary_path = resolved_run / "model_summary.csv"
+        report_path = resolved_run / "report.md"
+        if metrics_path.exists():
+            summary["metrics_preview"] = _frame_preview(metrics_path, max_rows=20)
+        if strategy_summary_path.exists():
+            summary["strategy_summary_preview"] = _frame_preview(
+                strategy_summary_path, max_rows=20
+            )
+        if model_summary_path.exists():
+            summary["model_summary_preview"] = _frame_preview(model_summary_path, max_rows=20)
+        if report_path.exists():
+            summary["report_sections"] = _extract_markdown_sections(report_path)
+        return summary
+
+    @mcp.tool(
+        name="marketlab_list_artifacts",
+        description="List files inside one completed MarketLab run directory.",
+        structured_output=True,
+    )
+    def marketlab_list_artifacts(run_path: str) -> dict[str, Any]:
+        resolved_run = sandbox.resolve_artifact_path(run_path)
+        artifacts = []
+        for path in sorted(resolved_run.iterdir()):
+            if path.is_file():
+                artifacts.append(
+                    {
+                        "path": str(path),
+                        "name": path.name,
+                        "kind": _artifact_kind(path),
+                        "byte_size": path.stat().st_size,
+                    }
+                )
+        return {"run_path": str(resolved_run), "artifacts": artifacts}
+
+    @mcp.tool(
+        name="marketlab_read_table_artifact",
+        description="Read a CSV artifact inside the artifact root and return a structured preview.",
+        structured_output=True,
+    )
+    def marketlab_read_table_artifact(path: str, max_rows: int = 50) -> dict[str, Any]:
+        resolved = sandbox.resolve_artifact_path(path)
+        if resolved.suffix != ".csv":
+            raise ValueError(f"{resolved} is not a CSV artifact.")
+        return _frame_preview(resolved, max_rows=max_rows)
+
+    @mcp.tool(
+        name="marketlab_read_text_artifact",
+        description="Read a Markdown, log, YAML, or text artifact under the workspace or artifact roots.",
+        structured_output=True,
+    )
+    def marketlab_read_text_artifact(path: str, max_chars: int = 12000) -> dict[str, Any]:
+        resolved = _resolve_readable_path(sandbox, path)
+        if _artifact_kind(resolved) not in {"text", "file"}:
+            raise ValueError(f"{resolved} is not a supported text artifact.")
+        content = resolved.read_text(encoding="utf-8")
+        return {
+            "path": str(resolved),
+            "char_count": len(content),
+            "content": content[: max(max_chars, 1)],
+        }
+
+    @mcp.tool(
+        name="marketlab_get_plot_artifact",
+        description="Read an image artifact and return it as a base64-encoded payload for review.",
+        structured_output=True,
+    )
+    def marketlab_get_plot_artifact(path: str) -> dict[str, Any]:
+        resolved = sandbox.resolve_artifact_path(path)
+        if _artifact_kind(resolved) != "image":
+            raise ValueError(f"{resolved} is not a supported plot artifact.")
+        encoded = base64.b64encode(resolved.read_bytes()).decode("ascii")
+        mime_type = (
+            "image/png"
+            if resolved.suffix.lower() == ".png"
+            else f"image/{resolved.suffix.lstrip('.')}"
+        )
+        return {
+            "path": str(resolved),
+            "mime_type": mime_type,
+            "byte_size": resolved.stat().st_size,
+            "base64": encoded,
+        }
+
+    @mcp.tool(
+        name="marketlab_compare_runs",
+        description="Compare summary-table artifacts across two completed MarketLab runs.",
+        structured_output=True,
+    )
+    def marketlab_compare_runs(left_run_path: str, right_run_path: str) -> dict[str, Any]:
+        left_run = sandbox.resolve_artifact_path(left_run_path)
+        right_run = sandbox.resolve_artifact_path(right_run_path)
+        comparison: dict[str, Any] = {
+            "left_run_path": str(left_run),
+            "right_run_path": str(right_run),
+            "tables": {},
+            "report_sections": {
+                "left": _extract_markdown_sections(left_run / "report.md"),
+                "right": _extract_markdown_sections(right_run / "report.md"),
+            },
+        }
+        for file_name in ("metrics.csv", "strategy_summary.csv", "model_summary.csv"):
+            left_path = left_run / file_name
+            right_path = right_run / file_name
+            if left_path.exists() and right_path.exists():
+                comparison["tables"][file_name] = _merge_summary_frame(left_path, right_path)
+        return comparison
+
+
+def _extract_markdown_sections(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [line.strip("# ").strip() for line in lines if line.startswith("## ")]
+
+
+def _frame_preview(path: Path, max_rows: int) -> dict[str, Any]:
+    frame = pd.read_csv(path)
+    preview = frame.head(max_rows)
+    return {
+        "path": str(path),
+        "row_count": int(len(frame)),
+        "columns": list(frame.columns),
+        "rows": preview.to_dict(orient="records"),
+    }
+
+
+def _artifact_kind(path: Path) -> str:
+    if path.suffix == ".csv":
+        return "table"
+    if path.suffix in {".md", ".log", ".txt", ".yaml", ".yml"}:
+        return "text"
+    if path.suffix.lower() in {".png", ".jpg", ".jpeg", ".gif"}:
+        return "image"
+    return "file"
+
+
+def _merge_summary_frame(left: Path, right: Path) -> dict[str, Any]:
+    left_frame = pd.read_csv(left)
+    right_frame = pd.read_csv(right)
+    key_candidates = ["strategy", "model_name", "fold_id"]
+    key = next(
+        (
+            candidate
+            for candidate in key_candidates
+            if candidate in left_frame.columns and candidate in right_frame.columns
+        ),
+        None,
+    )
+    if key is None:
+        return {
+            "left_columns": list(left_frame.columns),
+            "right_columns": list(right_frame.columns),
+            "left_rows": left_frame.to_dict(orient="records"),
+            "right_rows": right_frame.to_dict(orient="records"),
+        }
+
+    merged = left_frame.merge(
+        right_frame,
+        on=key,
+        how="outer",
+        suffixes=("_left", "_right"),
+    )
+    return {
+        "key": key,
+        "row_count": int(len(merged)),
+        "columns": list(merged.columns),
+        "rows": merged.to_dict(orient="records"),
+    }
+
+
+def _resolve_readable_path(sandbox: WorkspaceSandbox, path: str | Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+        if not sandbox.is_readable_path(resolved):
+            raise ValueError(f"Path {resolved} is outside the readable roots.")
+        return resolved
+
+    for resolver in (sandbox.resolve_artifact_path, sandbox.resolve_workspace_path):
+        try:
+            resolved = resolver(candidate)
+            if resolved.exists():
+                return resolved
+        except ValueError:
+            continue
+    raise ValueError(
+        f"Unable to resolve readable path {path!r} in the workspace or artifact roots."
+    )

--- a/src/marketlab/mcp/tools_artifacts.py
+++ b/src/marketlab/mcp/tools_artifacts.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+
+def register_artifact_tools(
+    mcp: Any,
+    *,
+    sandbox: WorkspaceSandbox,
+) -> None:
+    del mcp
+    del sandbox

--- a/src/marketlab/mcp/tools_configs.py
+++ b/src/marketlab/mcp/tools_configs.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+
+def register_config_tools(
+    mcp: Any,
+    *,
+    sandbox: WorkspaceSandbox,
+) -> None:
+    del mcp
+    del sandbox

--- a/src/marketlab/mcp/tools_configs.py
+++ b/src/marketlab/mcp/tools_configs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from marketlab.mcp.workspace import WorkspaceSandbox
+from marketlab.resources.templates import iter_config_template_names
 
 
 def register_config_tools(
@@ -10,5 +11,82 @@ def register_config_tools(
     *,
     sandbox: WorkspaceSandbox,
 ) -> None:
-    del mcp
-    del sandbox
+    @mcp.tool(
+        name="marketlab_list_templates",
+        description="List the bundled MarketLab config templates available for workspace config generation.",
+        structured_output=True,
+    )
+    def marketlab_list_templates() -> dict[str, Any]:
+        return {"templates": list(iter_config_template_names())}
+
+    @mcp.tool(
+        name="marketlab_create_config_from_template",
+        description="Create a workspace YAML config from a bundled MarketLab template and normalize its artifact root.",
+        structured_output=True,
+    )
+    def marketlab_create_config_from_template(
+        template_name: str,
+        destination: str,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        created_path = sandbox.create_config_from_template(
+            template_name=template_name,
+            destination=destination,
+            force=force,
+        )
+        return {
+            "config_path": str(created_path),
+            "template_name": template_name,
+        }
+
+    @mcp.tool(
+        name="marketlab_copy_repo_config",
+        description="Copy a repo-tracked config into the writable workspace and normalize its artifact root.",
+        structured_output=True,
+    )
+    def marketlab_copy_repo_config(
+        repo_config_path: str,
+        destination: str,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        copied_path = sandbox.copy_repo_config(
+            repo_config_path=repo_config_path,
+            destination=destination,
+            force=force,
+        )
+        return {
+            "config_path": str(copied_path),
+            "repo_config_path": repo_config_path,
+        }
+
+    @mcp.tool(
+        name="marketlab_read_config",
+        description="Read a workspace YAML config as structured data.",
+        structured_output=True,
+    )
+    def marketlab_read_config(config_path: str) -> dict[str, Any]:
+        resolved = sandbox.resolve_workspace_path(config_path)
+        return {
+            "config_path": str(resolved),
+            "document": sandbox.read_config(resolved),
+        }
+
+    @mcp.tool(
+        name="marketlab_patch_config",
+        description="Apply a recursive structured patch to a workspace YAML config.",
+        structured_output=True,
+    )
+    def marketlab_patch_config(config_path: str, patch: dict[str, Any]) -> dict[str, Any]:
+        patched_path = sandbox.patch_config(config_path=config_path, patch=patch)
+        return {
+            "config_path": str(patched_path),
+            "document": sandbox.read_config(patched_path),
+        }
+
+    @mcp.tool(
+        name="marketlab_validate_config",
+        description="Validate a workspace config through the existing MarketLab loader and path guardrails.",
+        structured_output=True,
+    )
+    def marketlab_validate_config(config_path: str) -> dict[str, Any]:
+        return sandbox.validate_config(config_path)

--- a/src/marketlab/mcp/tools_jobs.py
+++ b/src/marketlab/mcp/tools_jobs.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+from marketlab.mcp.jobs import MarketLabJobManager
+
+
+def register_job_tools(
+    mcp: Any,
+    *,
+    jobs: MarketLabJobManager,
+) -> None:
+    del mcp
+    del jobs

--- a/src/marketlab/mcp/tools_jobs.py
+++ b/src/marketlab/mcp/tools_jobs.py
@@ -10,5 +10,50 @@ def register_job_tools(
     *,
     jobs: MarketLabJobManager,
 ) -> None:
-    del mcp
-    del jobs
+    @mcp.tool(
+        name="marketlab_plan_run",
+        description="Create an execution plan for a MarketLab workflow. A successful plan is required before starting a job.",
+        structured_output=True,
+    )
+    def marketlab_plan_run(command: str, config_path: str) -> dict[str, Any]:
+        return jobs.create_plan(command=command, config_path=config_path)
+
+    @mcp.tool(
+        name="marketlab_start_job",
+        description="Start a queued MarketLab job from a previously created plan.",
+        structured_output=True,
+    )
+    def marketlab_start_job(plan_id: str) -> dict[str, Any]:
+        return jobs.start_job(plan_id)
+
+    @mcp.tool(
+        name="marketlab_list_jobs",
+        description="List queued, active, and completed MarketLab jobs for the current session.",
+        structured_output=True,
+    )
+    def marketlab_list_jobs() -> dict[str, Any]:
+        return jobs.list_jobs()
+
+    @mcp.tool(
+        name="marketlab_get_job_status",
+        description="Inspect the current status and metadata for one MarketLab job.",
+        structured_output=True,
+    )
+    def marketlab_get_job_status(job_id: str) -> dict[str, Any]:
+        return jobs.get_job(job_id)
+
+    @mcp.tool(
+        name="marketlab_tail_job_logs",
+        description="Read the latest log lines for a queued or running MarketLab job.",
+        structured_output=True,
+    )
+    def marketlab_tail_job_logs(job_id: str, lines: int = 40) -> dict[str, Any]:
+        return jobs.tail_logs(job_id, lines=lines)
+
+    @mcp.tool(
+        name="marketlab_cancel_job",
+        description="Cancel a queued or active MarketLab job for the current session.",
+        structured_output=True,
+    )
+    def marketlab_cancel_job(job_id: str) -> dict[str, Any]:
+        return jobs.cancel_job(job_id)

--- a/src/marketlab/mcp/workspace.py
+++ b/src/marketlab/mcp/workspace.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from marketlab.config import ExperimentConfig, load_config
+from marketlab.resources.templates import (
+    get_config_template_text,
+    iter_config_template_names,
+)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_resolve(path: str | Path, root: Path) -> Path:
+    candidate = Path(path)
+    resolved = (root / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    if not _is_relative_to(resolved, root):
+        raise ValueError(f"Path {resolved} escapes the allowed root {root}.")
+    return resolved
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if payload is None:
+        return {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"Config file {path} must contain a top-level mapping.")
+    return payload
+
+
+def _merge_patch(base: Any, patch: Any) -> Any:
+    if not isinstance(base, dict) or not isinstance(patch, dict):
+        return deepcopy(patch)
+
+    merged = deepcopy(base)
+    for key, value in patch.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = _merge_patch(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def _config_summary(config: ExperimentConfig) -> dict[str, Any]:
+    return {
+        "experiment_name": config.experiment_name,
+        "symbols": list(config.data.symbols),
+        "cache_dir": str(config.cache_dir),
+        "prepared_panel_path": str(config.prepared_panel_path),
+        "output_dir": str(config.output_dir),
+        "benchmark_strategy": config.evaluation.benchmark_strategy,
+        "model_names": [model.name for model in config.models],
+    }
+
+
+class WorkspaceSandbox:
+    def __init__(
+        self,
+        workspace_root: Path,
+        artifact_root: Path,
+        repo_root: Path | None = None,
+    ) -> None:
+        self.workspace_root = workspace_root.resolve()
+        self.artifact_root = artifact_root.resolve()
+        self.repo_root = repo_root.resolve() if repo_root is not None else None
+        self.system_root = (self.workspace_root / ".marketlab-mcp").resolve()
+        self.logs_root = (self.system_root / "logs").resolve()
+        self.configs_root = (self.workspace_root / "configs").resolve()
+        self._ensure_roots()
+
+    def _ensure_roots(self) -> None:
+        for root in (
+            self.workspace_root,
+            self.artifact_root,
+            self.system_root,
+            self.logs_root,
+            self.configs_root,
+        ):
+            root.mkdir(parents=True, exist_ok=True)
+
+    def resolve_workspace_path(self, path: str | Path) -> Path:
+        return _safe_resolve(path, self.workspace_root)
+
+    def resolve_artifact_path(self, path: str | Path) -> Path:
+        return _safe_resolve(path, self.artifact_root)
+
+    def resolve_repo_path(self, path: str | Path) -> Path:
+        if self.repo_root is None:
+            raise ValueError("Repo-root access is not enabled on this server.")
+        return _safe_resolve(path, self.repo_root)
+
+    def is_writable_path(self, path: Path) -> bool:
+        resolved = path.resolve()
+        return _is_relative_to(resolved, self.workspace_root) or _is_relative_to(
+            resolved, self.artifact_root
+        )
+
+    def is_readable_path(self, path: Path) -> bool:
+        resolved = path.resolve()
+        return self.is_writable_path(resolved) or (
+            self.repo_root is not None and _is_relative_to(resolved, self.repo_root)
+        )
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "workspace_root": str(self.workspace_root),
+            "artifact_root": str(self.artifact_root),
+            "repo_root": str(self.repo_root) if self.repo_root is not None else None,
+            "logs_root": str(self.logs_root),
+            "configs_root": str(self.configs_root),
+        }
+
+    def list_templates(self) -> list[str]:
+        return list(iter_config_template_names())
+
+    def create_config_from_template(
+        self,
+        *,
+        template_name: str,
+        destination: str | Path,
+        force: bool = False,
+    ) -> Path:
+        destination_path = self.resolve_workspace_path(destination)
+        if destination_path.exists() and not force:
+            raise FileExistsError(f"Refusing to overwrite existing file: {destination_path}")
+
+        payload = yaml.safe_load(get_config_template_text(template_name)) or {}
+        payload.setdefault("artifacts", {})
+        payload["artifacts"]["output_dir"] = str(self.artifact_root)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_text(
+            yaml.safe_dump(payload, sort_keys=False),
+            encoding="utf-8",
+        )
+        return destination_path
+
+    def copy_repo_config(
+        self,
+        *,
+        repo_config_path: str | Path,
+        destination: str | Path,
+        force: bool = False,
+    ) -> Path:
+        source = self.resolve_repo_path(repo_config_path)
+        destination_path = self.resolve_workspace_path(destination)
+        if destination_path.exists() and not force:
+            raise FileExistsError(f"Refusing to overwrite existing file: {destination_path}")
+        payload = _load_yaml(source)
+        payload.setdefault("artifacts", {})
+        payload["artifacts"]["output_dir"] = str(self.artifact_root)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_text(
+            yaml.safe_dump(payload, sort_keys=False),
+            encoding="utf-8",
+        )
+        return destination_path
+
+    def read_config(self, config_path: str | Path) -> dict[str, Any]:
+        path = self.resolve_workspace_path(config_path)
+        return _load_yaml(path)
+
+    def patch_config(
+        self,
+        *,
+        config_path: str | Path,
+        patch: dict[str, Any],
+    ) -> Path:
+        path = self.resolve_workspace_path(config_path)
+        payload = _load_yaml(path)
+        merged = _merge_patch(payload, patch)
+        path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+        return path
+
+    def validate_config(self, config_path: str | Path) -> dict[str, Any]:
+        path = self.resolve_workspace_path(config_path)
+        config = load_config(path)
+        self.validate_execution_paths(config)
+        return {
+            "config_path": str(path),
+            "summary": _config_summary(config),
+        }
+
+    def validate_execution_paths(self, config: ExperimentConfig) -> None:
+        writable_paths = [config.cache_dir, config.output_dir]
+        readable_paths = [
+            config.prepared_panel_path,
+            config.factor_model_path,
+            config.optimized_external_covariance_path,
+            config.optimized_external_expected_returns_path,
+        ]
+        for path in writable_paths:
+            if not self.is_writable_path(path):
+                raise ValueError(
+                    f"Writable path {path} is outside the allowed workspace or artifact roots."
+                )
+        for path in readable_paths:
+            if path is None:
+                continue
+            if not self.is_readable_path(path):
+                raise ValueError(
+                    f"Readable path {path} is outside the allowed workspace or repo roots."
+                )

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import anyio
+import pytest
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from tests.integration._cli_harness import build_synthetic_panel, write_raw_symbol_cache
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MCP_LAUNCHER = REPO_ROOT / "scripts" / "run_marketlab_mcp.py"
+
+
+async def _call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: dict | None = None,
+) -> dict:
+    result = await session.call_tool(name, arguments or {})
+    assert not result.isError, f"{name} returned an MCP error: {result}"
+    assert result.structuredContent is not None, f"{name} did not return structured content"
+    return result.structuredContent
+
+
+@pytest.mark.anyio
+async def test_mcp_server_supports_config_generation_run_execution_and_artifact_reads(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    artifact_root = tmp_path / "artifacts"
+    workspace.mkdir(parents=True)
+    artifact_root.mkdir(parents=True)
+
+    synthetic_panel = build_synthetic_panel(
+        (
+            ("VOO", 100.0, 0.9),
+            ("QQQ", 120.0, 1.0),
+            ("SMH", 80.0, 1.2),
+            ("XLV", 70.0, 0.6),
+            ("IEMG", 60.0, 0.7),
+        ),
+        start_date="2024-01-02",
+        end_date="2024-05-31",
+    )
+    cache_dir = workspace / "cache"
+    write_raw_symbol_cache(cache_dir, panel=synthetic_panel)
+
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    repo_src = str(REPO_ROOT / "src")
+    env["PYTHONPATH"] = repo_src if not existing_pythonpath else os.pathsep.join(
+        [repo_src, existing_pythonpath]
+    )
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            str(MCP_LAUNCHER),
+            "--workspace-root",
+            str(workspace),
+            "--artifact-root",
+            str(artifact_root),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            tool_names = sorted(tool.name for tool in tools.tools)
+            assert "marketlab_create_config_from_template" in tool_names
+            assert "marketlab_start_job" in tool_names
+            assert "marketlab_read_table_artifact" in tool_names
+
+            server_info = await _call_tool(session, "marketlab_server_info")
+            assert server_info["transport"] == "stdio"
+            assert not server_info["allow_network"]
+
+            created = await _call_tool(
+                session,
+                "marketlab_create_config_from_template",
+                {
+                    "template_name": "weekly_rank_smoke",
+                    "destination": "configs/mcp_smoke.yaml",
+                },
+            )
+            config_path = created["config_path"]
+
+            await _call_tool(
+                session,
+                "marketlab_patch_config",
+                {
+                    "config_path": str(Path(config_path).relative_to(workspace)),
+                    "patch": {
+                        "data": {
+                            "cache_dir": str(cache_dir),
+                            "start_date": "2024-01-02",
+                            "end_date": "2024-05-31",
+                        },
+                        "baselines": {
+                            "sma": {"enabled": False},
+                        },
+                        "artifacts": {
+                            "save_plots": False,
+                            "save_report_md": True,
+                        },
+                    },
+                },
+            )
+
+            validated = await _call_tool(
+                session,
+                "marketlab_validate_config",
+                {"config_path": str(Path(config_path).relative_to(workspace))},
+            )
+            assert validated["summary"]["cache_dir"] == str(cache_dir.resolve())
+            assert validated["summary"]["output_dir"] == str(artifact_root.resolve())
+
+            plan = await _call_tool(
+                session,
+                "marketlab_plan_run",
+                {
+                    "command": "backtest",
+                    "config_path": str(Path(config_path).relative_to(workspace)),
+                },
+            )
+            assert not plan["network_required"]
+
+            job = await _call_tool(
+                session,
+                "marketlab_start_job",
+                {"plan_id": plan["id"]},
+            )
+            job_id = job["id"]
+
+            for _ in range(240):
+                status = await _call_tool(
+                    session,
+                    "marketlab_get_job_status",
+                    {"job_id": job_id},
+                )
+                if status["status"] in {"succeeded", "failed", "cancelled"}:
+                    break
+                await anyio.sleep(0.1)
+            else:
+                raise AssertionError("Timed out waiting for MCP job completion.")
+
+            assert status["status"] == "succeeded", status
+            assert status["result_kind"] == "run_dir"
+            run_dir = Path(status["result_path"])
+
+            runs = await _call_tool(session, "marketlab_list_runs", {"limit": 5})
+            assert any(Path(run["run_path"]) == run_dir for run in runs["runs"])
+
+            summary = await _call_tool(
+                session,
+                "marketlab_get_run_summary",
+                {"run_path": str(run_dir)},
+            )
+            assert "metrics_preview" in summary
+            assert "strategy_summary_preview" in summary
+            assert "Strategy Summary" in summary["report_sections"]
+
+            artifacts = await _call_tool(
+                session,
+                "marketlab_list_artifacts",
+                {"run_path": str(run_dir)},
+            )
+            artifact_names = {artifact["name"] for artifact in artifacts["artifacts"]}
+            assert {"metrics.csv", "strategy_summary.csv", "report.md"} <= artifact_names
+
+            metrics_preview = await _call_tool(
+                session,
+                "marketlab_read_table_artifact",
+                {"path": str(run_dir / "metrics.csv"), "max_rows": 10},
+            )
+            assert metrics_preview["row_count"] >= 1
+            assert "strategy" in metrics_preview["columns"]
+
+            report_text = await _call_tool(
+                session,
+                "marketlab_read_text_artifact",
+                {"path": str(run_dir / "report.md"), "max_chars": 4000},
+            )
+            assert "Strategy Summary" in report_text["content"]

--- a/tests/unit/test_mcp_artifacts.py
+++ b/tests/unit/test_mcp_artifacts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from marketlab.mcp.server import create_server
+
+
+async def _call_tool(server, name: str, arguments: dict | None = None) -> dict:
+    _, structured = await server.app.call_tool(name, arguments or {})
+    assert structured is not None
+    return structured
+
+
+@pytest.mark.anyio
+async def test_compare_runs_reads_summary_tables_and_report_sections(tmp_path: Path) -> None:
+    server = create_server(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+        repo_root=Path.cwd(),
+        allow_network=False,
+    )
+    left_run = tmp_path / "artifacts" / "left"
+    right_run = tmp_path / "artifacts" / "right"
+    left_run.mkdir(parents=True)
+    right_run.mkdir(parents=True)
+
+    pd.DataFrame(
+        [
+            {"strategy": "buy_hold", "cagr": 0.10},
+            {"strategy": "sma", "cagr": 0.08},
+        ]
+    ).to_csv(left_run / "metrics.csv", index=False)
+    pd.DataFrame(
+        [
+            {"strategy": "buy_hold", "cagr": 0.11},
+            {"strategy": "sma", "cagr": 0.09},
+        ]
+    ).to_csv(right_run / "metrics.csv", index=False)
+    pd.DataFrame([{"strategy": "buy_hold", "avg_gross_exposure": 1.0}]).to_csv(
+        left_run / "strategy_summary.csv",
+        index=False,
+    )
+    pd.DataFrame([{"strategy": "buy_hold", "avg_gross_exposure": 0.95}]).to_csv(
+        right_run / "strategy_summary.csv",
+        index=False,
+    )
+    pd.DataFrame([{"model_name": "logistic_regression", "mean_roc_auc": 0.6}]).to_csv(
+        left_run / "model_summary.csv",
+        index=False,
+    )
+    pd.DataFrame([{"model_name": "logistic_regression", "mean_roc_auc": 0.62}]).to_csv(
+        right_run / "model_summary.csv",
+        index=False,
+    )
+    (left_run / "report.md").write_text(
+        "# Report\n\n## Strategy Summary\n\nLeft\n\n## Cost Sensitivity\n\nBody\n",
+        encoding="utf-8",
+    )
+    (right_run / "report.md").write_text(
+        "# Report\n\n## Strategy Summary\n\nRight\n\n## Benchmark-Relative Summary\n\nBody\n",
+        encoding="utf-8",
+    )
+
+    try:
+        listed = await _call_tool(server, "marketlab_list_runs", {"limit": 10})
+        run_paths = {Path(run["run_path"]).name for run in listed["runs"]}
+        assert {"left", "right"} <= run_paths
+
+        comparison = await _call_tool(
+            server,
+            "marketlab_compare_runs",
+            {
+                "left_run_path": str(left_run),
+                "right_run_path": str(right_run),
+            },
+        )
+        assert "metrics.csv" in comparison["tables"]
+        assert comparison["tables"]["metrics.csv"]["key"] == "strategy"
+        assert "Strategy Summary" in comparison["report_sections"]["left"]
+        assert "Benchmark-Relative Summary" in comparison["report_sections"]["right"]
+    finally:
+        server.close()

--- a/tests/unit/test_mcp_codex_config.py
+++ b/tests/unit/test_mcp_codex_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_codex_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
+    document = tomllib.loads(Path("docs/codex.config.toml.example").read_text(encoding="utf-8"))
+
+    assert set(document["mcp_servers"]) == {
+        "marketlab",
+        "marketlab_online",
+    }
+
+    offline = document["mcp_servers"]["marketlab"]
+    online = document["mcp_servers"]["marketlab_online"]
+
+    assert offline["command"] == "docker"
+    assert offline["args"] == [
+        "exec",
+        "-i",
+        "marketlab-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/artifacts",
+        "--repo-root",
+        "/app/repo",
+    ]
+    assert offline["startup_timeout_sec"] == 20
+    assert offline["tool_timeout_sec"] == 120
+    assert online["args"] == [*offline["args"], "--allow-network"]
+    assert online["startup_timeout_sec"] == offline["startup_timeout_sec"]
+    assert online["tool_timeout_sec"] == offline["tool_timeout_sec"]
+
+
+def test_codex_mcp_sample_matches_compose_container_contract() -> None:
+    compose_text = Path("docker/compose.mcp.yml").read_text(encoding="utf-8")
+    sample_text = Path("docs/codex.config.toml.example").read_text(encoding="utf-8")
+
+    assert 'container_name: marketlab-mcp' in compose_text
+    assert '/app/workspace' in compose_text
+    assert '/app/artifacts' in compose_text
+    assert '/app/repo:ro' in compose_text
+    assert '"marketlab-mcp"' in sample_text
+    assert '"/app/workspace"' in sample_text
+    assert '"/app/artifacts"' in sample_text
+    assert '"/app/repo"' in sample_text

--- a/tests/unit/test_mcp_jobs.py
+++ b/tests/unit/test_mcp_jobs.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from marketlab.mcp.jobs import MarketLabJobManager
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+
+def _write_minimal_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "experiment_name: mcp_job_test",
+                "data:",
+                "  symbols: [VOO, QQQ, SMH, XLV, IEMG]",
+                "  start_date: '2024-01-02'",
+                "  end_date: '2024-03-29'",
+                f"  cache_dir: '{(path.parent.parent / 'cache').as_posix()}'",
+                "artifacts:",
+                f"  output_dir: '{(path.parent.parent.parent / 'artifacts').as_posix()}'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _wait_for_status(manager: MarketLabJobManager, job_id: str, statuses: set[str]) -> dict:
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        job = manager.get_job(job_id)
+        if job["status"] in statuses:
+            return job
+        time.sleep(0.05)
+    raise AssertionError(f"Job {job_id} never reached one of {sorted(statuses)}")
+
+
+def test_job_manager_queues_jobs_and_allows_cancelling_queued_work(tmp_path: Path) -> None:
+    sandbox = WorkspaceSandbox(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+    )
+    config_path = _write_minimal_config(sandbox.workspace_root / "configs" / "job.yaml")
+
+    def command_builder(_: str, __: Path) -> list[str]:
+        return [
+            sys.executable,
+            "-c",
+            (
+                "import time; "
+                "print('job-start'); "
+                "time.sleep(1.0); "
+                "print(r'" + str(sandbox.artifact_root / 'runs' / 'run-a') + "')"
+            ),
+        ]
+
+    manager = MarketLabJobManager(
+        sandbox=sandbox,
+        allow_network=True,
+        command_builder=command_builder,
+    )
+    try:
+        first_plan = manager.create_plan(command="backtest", config_path=config_path)
+        second_plan = manager.create_plan(command="backtest", config_path=config_path)
+        first_job = manager.start_job(first_plan["id"])
+        second_job = manager.start_job(second_plan["id"])
+
+        _wait_for_status(manager, first_job["id"], {"running"})
+        queued = manager.get_job(second_job["id"])
+        assert queued["status"] == "queued"
+
+        cancelled = manager.cancel_job(second_job["id"])
+        assert cancelled["status"] == "cancelled"
+
+        finished = _wait_for_status(manager, first_job["id"], {"succeeded"})
+        assert finished["result_kind"] == "run_dir"
+        assert "run-a" in finished["result_path"]
+    finally:
+        manager.close()
+
+
+def test_plan_creation_rejects_network_when_cache_is_missing(tmp_path: Path) -> None:
+    sandbox = WorkspaceSandbox(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+    )
+    config_path = _write_minimal_config(sandbox.workspace_root / "configs" / "network.yaml")
+
+    manager = MarketLabJobManager(
+        sandbox=sandbox,
+        allow_network=False,
+    )
+    try:
+        with pytest.raises(ValueError, match="requires network access"):
+            manager.create_plan(command="backtest", config_path=config_path)
+    finally:
+        manager.close()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from marketlab.mcp.server import create_server
+
+
+async def _call_tool(server, name: str, arguments: dict | None = None) -> dict:
+    _, structured = await server.app.call_tool(name, arguments or {})
+    assert structured is not None
+    return structured
+
+
+@pytest.mark.anyio
+async def test_server_info_and_config_tools_work_in_process(tmp_path: Path) -> None:
+    server = create_server(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+        repo_root=Path.cwd(),
+        allow_network=False,
+    )
+    try:
+        info = await _call_tool(server, "marketlab_server_info")
+        assert info["server_name"] == "marketlab"
+        assert "marketlab_create_config_from_template" in info["tool_groups"]["configs"]
+
+        created = await _call_tool(
+            server,
+            "marketlab_create_config_from_template",
+            {
+                "template_name": "weekly_rank_smoke",
+                "destination": "configs/test.yaml",
+            },
+        )
+        config_path = Path(created["config_path"]).relative_to(tmp_path / "workspace")
+
+        read_result = await _call_tool(
+            server,
+            "marketlab_read_config",
+            {"config_path": str(config_path)},
+        )
+        assert read_result["document"]["artifacts"]["output_dir"] == str(
+            (tmp_path / "artifacts").resolve()
+        )
+
+        patched = await _call_tool(
+            server,
+            "marketlab_patch_config",
+            {
+                "config_path": str(config_path),
+                "patch": {
+                    "data": {
+                        "cache_dir": str((tmp_path / "workspace" / "cache").resolve()),
+                        "start_date": "2024-01-02",
+                        "end_date": "2024-03-29",
+                    }
+                },
+            },
+        )
+        assert patched["document"]["data"]["start_date"] == "2024-01-02"
+
+        validated = await _call_tool(
+            server,
+            "marketlab_validate_config",
+            {"config_path": str(config_path)},
+        )
+        assert validated["summary"]["output_dir"] == str((tmp_path / "artifacts").resolve())
+    finally:
+        server.close()

--- a/tests/unit/test_mcp_vscode_config.py
+++ b/tests/unit/test_mcp_vscode_config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_vscode_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
+    document = json.loads(Path(".vscode/mcp.json.example").read_text(encoding="utf-8"))
+
+    assert set(document["servers"]) == {
+        "marketlab-docker-offline",
+        "marketlab-docker-online",
+    }
+
+    offline = document["servers"]["marketlab-docker-offline"]
+    online = document["servers"]["marketlab-docker-online"]
+
+    assert offline["type"] == "stdio"
+    assert offline["command"] == "docker"
+    assert offline["args"] == [
+        "exec",
+        "-i",
+        "marketlab-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/artifacts",
+        "--repo-root",
+        "/app/repo",
+    ]
+    assert online["args"] == [*offline["args"], "--allow-network"]
+
+
+def test_vscode_mcp_sample_matches_compose_container_contract() -> None:
+    compose_text = Path("docker/compose.mcp.yml").read_text(encoding="utf-8")
+    sample_text = Path(".vscode/mcp.json.example").read_text(encoding="utf-8")
+
+    assert 'container_name: marketlab-mcp' in compose_text
+    assert '/app/workspace' in compose_text
+    assert '/app/artifacts' in compose_text
+    assert '/app/repo:ro' in compose_text
+    assert '"marketlab-mcp"' in sample_text
+    assert '"/app/workspace"' in sample_text
+    assert '"/app/artifacts"' in sample_text
+    assert '"/app/repo"' in sample_text

--- a/tests/unit/test_mcp_workspace.py
+++ b/tests/unit/test_mcp_workspace.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from marketlab.mcp.workspace import WorkspaceSandbox
+
+
+def test_create_config_from_template_normalizes_artifact_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    artifacts = tmp_path / "artifacts"
+    sandbox = WorkspaceSandbox(workspace_root=workspace, artifact_root=artifacts)
+
+    created_path = sandbox.create_config_from_template(
+        template_name="weekly_rank_smoke",
+        destination="configs/generated.yaml",
+    )
+
+    document = sandbox.read_config(created_path.relative_to(workspace))
+    assert created_path.exists()
+    assert document["artifacts"]["output_dir"] == str(artifacts.resolve())
+
+
+def test_copy_repo_config_rewrites_output_dir_into_artifact_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
+    source_path = repo_root / "configs" / "repo_config.yaml"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text(
+        "experiment_name: copied\nartifacts:\n  output_dir: artifacts/runs\n",
+        encoding="utf-8",
+    )
+
+    sandbox = WorkspaceSandbox(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+        repo_root=repo_root,
+    )
+
+    copied_path = sandbox.copy_repo_config(
+        repo_config_path="configs/repo_config.yaml",
+        destination="configs/copied.yaml",
+    )
+
+    document = sandbox.read_config(copied_path.relative_to(sandbox.workspace_root))
+    assert document["artifacts"]["output_dir"] == str(sandbox.artifact_root)
+
+
+def test_patch_config_and_validate_config_use_existing_loader(tmp_path: Path) -> None:
+    sandbox = WorkspaceSandbox(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+    )
+    config_path = sandbox.create_config_from_template(
+        template_name="weekly_rank_smoke",
+        destination="configs/smoke.yaml",
+    )
+
+    sandbox.patch_config(
+        config_path=config_path.relative_to(sandbox.workspace_root),
+        patch={
+            "data": {
+                "cache_dir": str(sandbox.workspace_root / "cache"),
+                "start_date": "2024-01-02",
+                "end_date": "2024-03-29",
+            },
+            "artifacts": {"output_dir": str(sandbox.artifact_root)},
+        },
+    )
+
+    validation = sandbox.validate_config(config_path.relative_to(sandbox.workspace_root))
+
+    assert validation["summary"]["output_dir"] == str(sandbox.artifact_root)
+    assert validation["summary"]["cache_dir"] == str((sandbox.workspace_root / "cache").resolve())
+
+
+def test_validate_config_rejects_writes_outside_sandbox(tmp_path: Path) -> None:
+    sandbox = WorkspaceSandbox(
+        workspace_root=tmp_path / "workspace",
+        artifact_root=tmp_path / "artifacts",
+    )
+    config_path = sandbox.create_config_from_template(
+        template_name="weekly_rank_smoke",
+        destination="configs/unsafe.yaml",
+    )
+
+    sandbox.patch_config(
+        config_path=config_path.relative_to(sandbox.workspace_root),
+        patch={"artifacts": {"output_dir": str(tmp_path.parent / "outside-runs")}},
+    )
+
+    with pytest.raises(ValueError, match="outside the allowed workspace or artifact roots"):
+        sandbox.validate_config(config_path.relative_to(sandbox.workspace_root))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = lint, docs, py312, py313, py314, integration, package, preflight-fast, preflight-slow, preflight
+env_list = lint, docs, py312, py313, py314, integration, package, mcp-docker, preflight-fast, preflight-slow, preflight
 skip_missing_interpreters = true
 isolated_build = true
 work_dir = {tox_root}{/}.tox
@@ -7,6 +7,7 @@ work_dir = {tox_root}{/}.tox
 [testenv]
 description = Run the fast deterministic unit suite through the bootstrapped Python environment
 package = editable
+extras = mcp
 deps =
     pytest>=8.0
 commands =
@@ -54,6 +55,16 @@ set_env =
 commands =
     {envpython} -m build --no-isolation
     {envpython} scripts/check_package.py
+
+[testenv:mcp-docker]
+description = Build the Docker image and exercise the MarketLab MCP stdio bridge through docker exec
+basepython = py312
+package = editable
+extras = mcp
+deps =
+    anyio>=4.0
+commands =
+    {envpython} scripts/check_mcp_docker.py
 
 [testenv:preflight-fast]
 description = Run the fast local validation gate through the CI-aligned tox envs


### PR DESCRIPTION
## Summary
- add the MarketLab MCP packaging, stdio launcher, and workspace/artifact sandbox
- add config authoring and validation tools, queued job controls, and artifact inspection tools
- add Docker sidecar docs, client examples, package smoke coverage, and the dedicated MCP CI lane

## Roadmap
- Phase 6 epic: #56
- #57 packaging, launcher, and workspace sandbox
- #58 config authoring and validation tools
- #59 queued execution controls and job logs
- #60 artifact inspection and run comparison tools
- #61 Docker sidecar docs, compose example, and MCP CI

## Validation
- `py -3.14 -m ruff check .`
- `py -3.14 -m mkdocs build --strict`
- `py -3.14 scripts/check_mcp_docker.py`
- `py -3.12 -m tox -e preflight` was not runnable on this host because only Python 3.14 is installed and the tox envs are pinned to `py312`
- `py -3.12 -m tox -e mcp-docker` was not runnable on this host for the same interpreter reason; the underlying Docker smoke passed directly via `py -3.14 scripts/check_mcp_docker.py`

Closes #57
Closes #58
Closes #59
Closes #60
Closes #61
Refs #56
