### PR TITLE
feat: add autonomous single-ETF paper loop with LLM approvals

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .codex/
+.env
 .docker-config/
 .git/
 .github/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+ALPACA_API_KEY_ID=your-paper-key-id
+ALPACA_API_SECRET_KEY=your-paper-secret
+ALPACA_DATA_BASE_URL=https://data.alpaca.markets
+ALPACA_TRADING_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_DATA_FEED=iex
+ALPACA_TIMEOUT_SECONDS=30
+OPENAI_API_KEY=your-openai-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/.github/issue-seeds/phase7-voo-paper.json
+++ b/.github/issue-seeds/phase7-voo-paper.json
@@ -1,0 +1,49 @@
+{
+  "project": {
+    "number": 3
+  },
+  "labels": [
+    {
+      "name": "phase-7",
+      "color": "0052cc",
+      "description": "Phase 7 roadmap work for the configurable single-ETF paper-trading MVP."
+    },
+    {
+      "name": "track:broker",
+      "color": "d4c5f9",
+      "description": "Broker, paper-trading, and order-routing work."
+    },
+    {
+      "name": "track:ops",
+      "color": "5319e7",
+      "description": "Scheduler, deployment, and operational runbook work."
+    }
+  ],
+  "issues": [
+    {
+      "title": "Phase 7.1: autonomous single-ETF paper loop with OpenAI and Claude backends",
+      "labels": ["phase-7", "priority:p0", "track:platform"],
+      "body": "## Summary\nAdd an unattended single-ETF paper loop that writes six-model consensus proposals, routes agent approval through either OpenAI or Claude with deterministic fallback, and reports one-month paper outcomes against baselines.\n\n## Scope\n- keep the paper loop configurable for any single ETF\n- tracked unattended-month config uses `QQQ`\n- ship `VOO` as a first-class alternate config\n- replace the pinned single-model proposal with a deterministic `4-of-6` consensus proposal\n- add an autonomous agent worker that can use `openai` or `claude`\n- keep `deterministic_consensus` as the required fallback backend\n- add month-run paper reporting against `buy_hold`, `sma`, each model path, and the consensus path\n\n## Non-goals\n- no live-money broker support\n- no multi-symbol execution\n- no freeform LLM trade generation\n- no web UI\n"
+    },
+    {
+      "title": "Add six-model paper decision and consensus proposal artifacts",
+      "labels": ["phase-7", "priority:p0", "track:strategy"],
+      "body": "## Scope\n- expand `paper-decision` from one model to the full six-model registry\n- persist one proposal plus one evidence artifact per trade date\n- apply a deterministic `4-of-6` long-vote rule for the executable consensus proposal\n- keep the paper path single-ETF, long-or-cash, and one-day horizon only\n\n## Depends on\n- Phase 7.1: autonomous single-ETF paper loop with OpenAI and Claude backends\n\n## Review\n- financial-expert\n- qa\n"
+    },
+    {
+      "title": "Add autonomous paper agent worker and deterministic approval backend",
+      "labels": ["phase-7", "priority:p0", "track:platform", "track:broker"],
+      "body": "## Scope\n- add `paper-agent-approve` and a long-running agent worker service\n- keep agent authority limited to approve-or-reject of the existing proposal only\n- add deterministic approval rules for malformed or inconsistent proposals\n- persist provider, model, rationale, and fallback metadata in approval artifacts\n\n## Depends on\n- Add six-model paper decision and consensus proposal artifacts\n\n## Review\n- critic\n- qa\n"
+    },
+    {
+      "title": "Add OpenAI and Claude approval backends with structured fallback",
+      "labels": ["phase-7", "priority:p0", "track:platform"],
+      "body": "## Scope\n- add `paper.agent_backend`, `paper.agent_model`, and timeout/fallback config fields\n- implement OpenAI structured-output approval decisions with the official SDK\n- implement Claude structured-output approval decisions with the official SDK\n- fall back to `deterministic_consensus` on provider timeout, API failure, or invalid output\n\n## Depends on\n- Add autonomous paper agent worker and deterministic approval backend\n\n## Review\n- critic\n- qa\n"
+    },
+    {
+      "title": "Add tracked QQQ and VOO paper configs plus month-run paper reporting",
+      "labels": ["phase-7", "priority:p1", "track:ops", "track:docs"],
+      "body": "## Scope\n- keep `configs/experiment.qqq_paper_daily.yaml` as the tracked unattended-month config\n- add `configs/experiment.voo_paper_daily.yaml` as a first-class alternate config\n- update Compose and docs for scheduler plus agent worker plus MCP sidecar\n- add `paper-report` outputs for realized paper path, consensus, each model path, `buy_hold`, and `sma`\n\n## Depends on\n- Add OpenAI and Claude approval backends with structured fallback\n\n## Review\n- critic\n- qa\n"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 .codex/
 .tox/
 .tox-ci/
+.env
+.env.*
+!.env.example
 build/
 dist/
 site/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # MarketLab
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly supervised modeling rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, and reviewable artifact summaries.
+MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly and daily supervised timing rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, reviewable artifact summaries, and a local Alpaca paper-trading MVP for a configurable daily single-ETF timing loop.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
+See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.
 See [docs/codex-mcp.md](docs/codex-mcp.md) for attaching the Docker-packaged MCP server to a new Codex session.
 See [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md) for the VS Code stable + GitHub Copilot connection path.
@@ -16,6 +17,11 @@ python scripts/run_marketlab.py prepare-data --config configs/experiment.weekly_
 python scripts/run_marketlab.py backtest --config configs/experiment.weekly_rank.yaml
 python scripts/run_marketlab.py train-models --config configs/experiment.weekly_rank.yaml
 python scripts/run_marketlab.py run-experiment --config configs/experiment.weekly_rank.yaml
+python scripts/run_marketlab.py paper-status --config configs/experiment.qqq_paper_daily.yaml
+python scripts/run_marketlab.py paper-decision --config configs/experiment.qqq_paper_daily.yaml
+python scripts/run_marketlab.py paper-agent-approve --config configs/experiment.qqq_paper_daily.yaml --once
+python scripts/run_marketlab.py paper-scheduler --config configs/experiment.qqq_paper_daily.yaml --once
+python scripts/run_marketlab.py paper-report --config configs/experiment.qqq_paper_daily.yaml --start 2026-04-13 --end 2026-05-15
 ```
 
 `python scripts/run_marketlab.py ...` is the canonical local invocation path because it always resolves to the source tree under `src/`.
@@ -32,6 +38,13 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `backtest`: run the enabled baselines (`buy_hold`, `sma`, optional config-defined allocation baselines, and the optional executable optimized baseline) and write performance, analytics summaries, report, and plots.
 - `train-models`: fit the configured models across walk-forward folds and write raw training artifacts plus fold/model summaries, ranking diagnostics, calibration diagnostics, threshold diagnostics, and review plots.
 - `run-experiment`: run baselines and ML strategies together on the shared out-of-sample window and write the experiment outputs, analytics summaries, ranking-aware ML summary CSVs, calibration/threshold diagnostics, and review plots.
+- `paper-decision`: refresh Alpaca daily data, retrain the six-model daily paper set for the configured single ETF, and persist one consensus proposal plus evidence.
+- `paper-status`: read the latest persisted paper-trading status plus the latest proposal summary.
+- `paper-approve`: approve or reject one persisted proposal by actor `agent` or `manual`.
+- `paper-agent-approve`: run the autonomous agent worker once or in a loop, using `openai`, `claude`, or deterministic fallback to approve or reject pending proposals.
+- `paper-submit`: reconcile the approved proposal against the Alpaca paper account and persist either a submitted fractional `DAY` market order, a no-op, or a skipped submission.
+- `paper-scheduler`: run the long-lived local paper loop for the configured decision and submission windows.
+- `paper-report`: build a month-run paper report comparing the realized paper path, the consensus path, each model path, `buy_hold`, and `sma`.
 
 ## Artifact Outputs
 
@@ -295,6 +308,8 @@ Interpretation rules:
 `configs/experiment.voo_long_only.ytd.yaml` is a tracked one-symbol directional timing example built around `VOO` from `2018-01-01` through `2026-04-03`. It currently compares five sklearn models, runs in `long_only` mode with `long_n: 1`, and lowers `min_test_rows` to `10` so quarterly test folds stay viable on a one-symbol weekly dataset.
 
 Treat this config as a timing study, not as a cross-sectional ranking experiment. Compare its ML outputs primarily against `buy_hold` and `sma`, and do not read the results as evidence about cross-sectional ranking skill.
+
+The separate Phase 7 paper-trading path is now a configurable single-ETF loop. The tracked unattended-month config is `configs/experiment.qqq_paper_daily.yaml`, and `configs/experiment.voo_paper_daily.yaml` ships as the first alternate comparison config.
 
 ## Lightweight Model Comparison Set
 

--- a/configs/experiment.qqq_paper_daily.yaml
+++ b/configs/experiment.qqq_paper_daily.yaml
@@ -1,0 +1,83 @@
+experiment_name: qqq_paper_daily
+
+data:
+  symbols: [QQQ]
+  start_date: "2018-01-01"
+  end_date: "2026-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data-qqq-paper-daily"
+  prepared_panel_filename: "panel.csv"
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 1
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "D"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 1
+    step_months: 1
+    min_train_rows: 200
+    min_test_rows: 15
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: true
+  data_provider: "alpaca"
+  broker: "alpaca"
+  execution_mode: "agent_approval"
+  agent_backend: "openai"
+  agent_model: "gpt-4o-mini"
+  agent_timeout_seconds: 30
+  agent_fallback_backend: "deterministic_consensus"
+  consensus_min_long_votes: 4
+  schedule_timezone: "America/New_York"
+  decision_time: "16:10"
+  submission_time: "19:05"
+  order_type: "day_market"
+  position_sizing: "full_equity_fractional"
+  approval_inbox_dir: "artifacts/paper/inbox"
+  state_dir: "artifacts/paper/state"
+  poll_interval_seconds: 30
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.voo_paper_daily.yaml
+++ b/configs/experiment.voo_paper_daily.yaml
@@ -1,0 +1,83 @@
+experiment_name: voo_paper_daily
+
+data:
+  symbols: [VOO]
+  start_date: "2018-01-01"
+  end_date: "2026-12-31"
+  interval: "1d"
+  cache_dir: "artifacts/data-voo-paper-daily"
+  prepared_panel_filename: "panel.csv"
+
+features:
+  return_windows: [5, 10, 20, 40]
+  ma_windows: [10, 20, 50]
+  vol_windows: [10, 20]
+  momentum_window: 20
+
+target:
+  horizon_days: 1
+  type: "direction"
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "D"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 10
+
+baselines:
+  buy_hold: true
+  sma:
+    enabled: true
+    fast_window: 20
+    slow_window: 50
+
+models:
+  - name: logistic_regression
+  - name: logistic_l1
+  - name: random_forest
+  - name: extra_trees
+  - name: gradient_boosting
+  - name: hist_gradient_boosting
+
+evaluation:
+  walk_forward:
+    train_years: 3
+    test_months: 1
+    step_months: 1
+    min_train_rows: 200
+    min_test_rows: 15
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: true
+  data_provider: "alpaca"
+  broker: "alpaca"
+  execution_mode: "agent_approval"
+  agent_backend: "openai"
+  agent_model: "gpt-4o-mini"
+  agent_timeout_seconds: 30
+  agent_fallback_backend: "deterministic_consensus"
+  consensus_min_long_votes: 4
+  schedule_timezone: "America/New_York"
+  decision_time: "16:10"
+  submission_time: "19:05"
+  order_type: "day_market"
+  position_sizing: "full_equity_fractional"
+  approval_inbox_dir: "artifacts/paper/inbox"
+  state_dir: "artifacts/paper/state"
+  poll_interval_seconds: 30
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/docker/compose.paper.yml
+++ b/docker/compose.paper.yml
@@ -1,0 +1,69 @@
+services:
+  marketlab-paper-mcp:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: marketlab-mcp:local
+    container_name: marketlab-paper-mcp
+    restart: unless-stopped
+    user: "${MARKETLAB_UID:-1000}:${MARKETLAB_GID:-1000}"
+    entrypoint: ["sleep", "infinity"]
+    working_dir: /app
+    volumes:
+      - ../workspace:/app/workspace
+      - ../artifacts:/app/repo/artifacts
+      - ..:/app/repo:ro
+
+  marketlab-paper-scheduler:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: marketlab-mcp:local
+    container_name: marketlab-paper-scheduler
+    restart: unless-stopped
+    user: "${MARKETLAB_UID:-1000}:${MARKETLAB_GID:-1000}"
+    working_dir: /app
+    command:
+      - paper-scheduler
+      - --config
+      - /app/repo/configs/experiment.qqq_paper_daily.yaml
+    environment:
+      ALPACA_API_KEY_ID: "${ALPACA_API_KEY_ID:-}"
+      ALPACA_API_SECRET_KEY: "${ALPACA_API_SECRET_KEY:-}"
+      ALPACA_DATA_BASE_URL: "${ALPACA_DATA_BASE_URL:-https://data.alpaca.markets}"
+      ALPACA_TRADING_BASE_URL: "${ALPACA_TRADING_BASE_URL:-https://paper-api.alpaca.markets}"
+      ALPACA_DATA_FEED: "${ALPACA_DATA_FEED:-iex}"
+      ALPACA_TIMEOUT_SECONDS: "${ALPACA_TIMEOUT_SECONDS:-30}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+    volumes:
+      - ../workspace:/app/workspace
+      - ../artifacts:/app/repo/artifacts
+      - ..:/app/repo:ro
+
+  marketlab-paper-agent:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: marketlab-mcp:local
+    container_name: marketlab-paper-agent
+    restart: unless-stopped
+    user: "${MARKETLAB_UID:-1000}:${MARKETLAB_GID:-1000}"
+    working_dir: /app
+    command:
+      - paper-agent-approve
+      - --config
+      - /app/repo/configs/experiment.qqq_paper_daily.yaml
+    environment:
+      ALPACA_API_KEY_ID: "${ALPACA_API_KEY_ID:-}"
+      ALPACA_API_SECRET_KEY: "${ALPACA_API_SECRET_KEY:-}"
+      ALPACA_DATA_BASE_URL: "${ALPACA_DATA_BASE_URL:-https://data.alpaca.markets}"
+      ALPACA_TRADING_BASE_URL: "${ALPACA_TRADING_BASE_URL:-https://paper-api.alpaca.markets}"
+      ALPACA_DATA_FEED: "${ALPACA_DATA_FEED:-iex}"
+      ALPACA_TIMEOUT_SECONDS: "${ALPACA_TIMEOUT_SECONDS:-30}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+    volumes:
+      - ../workspace:/app/workspace
+      - ../artifacts:/app/repo/artifacts
+      - ..:/app/repo:ro

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-Phases 1 through 5 are complete.
+Phases 1 through 6 are complete.
 
 MarketLab is a public research MVP with:
 
@@ -12,6 +12,7 @@ MarketLab is a public research MVP with:
 - a Dockerized manual runner workflow
 - release automation and a batched release path
 - richer Phase 5 baseline, diagnostics, and scenario-pack coverage
+- a Phase 7 local paper-trading MVP for a configurable daily single-ETF timing loop
 
 The project now supports a small, reviewable end-to-end research workflow rather than a local-only scaffold.
 
@@ -24,6 +25,13 @@ The project now supports a small, reviewable end-to-end research workflow rather
 - `marketlab list-configs`
 - `marketlab write-config --name ... --output ...`
 - `marketlab-mcp --workspace-root ... --artifact-root ...`
+- `marketlab paper-decision --config ...`
+- `marketlab paper-status --config ...`
+- `marketlab paper-approve --config ... --proposal-id ... --decision ... --actor ...`
+- `marketlab paper-agent-approve --config ...`
+- `marketlab paper-submit --config ...`
+- `marketlab paper-scheduler --config ...`
+- `marketlab paper-report --config ... --start ... --end ...`
 
 Current workflow surface:
 
@@ -37,6 +45,8 @@ Current workflow surface:
 - lightweight sklearn comparison baseline
 - CSV, plot, and Markdown reporting artifacts
 - sandboxed config authoring, async job control, and run-artifact inspection for MCP clients
+- local file-backed paper-trading proposals, approvals, and submission state
+- local Docker Compose scheduling for the daily single-ETF paper loop
 
 ## Phase 4 Outcomes Worth Keeping
 
@@ -50,27 +60,30 @@ The most important Phase 4 outcomes were about research quality rather than head
 
 The key lesson from Phase 4 is that score quality, realized strategy outcomes, and overall research robustness are separate questions. Phase 4 improved how clearly the repo answers those questions; it did not, by itself, establish durable trading edge.
 
-## Phase 6 Direction
+## Phase 7 Direction
 
-Phase 6 should productize the current workflow for LLM-driven use through a Docker-friendly MCP server.
+Phase 7 extends the research workflow into a narrow paper-only execution loop for a configurable daily single-ETF timing strategy.
 
 Priority direction:
 
-- keep the protocol surface tools-first and generic-client-friendly
-- make config authoring and execution safe through workspace sandboxing and confirmation gates
-- preserve the installed CLI as the execution backend so MCP behavior matches the packaged product
-- keep Docker as the deployment wrapper instead of introducing a second runtime architecture
+- keep the live-ish path intentionally narrow and paper-only
+- keep model selection explicit through tracked configs instead of auto-promoting research winners
+- preserve the CLI as the execution backend and use MCP only for proposal review and approval
+- keep the scheduler local and Dockerized instead of introducing a hosted control plane
+- keep the autonomous agent limited to approve-or-reject of the deterministic consensus proposal
 
-## Phase 6 Candidate Workstreams
+## Phase 7 Workstreams
 
-- MCP server scaffold and workspace sandboxing
-- template-driven config authoring and validation tools
-- async job planning, queued execution, and log tails
-- artifact inspection, plot retrieval, and compact run comparison
-- Docker sidecar docs and required MCP CI
+- daily one-day timing support for the single-ETF paper path
+- six-model consensus paper proposals with persisted evidence artifacts
+- autonomous approval worker with `openai`, `claude`, and deterministic fallback
+- Alpaca paper order submission, account snapshots, and order polling
+- tracked `QQQ` plus alternate `VOO` paper configs
+- month-run paper reporting against consensus, per-model paths, `buy_hold`, and `sma`
+- local Docker Compose scheduler and agent worker plus the Phase 7 operations runbook
 
 ## Deferred
 
 - stricter branch and ruleset hardening can wait
 - wiki polish remains optional
-- cron-based Docker automation is still optional and not part of the MVP
+- live-money broker support remains out of scope

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,7 +9,9 @@ MarketLab is a research toolkit for running repeatable market experiments from a
 
 The current library is built for research, not live trading. It is good at making assumptions explicit, replaying the same workflow, and showing why a result happened. It is not claiming that a model is ready for production deployment.
 
-This explainer uses the current `VOO` timing example at `configs/experiment.voo_long_only.ytd.yaml` and the local run directory `artifacts/runs/voo_long_only_ytd/20260403T080623Z/`.
+This explainer uses the current weekly `VOO` timing example at `configs/experiment.voo_long_only.ytd.yaml` and the local run directory `artifacts/runs/voo_long_only_ytd/20260403T080623Z/`.
+
+Phase 7 also adds separate daily paper-trading configs at `configs/experiment.qqq_paper_daily.yaml` and `configs/experiment.voo_paper_daily.yaml`. Those newer configs are intentionally operational: they use a six-model consensus proposal, an autonomous approval worker, and paper-account state artifacts. This explainer stays focused on the weekly research example because it is easier to read as a standalone methodology walkthrough.
 
 ## What Problem The Library Is Solving
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -46,6 +46,13 @@ Artifacts:
 - `marketlab_get_plot_artifact`
 - `marketlab_compare_runs`
 
+Paper:
+
+- `marketlab_list_paper_proposals`
+- `marketlab_read_paper_proposal`
+- `marketlab_get_paper_status`
+- `marketlab_decide_paper_proposal`
+
 ## Local Install
 
 Install the MCP extra:
@@ -68,6 +75,7 @@ The generic deployment shape is a long-lived container plus one `docker exec -i`
 Example helper files:
 
 - `docker/compose.mcp.yml`
+- `docker/compose.paper.yml`
 - `docs/codex.config.toml.example`
 - `.vscode/mcp.json.example`
 

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -1,0 +1,201 @@
+# Phase 7 Paper Trading
+
+Phase 7 adds a local, paper-only execution loop around a configurable single-ETF timing strategy. It stays deliberately narrow:
+
+- one configured ETF ticker
+- one target: `direction`
+- one horizon: `1` trading day
+- one execution style: `long` or `cash`
+- one broker family: Alpaca paper only
+- one deployment shape: local Docker Compose plus a file-backed approval inbox
+
+This is still a paper-trading MVP. It is not a live-money workflow. The tracked unattended-month config uses `QQQ`, and `VOO` ships as the first alternate comparison config.
+
+## Tracked Config
+
+The tracked Phase 7 config is:
+
+- `configs/experiment.qqq_paper_daily.yaml`
+- `configs/experiment.voo_paper_daily.yaml` is the first alternate config with the same paper loop shape
+
+It pins the current paper path to:
+
+- `data.symbols: [QQQ]`
+- `rebalance_frequency: "D"`
+- `target.horizon_days: 1`
+- `portfolio.ranking.mode: "long_only"`
+- `long_n: 1`
+- `short_n: 1`
+- `min_score_threshold: 0.55`
+- six configured models:
+  - `logistic_regression`
+  - `logistic_l1`
+  - `random_forest`
+  - `extra_trees`
+  - `gradient_boosting`
+  - `hist_gradient_boosting`
+- consensus rule: `4` or more long votes out of `6`
+- default execution mode: `agent_approval`
+- default provider backend in the tracked config: `openai`
+- required fallback backend: `deterministic_consensus`
+
+The paper path intentionally does not auto-pick the latest research winner at runtime. If the model set, threshold, or provider backend changes, do that by changing the tracked config and reviewing the research outcome first.
+
+## Command Surface
+
+New CLI commands:
+
+```bash
+python scripts/run_marketlab.py paper-decision --config configs/experiment.qqq_paper_daily.yaml
+python scripts/run_marketlab.py paper-status --config configs/experiment.qqq_paper_daily.yaml
+python scripts/run_marketlab.py paper-approve --config configs/experiment.qqq_paper_daily.yaml --proposal-id <id> --decision approve --actor agent
+python scripts/run_marketlab.py paper-agent-approve --config configs/experiment.qqq_paper_daily.yaml --once
+python scripts/run_marketlab.py paper-submit --config configs/experiment.qqq_paper_daily.yaml
+python scripts/run_marketlab.py paper-scheduler --config configs/experiment.qqq_paper_daily.yaml --once
+python scripts/run_marketlab.py paper-report --config configs/experiment.qqq_paper_daily.yaml --start 2026-04-13 --end 2026-05-15
+```
+
+Behavior:
+
+- `paper-decision` refreshes Alpaca daily bars, rebuilds the latest feature snapshot, retrains all six configured models on the rolling historical window, and writes one consensus proposal plus one evidence artifact.
+- `paper-status` reads the latest persisted status plus the latest proposal summary.
+- `paper-approve` records an `approve` or `reject` decision by actor `agent` or `manual`.
+- `paper-agent-approve` runs the autonomous agent worker once or in a loop. It may use `openai`, `claude`, or `deterministic_consensus`, but it may only approve or reject the existing proposal as written.
+- `paper-submit` enforces the approval mode, reconciles against the current paper position, and either submits one fractional `DAY` market order or records a skipped or no-op submission.
+- `paper-scheduler` is the long-running local loop used by Docker Compose.
+- `paper-report` reconstructs the paper-run outcome over a chosen date range and compares the realized paper path, the consensus path, each model path, `buy_hold`, and `sma`.
+
+## Approval Modes
+
+`paper.execution_mode` supports:
+
+- `autonomous`: submit without approval
+- `agent_approval`: require `paper-approve ... --actor agent`
+- `manual_approval`: require `paper-approve ... --actor manual`
+
+If approval is still missing when the submission phase runs, the trade is skipped and the submission state records the reason.
+
+## Agent Backends
+
+`paper.agent_backend` supports:
+
+- `openai`
+- `claude`
+- `deterministic_consensus`
+
+The tracked config defaults to `openai`, but the worker always falls back to `deterministic_consensus` when:
+
+- the provider key is missing
+- the provider times out
+- the provider call fails
+- the provider returns invalid structured output
+
+The LLM is not allowed to invent a different trade. It only approves or rejects the consensus proposal and records a short rationale.
+
+## Persisted State
+
+Phase 7 uses a file-backed approval inbox and per-trade state under `artifacts/paper/`.
+
+The main persisted surfaces are:
+
+- inbox proposals: `artifacts/paper/inbox/*.json`
+- trade proposal: `artifacts/paper/state/trades/<trade-date>/proposal.json`
+- trade evidence: `artifacts/paper/state/trades/<trade-date>/evidence.json`
+- trade approval: `artifacts/paper/state/trades/<trade-date>/approval.json`
+- order preview: `artifacts/paper/state/trades/<trade-date>/order_preview.json`
+- account snapshot: `artifacts/paper/state/trades/<trade-date>/account_snapshot.json`
+- submission state: `artifacts/paper/state/trades/<trade-date>/submission.json`
+- order polling result: `artifacts/paper/state/trades/<trade-date>/order_status.json`
+- month-run reports: `artifacts/paper/reports/<start>_<end>/`
+- latest status summary: `artifacts/paper/state/status.json`
+
+This is the shared contract between the CLI, the scheduler, and the MCP paper tools.
+
+## Alpaca Environment
+
+Keep credentials in environment variables, not YAML. For local runs, copy `.env.example` to `.env` in the repo root and fill in the paper credentials:
+
+```bash
+cp .env.example .env
+```
+
+The local CLI and MCP paper path will load `.env` from the current working directory when those variables are not already present in the process environment.
+
+Example `.env` values:
+
+```bash
+ALPACA_API_KEY_ID="..."
+ALPACA_API_SECRET_KEY="..."
+ALPACA_DATA_BASE_URL="https://data.alpaca.markets"
+ALPACA_TRADING_BASE_URL="https://paper-api.alpaca.markets"
+ALPACA_DATA_FEED="iex"
+ALPACA_TIMEOUT_SECONDS="30"
+OPENAI_API_KEY="..."
+ANTHROPIC_API_KEY="..."
+```
+
+The paper broker path rejects non-paper trading endpoints at runtime unless the base URL is a local test server.
+
+## Docker Compose Loop
+
+The checked-in local stack is:
+
+- `docker/compose.paper.yml`
+
+It starts:
+
+- `marketlab-paper-scheduler`
+- `marketlab-paper-agent`
+- `marketlab-paper-mcp`
+
+Start the stack:
+
+```bash
+docker compose --env-file .env -f docker/compose.paper.yml up -d --build
+```
+
+On Linux, export the host UID and GID first so the bind-mounted directories stay writable:
+
+```bash
+export MARKETLAB_UID="$(id -u)"
+export MARKETLAB_GID="$(id -g)"
+docker compose --env-file .env -f docker/compose.paper.yml up -d --build
+```
+
+The scheduler uses the tracked repo config at `/app/repo/configs/experiment.qqq_paper_daily.yaml` and a writable artifact submount at `/app/repo/artifacts`.
+
+The agent worker uses the same tracked config and artifact mount, so the approval loop and the scheduler see the same proposal, approval, and submission state.
+
+The matching MCP sidecar should be launched with the same artifact root so it sees the same proposal and submission files:
+
+```bash
+docker exec -i marketlab-paper-mcp \
+  marketlab-mcp \
+  --workspace-root /app/workspace \
+  --artifact-root /app/repo/artifacts \
+  --repo-root /app/repo
+```
+
+## MCP Paper Tools
+
+The MCP server now also exposes a narrow paper-review surface:
+
+- `marketlab_list_paper_proposals`
+- `marketlab_read_paper_proposal`
+- `marketlab_get_paper_status`
+- `marketlab_decide_paper_proposal`
+
+These tools intentionally stop at review and approval. Order submission still happens through the CLI-backed scheduler path.
+
+## Fixed Defaults
+
+Phase 7 defaults are fixed on purpose:
+
+- schedule timezone: `America/New_York`
+- decision time: `16:10`
+- submission time: `19:05`
+- order style: `market` plus `day`
+- position sizing: full-equity fractional exposure in the configured ETF when long, `0%` when in cash
+- execution policy: deterministic `4-of-6` consensus proposals
+- no shorts
+- no live-money path

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - How It Works: how-it-works.md
   - Architecture: architecture.md
   - Phase 5 Scenarios: phase5-scenarios.md
+  - Phase 7 Paper Trading: paper-trading.md
   - MCP Server: mcp-server.md
   - Codex MCP: codex-mcp.md
   - VS Code Copilot MCP: mcp-vscode-copilot.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+  "anthropic>=0.49",
   "matplotlib>=3.8",
+  "openai>=1.0",
   "pandas>=2.2",
   "PyYAML>=6.0",
   "yfinance>=0.2",

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
 import argparse
+import json
 
 from marketlab._version import get_version
 from marketlab.config import load_config
 from marketlab.log import configure_logging
+from marketlab.paper import (
+    decide_paper_proposal,
+    get_paper_status,
+    run_agent_approval_loop,
+    run_paper_decision,
+    run_paper_report,
+    run_paper_submit,
+    run_scheduler_loop,
+)
 from marketlab.pipeline import backtest, prepare_data, run_experiment, train_models
 from marketlab.resources.templates import CONFIG_TEMPLATE_NAMES, write_config_template
 
@@ -17,6 +27,34 @@ def build_parser() -> argparse.ArgumentParser:
     for command_name in ("prepare-data", "backtest", "run-experiment", "train-models"):
         command = subparsers.add_parser(command_name)
         command.add_argument("--config", required=True)
+
+    paper_decision = subparsers.add_parser("paper-decision")
+    paper_decision.add_argument("--config", required=True)
+
+    paper_submit = subparsers.add_parser("paper-submit")
+    paper_submit.add_argument("--config", required=True)
+
+    paper_approve = subparsers.add_parser("paper-approve")
+    paper_approve.add_argument("--config", required=True)
+    paper_approve.add_argument("--proposal-id", required=True)
+    paper_approve.add_argument("--decision", required=True, choices=("approve", "reject"))
+    paper_approve.add_argument("--actor", required=True, choices=("agent", "manual"))
+
+    paper_status = subparsers.add_parser("paper-status")
+    paper_status.add_argument("--config", required=True)
+
+    paper_agent_approve = subparsers.add_parser("paper-agent-approve")
+    paper_agent_approve.add_argument("--config", required=True)
+    paper_agent_approve.add_argument("--once", action="store_true")
+
+    paper_scheduler = subparsers.add_parser("paper-scheduler")
+    paper_scheduler.add_argument("--config", required=True)
+    paper_scheduler.add_argument("--once", action="store_true")
+
+    paper_report = subparsers.add_parser("paper-report")
+    paper_report.add_argument("--config", required=True)
+    paper_report.add_argument("--start", required=True)
+    paper_report.add_argument("--end", required=True)
 
     subparsers.add_parser("list-configs")
 
@@ -47,6 +85,43 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     config = load_config(args.config)
+
+    if args.command == "paper-decision":
+        result = run_paper_decision(config)
+        print(result.get("proposal_path", result["status_path"]))
+        return 0
+
+    if args.command == "paper-submit":
+        result = run_paper_submit(config)
+        print(result.get("submission_path", result["status_path"]))
+        return 0
+
+    if args.command == "paper-approve":
+        result = decide_paper_proposal(
+            config,
+            proposal_id=args.proposal_id,
+            decision=args.decision,
+            actor=args.actor,
+        )
+        print(result["approval_path"])
+        return 0
+
+    if args.command == "paper-status":
+        print(json.dumps(get_paper_status(config), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "paper-agent-approve":
+        run_agent_approval_loop(config, once=args.once)
+        return 0
+
+    if args.command == "paper-scheduler":
+        run_scheduler_loop(config, once=args.once)
+        return 0
+
+    if args.command == "paper-report":
+        result = run_paper_report(config, start_date=args.start, end_date=args.end)
+        print(result["report_path"])
+        return 0
 
     if args.command == "prepare-data":
         _, panel_path = prepare_data(config)

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -11,6 +11,12 @@ ALLOCATION_MODES = {"equal", "group_weights", "symbol_weights"}
 OPTIMIZED_METHODS = {"black_litterman", "mean_variance", "risk_parity"}
 COVARIANCE_ESTIMATORS = {"diagonal_shrinkage", "ewma", "external_csv", "sample"}
 EXPECTED_RETURN_SOURCES = {"external_csv", "historical_mean"}
+PAPER_DATA_PROVIDERS = {"alpaca"}
+PAPER_BROKERS = {"alpaca"}
+PAPER_EXECUTION_MODES = {"autonomous", "agent_approval", "manual_approval"}
+PAPER_ORDER_TYPES = {"day_market"}
+PAPER_POSITION_SIZING = {"full_equity_fractional"}
+PAPER_AGENT_BACKENDS = {"claude", "deterministic_consensus", "openai"}
 WEIGHT_TOLERANCE = 1e-6
 
 
@@ -155,6 +161,27 @@ class ArtifactsConfig:
 
 
 @dataclass(slots=True)
+class PaperConfig:
+    enabled: bool = False
+    data_provider: str = "alpaca"
+    broker: str = "alpaca"
+    execution_mode: str = "agent_approval"
+    agent_backend: str = "deterministic_consensus"
+    agent_model: str = ""
+    agent_timeout_seconds: int = 30
+    agent_fallback_backend: str = "deterministic_consensus"
+    consensus_min_long_votes: int = 4
+    schedule_timezone: str = "America/New_York"
+    decision_time: str = "16:10"
+    submission_time: str = "19:05"
+    order_type: str = "day_market"
+    position_sizing: str = "full_equity_fractional"
+    approval_inbox_dir: str = "artifacts/paper/inbox"
+    state_dir: str = "artifacts/paper/state"
+    poll_interval_seconds: int = 30
+
+
+@dataclass(slots=True)
 class ExperimentConfig:
     experiment_name: str = "weekly_rank_v1"
     data: DataConfig = field(default_factory=DataConfig)
@@ -171,6 +198,7 @@ class ExperimentConfig:
     )
     evaluation: EvaluationConfig = field(default_factory=EvaluationConfig)
     artifacts: ArtifactsConfig = field(default_factory=ArtifactsConfig)
+    paper: PaperConfig = field(default_factory=PaperConfig)
     base_dir: Path = field(default_factory=Path.cwd, repr=False)
 
     def resolve_path(self, value: str | Path) -> Path:
@@ -190,6 +218,14 @@ class ExperimentConfig:
     @property
     def output_dir(self) -> Path:
         return self.resolve_path(self.artifacts.output_dir)
+
+    @property
+    def paper_approval_inbox_dir(self) -> Path:
+        return self.resolve_path(self.paper.approval_inbox_dir)
+
+    @property
+    def paper_state_dir(self) -> Path:
+        return self.resolve_path(self.paper.state_dir)
 
     @property
     def optimized_external_covariance_path(self) -> Path | None:
@@ -281,6 +317,15 @@ def _validate_positive_float(label: str, value: float) -> None:
         raise ValueError(f"{label} must be a finite positive value.")
 
 
+def _validate_clock_string(label: str, value: str) -> None:
+    parts = value.split(":")
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        raise ValueError(f"{label} must use HH:MM 24-hour format.")
+    hour, minute = (int(part) for part in parts)
+    if hour not in range(24) or minute not in range(60):
+        raise ValueError(f"{label} must use HH:MM 24-hour format.")
+
+
 def _validate_config(config: ExperimentConfig) -> None:
     symbols = list(config.data.symbols)
     symbol_set = set(symbols)
@@ -315,6 +360,44 @@ def _validate_config(config: ExperimentConfig) -> None:
         "evaluation.cost_sensitivity_bps",
         config.evaluation.cost_sensitivity_bps,
     )
+    paper = config.paper
+    if paper.data_provider not in PAPER_DATA_PROVIDERS:
+        allowed = ", ".join(sorted(PAPER_DATA_PROVIDERS))
+        raise ValueError(f"paper.data_provider must be one of: {allowed}")
+    if paper.broker not in PAPER_BROKERS:
+        allowed = ", ".join(sorted(PAPER_BROKERS))
+        raise ValueError(f"paper.broker must be one of: {allowed}")
+    if paper.execution_mode not in PAPER_EXECUTION_MODES:
+        allowed = ", ".join(sorted(PAPER_EXECUTION_MODES))
+        raise ValueError(f"paper.execution_mode must be one of: {allowed}")
+    if paper.agent_backend not in PAPER_AGENT_BACKENDS:
+        allowed = ", ".join(sorted(PAPER_AGENT_BACKENDS))
+        raise ValueError(f"paper.agent_backend must be one of: {allowed}")
+    if paper.agent_fallback_backend not in PAPER_AGENT_BACKENDS:
+        allowed = ", ".join(sorted(PAPER_AGENT_BACKENDS))
+        raise ValueError(f"paper.agent_fallback_backend must be one of: {allowed}")
+    if paper.agent_fallback_backend != "deterministic_consensus":
+        raise ValueError(
+            "paper.agent_fallback_backend must remain 'deterministic_consensus' in Phase 7.1."
+        )
+    if paper.agent_backend in {"openai", "claude"} and paper.agent_model.strip() == "":
+        raise ValueError(
+            "paper.agent_model must be set when paper.agent_backend is 'openai' or 'claude'."
+        )
+    if paper.order_type not in PAPER_ORDER_TYPES:
+        allowed = ", ".join(sorted(PAPER_ORDER_TYPES))
+        raise ValueError(f"paper.order_type must be one of: {allowed}")
+    if paper.position_sizing not in PAPER_POSITION_SIZING:
+        allowed = ", ".join(sorted(PAPER_POSITION_SIZING))
+        raise ValueError(f"paper.position_sizing must be one of: {allowed}")
+    _validate_clock_string("paper.decision_time", paper.decision_time)
+    _validate_clock_string("paper.submission_time", paper.submission_time)
+    if paper.agent_timeout_seconds < 1:
+        raise ValueError("paper.agent_timeout_seconds must be at least 1.")
+    if paper.consensus_min_long_votes < 1:
+        raise ValueError("paper.consensus_min_long_votes must be at least 1.")
+    if paper.poll_interval_seconds < 1:
+        raise ValueError("paper.poll_interval_seconds must be at least 1.")
 
     optimized = config.baselines.optimized
     if optimized.method not in OPTIMIZED_METHODS:
@@ -538,6 +621,7 @@ def load_config(path: str | Path) -> ExperimentConfig:
             factor_model_path=(payload.get("evaluation") or {}).get("factor_model_path", ""),
         ),
         artifacts=_section(ArtifactsConfig, payload.get("artifacts")),
+        paper=_section(PaperConfig, payload.get("paper")),
         base_dir=_config_base_dir(config_path),
     )
     _normalize_mapping_sections(config)

--- a/src/marketlab/data/market.py
+++ b/src/marketlab/data/market.py
@@ -73,6 +73,8 @@ def raw_cache_path(cache_dir: str | Path, symbol: str) -> Path:
 def load_symbol_frames(
     config: ExperimentConfig,
     provider: MarketDataProvider | None = None,
+    *,
+    force_refresh: bool = False,
 ) -> dict[str, pd.DataFrame]:
     cache_dir = config.cache_dir
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -81,7 +83,7 @@ def load_symbol_frames(
     frames: dict[str, pd.DataFrame] = {}
     for symbol in config.data.symbols:
         symbol_cache = raw_cache_path(cache_dir, symbol)
-        if symbol_cache.exists():
+        if symbol_cache.exists() and not force_refresh:
             LOGGER.info("Loading cached raw data for %s from %s", symbol, symbol_cache)
             frames[symbol] = pd.read_csv(symbol_cache)
             continue

--- a/src/marketlab/env.py
+++ b/src/marketlab/env.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _strip_env_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    comment_index = value.find(" #")
+    if comment_index >= 0:
+        return value[:comment_index].rstrip()
+    return value
+
+
+def load_env_file(*, override: bool = False) -> Path | None:
+    candidates: list[Path] = []
+    configured = os.environ.get("MARKETLAB_ENV_FILE", "").strip()
+    if configured:
+        candidates.append(Path(configured).expanduser())
+    candidates.append(Path.cwd() / ".env")
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if not resolved.exists() or not resolved.is_file():
+            continue
+
+        for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export ") :].strip()
+            if "=" not in line:
+                continue
+            key, raw_value = line.split("=", 1)
+            env_key = key.strip()
+            if env_key == "":
+                continue
+            env_value = _strip_env_value(raw_value)
+            if override or env_key not in os.environ:
+                os.environ[env_key] = env_value
+        return resolved
+
+    return None

--- a/src/marketlab/mcp/server.py
+++ b/src/marketlab/mcp/server.py
@@ -9,6 +9,7 @@ from marketlab.mcp.tools_admin import register_admin_tools
 from marketlab.mcp.tools_artifacts import register_artifact_tools
 from marketlab.mcp.tools_configs import register_config_tools
 from marketlab.mcp.tools_jobs import register_job_tools
+from marketlab.mcp.tools_paper import register_paper_tools
 from marketlab.mcp.workspace import WorkspaceSandbox
 
 
@@ -71,6 +72,7 @@ class MarketLabMCPServer:
         register_config_tools(self._mcp, sandbox=self._sandbox)
         register_job_tools(self._mcp, jobs=self._jobs)
         register_artifact_tools(self._mcp, sandbox=self._sandbox)
+        register_paper_tools(self._mcp, sandbox=self._sandbox)
 
     @property
     def app(self) -> Any:

--- a/src/marketlab/mcp/tools_admin.py
+++ b/src/marketlab/mcp/tools_admin.py
@@ -31,6 +31,12 @@ ARTIFACT_TOOLS = [
     "marketlab_get_plot_artifact",
     "marketlab_compare_runs",
 ]
+PAPER_TOOLS = [
+    "marketlab_list_paper_proposals",
+    "marketlab_read_paper_proposal",
+    "marketlab_get_paper_status",
+    "marketlab_decide_paper_proposal",
+]
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:
@@ -63,6 +69,7 @@ def register_admin_tools(
                 "configs": CONFIG_TOOLS,
                 "jobs": JOB_TOOLS,
                 "artifacts": ARTIFACT_TOOLS,
+                "paper": PAPER_TOOLS,
             },
         }
 

--- a/src/marketlab/mcp/tools_paper.py
+++ b/src/marketlab/mcp/tools_paper.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+from marketlab.config import load_config
+from marketlab.mcp.workspace import WorkspaceSandbox
+from marketlab.paper import (
+    decide_paper_proposal,
+    get_paper_status,
+    list_paper_proposals,
+    read_paper_proposal,
+)
+
+
+def _resolve_config_path(
+    sandbox: WorkspaceSandbox,
+    config_path: str,
+):
+    candidates = []
+    try:
+        candidates.append(sandbox.resolve_workspace_path(config_path))
+    except ValueError:
+        pass
+    if sandbox.repo_root is not None:
+        try:
+            candidates.append(sandbox.resolve_repo_path(config_path))
+        except ValueError:
+            pass
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    if candidates:
+        return candidates[0]
+    raise ValueError(f"Config path {config_path!r} is outside the workspace and repo roots.")
+
+
+def register_paper_tools(
+    mcp: Any,
+    *,
+    sandbox: WorkspaceSandbox,
+) -> None:
+    @mcp.tool(
+        name="marketlab_list_paper_proposals",
+        description="List persisted paper-trading proposals from the file-backed approval inbox.",
+        structured_output=True,
+    )
+    def marketlab_list_paper_proposals(config_path: str) -> dict[str, Any]:
+        resolved = _resolve_config_path(sandbox, config_path)
+        config = load_config(resolved)
+        sandbox.validate_execution_paths(config)
+        return {
+            "config_path": str(resolved),
+            "proposals": list_paper_proposals(config),
+        }
+
+    @mcp.tool(
+        name="marketlab_read_paper_proposal",
+        description="Read one persisted paper-trading proposal from the file-backed approval inbox.",
+        structured_output=True,
+    )
+    def marketlab_read_paper_proposal(
+        config_path: str,
+        proposal_id: str,
+    ) -> dict[str, Any]:
+        resolved = _resolve_config_path(sandbox, config_path)
+        config = load_config(resolved)
+        sandbox.validate_execution_paths(config)
+        return {
+            "config_path": str(resolved),
+            "proposal": read_paper_proposal(config, proposal_id=proposal_id),
+        }
+
+    @mcp.tool(
+        name="marketlab_get_paper_status",
+        description="Read the latest persisted paper-trading status and latest proposal summary.",
+        structured_output=True,
+    )
+    def marketlab_get_paper_status(config_path: str) -> dict[str, Any]:
+        resolved = _resolve_config_path(sandbox, config_path)
+        config = load_config(resolved)
+        sandbox.validate_execution_paths(config)
+        status = get_paper_status(config)
+        return {
+            "config_path": str(resolved),
+            **status,
+        }
+
+    @mcp.tool(
+        name="marketlab_decide_paper_proposal",
+        description="Approve or reject one persisted paper-trading proposal through the shared approval inbox.",
+        structured_output=True,
+    )
+    def marketlab_decide_paper_proposal(
+        config_path: str,
+        proposal_id: str,
+        decision: str,
+        actor: str,
+    ) -> dict[str, Any]:
+        resolved = _resolve_config_path(sandbox, config_path)
+        config = load_config(resolved)
+        sandbox.validate_execution_paths(config)
+        decision_result = decide_paper_proposal(
+            config,
+            proposal_id=proposal_id,
+            decision=decision,
+            actor=actor,
+        )
+        return {
+            "config_path": str(resolved),
+            **decision_result,
+        }

--- a/src/marketlab/mcp/workspace.py
+++ b/src/marketlab/mcp/workspace.py
@@ -60,6 +60,8 @@ def _config_summary(config: ExperimentConfig) -> dict[str, Any]:
         "output_dir": str(config.output_dir),
         "benchmark_strategy": config.evaluation.benchmark_strategy,
         "model_names": [model.name for model in config.models],
+        "paper_enabled": config.paper.enabled,
+        "paper_execution_mode": config.paper.execution_mode,
     }
 
 
@@ -192,6 +194,13 @@ class WorkspaceSandbox:
 
     def validate_execution_paths(self, config: ExperimentConfig) -> None:
         writable_paths = [config.cache_dir, config.output_dir]
+        if config.paper.enabled:
+            writable_paths.extend(
+                [
+                    config.paper_approval_inbox_dir,
+                    config.paper_state_dir,
+                ]
+            )
         readable_paths = [
             config.prepared_panel_path,
             config.factor_model_path,

--- a/src/marketlab/paper/__init__.py
+++ b/src/marketlab/paper/__init__.py
@@ -1,0 +1,29 @@
+from .agent import run_agent_approval_iteration, run_agent_approval_loop
+from .report import run_paper_report
+from .scheduler import run_scheduler_iteration, run_scheduler_loop
+from .service import (
+    decide_paper_proposal,
+    get_paper_status,
+    list_paper_proposals,
+    read_paper_evidence,
+    read_paper_proposal,
+    run_paper_decision,
+    run_paper_submit,
+    validate_paper_trading_config,
+)
+
+__all__ = [
+    "decide_paper_proposal",
+    "get_paper_status",
+    "list_paper_proposals",
+    "read_paper_evidence",
+    "read_paper_proposal",
+    "run_agent_approval_iteration",
+    "run_agent_approval_loop",
+    "run_paper_decision",
+    "run_paper_report",
+    "run_paper_submit",
+    "run_scheduler_iteration",
+    "run_scheduler_loop",
+    "validate_paper_trading_config",
+]

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from marketlab.config import ExperimentConfig
+from marketlab.env import load_env_file
+from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+from marketlab.paper.service import (
+    APPROVAL_PENDING,
+    PaperStateStore,
+    _now_utc,
+    decide_paper_proposal,
+    read_paper_evidence,
+    validate_paper_trading_config,
+)
+
+
+class AgentDecisionError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True, frozen=True)
+class AgentDecision:
+    decision: str
+    rationale: str
+    provider: str
+    model: str
+    fallback_used: bool = False
+    fallback_reason: str = ""
+
+
+class AgentBackend:
+    provider_name = "base"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        proposal: dict[str, Any],
+        evidence: dict[str, Any],
+        status: dict[str, Any] | None,
+        account_context: dict[str, Any],
+    ) -> AgentDecision:
+        raise NotImplementedError
+
+
+def _json_dump(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _worker_state_path(config: ExperimentConfig) -> Path:
+    return config.paper_state_dir / "agent_worker.json"
+
+
+def _load_worker_state(config: ExperimentConfig) -> dict[str, Any]:
+    path = _worker_state_path(config)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_worker_state(config: ExperimentConfig, payload: dict[str, Any]) -> Path:
+    return _json_dump(_worker_state_path(config), payload)
+
+
+def _decision_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "decision": {
+                "type": "string",
+                "enum": ["approve", "reject"],
+            },
+            "rationale": {
+                "type": "string",
+            },
+        },
+        "required": ["decision", "rationale"],
+        "additionalProperties": False,
+    }
+
+
+def _approval_policy_prompt() -> str:
+    return (
+        "Review the attached paper-trading proposal evidence and decide whether to "
+        "approve or reject the existing proposal. You may only approve or reject the "
+        "proposal as written. Do not invent a different trade, symbol, quantity, side, "
+        "target weight, threshold, or date. Return only the required structured output."
+    )
+
+
+def _coerce_agent_decision(payload: Any, *, provider: str, model: str) -> AgentDecision:
+    if not isinstance(payload, dict):
+        raise AgentDecisionError(f"{provider} returned a non-object structured response.")
+    decision = str(payload.get("decision", "")).strip().lower()
+    rationale = str(payload.get("rationale", "")).strip()
+    if decision not in {"approve", "reject"}:
+        raise AgentDecisionError(f"{provider} returned an invalid decision: {decision!r}")
+    if rationale == "":
+        raise AgentDecisionError(f"{provider} returned an empty rationale.")
+    return AgentDecision(
+        decision=decision,
+        rationale=rationale,
+        provider=provider,
+        model=model,
+    )
+
+
+def _proposal_is_consistent(proposal: dict[str, Any], evidence: dict[str, Any]) -> tuple[bool, str]:
+    if proposal.get("proposal_id") != evidence.get("proposal_id"):
+        return False, "proposal_id mismatch"
+    if proposal.get("symbol") != evidence.get("symbol"):
+        return False, "symbol mismatch"
+    if proposal.get("effective_date") != evidence.get("effective_date"):
+        return False, "effective_date mismatch"
+    if proposal.get("decision_policy") != "consensus_vote":
+        return False, "unsupported decision policy"
+    if proposal.get("decision") != evidence.get("decision"):
+        return False, "decision mismatch"
+    if float(proposal.get("target_weight", 0.0)) != float(evidence.get("target_weight", 0.0)):
+        return False, "target_weight mismatch"
+    if int(proposal.get("long_vote_count", -1)) != int(evidence.get("long_vote_count", -2)):
+        return False, "long_vote_count mismatch"
+    if int(proposal.get("cash_vote_count", -1)) != int(evidence.get("cash_vote_count", -2)):
+        return False, "cash_vote_count mismatch"
+    models = evidence.get("models", [])
+    if not isinstance(models, list) or len(models) == 0:
+        return False, "missing model evidence"
+    long_votes = sum(1 for row in models if row.get("vote") == "long")
+    if long_votes != int(evidence.get("long_vote_count", -1)):
+        return False, "model vote tally mismatch"
+    return True, ""
+
+
+class DeterministicConsensusBackend(AgentBackend):
+    provider_name = "deterministic_consensus"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        proposal: dict[str, Any],
+        evidence: dict[str, Any],
+        status: dict[str, Any] | None,
+        account_context: dict[str, Any],
+    ) -> AgentDecision:
+        is_consistent, reason = _proposal_is_consistent(proposal, evidence)
+        if not is_consistent:
+            return AgentDecision(
+                decision="reject",
+                rationale=f"Rejected because the proposal evidence is inconsistent: {reason}.",
+                provider=self.provider_name,
+                model=self.provider_name,
+            )
+
+        long_vote_count = int(evidence["long_vote_count"])
+        model_count = len(evidence["models"])
+        threshold = int(evidence["consensus_rule"]["min_long_votes"])
+        decision = str(proposal["decision"])
+        return AgentDecision(
+            decision="approve",
+            rationale=(
+                f"Approved because the proposal is internally consistent and the "
+                f"{long_vote_count}/{model_count} consensus vote satisfies the "
+                f"minimum-long-vote threshold of {threshold} for a {decision} action."
+            ),
+            provider=self.provider_name,
+            model=self.provider_name,
+        )
+
+
+def _extract_openai_text(response: Any) -> str:
+    output_text = getattr(response, "output_text", None)
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+
+    parts: list[str] = []
+    for output in getattr(response, "output", []) or []:
+        if getattr(output, "type", None) != "message":
+            continue
+        for item in getattr(output, "content", []) or []:
+            item_type = getattr(item, "type", None)
+            if item_type == "refusal":
+                raise AgentDecisionError(f"OpenAI refusal: {getattr(item, 'refusal', '')}")
+            text_value = getattr(item, "text", None)
+            if isinstance(text_value, str) and text_value.strip():
+                parts.append(text_value)
+    if parts:
+        return "".join(parts)
+    raise AgentDecisionError("OpenAI returned no parseable text output.")
+
+
+class OpenAIAgentBackend(AgentBackend):
+    provider_name = "openai"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        proposal: dict[str, Any],
+        evidence: dict[str, Any],
+        status: dict[str, Any] | None,
+        account_context: dict[str, Any],
+    ) -> AgentDecision:
+        load_env_file()
+        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if api_key == "":
+            raise AgentDecisionError("OPENAI_API_KEY is not configured.")
+
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise AgentDecisionError("The openai package is required for paper.agent_backend='openai'.") from exc
+
+        client = OpenAI(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
+        response = client.responses.create(
+            model=config.paper.agent_model,
+            input=[
+                {"role": "system", "content": _approval_policy_prompt()},
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "proposal": proposal,
+                            "evidence": evidence,
+                            "latest_status": status,
+                            "account_context": account_context,
+                        },
+                        sort_keys=True,
+                    ),
+                },
+            ],
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "paper_agent_decision",
+                    "strict": True,
+                    "schema": _decision_schema(),
+                }
+            },
+        )
+        output_text = _extract_openai_text(response)
+        return _coerce_agent_decision(
+            json.loads(output_text),
+            provider=self.provider_name,
+            model=config.paper.agent_model,
+        )
+
+
+class ClaudeAgentBackend(AgentBackend):
+    provider_name = "claude"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        proposal: dict[str, Any],
+        evidence: dict[str, Any],
+        status: dict[str, Any] | None,
+        account_context: dict[str, Any],
+    ) -> AgentDecision:
+        load_env_file()
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+        if api_key == "":
+            raise AgentDecisionError("ANTHROPIC_API_KEY is not configured.")
+
+        try:
+            from anthropic import Anthropic
+        except ImportError as exc:
+            raise AgentDecisionError("The anthropic package is required for paper.agent_backend='claude'.") from exc
+
+        client = Anthropic(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
+        response = client.messages.create(
+            model=config.paper.agent_model,
+            max_tokens=256,
+            system=_approval_policy_prompt(),
+            messages=[
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "proposal": proposal,
+                            "evidence": evidence,
+                            "latest_status": status,
+                            "account_context": account_context,
+                        },
+                        sort_keys=True,
+                    ),
+                }
+            ],
+            output_config={
+                "format": {
+                    "type": "json_schema",
+                    "schema": _decision_schema(),
+                }
+            },
+        )
+        content = getattr(response, "content", []) or []
+        if not content:
+            raise AgentDecisionError("Claude returned no content.")
+        first_item = content[0]
+        text = getattr(first_item, "text", None)
+        if not isinstance(text, str) or not text.strip():
+            raise AgentDecisionError("Claude returned no structured JSON text.")
+        return _coerce_agent_decision(
+            json.loads(text),
+            provider=self.provider_name,
+            model=config.paper.agent_model,
+        )
+
+
+def _build_backend(config: ExperimentConfig, backend_name: str) -> AgentBackend:
+    if backend_name == "deterministic_consensus":
+        return DeterministicConsensusBackend()
+    if backend_name == "openai":
+        return OpenAIAgentBackend()
+    if backend_name == "claude":
+        return ClaudeAgentBackend()
+    raise AgentDecisionError(f"Unsupported paper agent backend: {backend_name}")
+
+
+def _evaluate_with_fallback(
+    config: ExperimentConfig,
+    *,
+    proposal: dict[str, Any],
+    evidence: dict[str, Any],
+    status: dict[str, Any] | None,
+    account_context: dict[str, Any],
+) -> AgentDecision:
+    requested_backend = config.paper.agent_backend
+    primary = _build_backend(config, requested_backend)
+    try:
+        return primary.evaluate(
+            config=config,
+            proposal=proposal,
+            evidence=evidence,
+            status=status,
+            account_context=account_context,
+        )
+    except Exception as exc:
+        fallback_backend_name = config.paper.agent_fallback_backend
+        if fallback_backend_name == requested_backend:
+            raise
+        fallback = _build_backend(config, fallback_backend_name)
+        fallback_result = fallback.evaluate(
+            config=config,
+            proposal=proposal,
+            evidence=evidence,
+            status=status,
+            account_context=account_context,
+        )
+        return AgentDecision(
+            decision=fallback_result.decision,
+            rationale=fallback_result.rationale,
+            provider=fallback_result.provider,
+            model=fallback_result.model,
+            fallback_used=True,
+            fallback_reason=f"{requested_backend} backend failed: {exc}",
+        )
+
+
+def _current_account_context(
+    config: ExperimentConfig,
+    *,
+    broker: AlpacaPaperBrokerClient | None = None,
+) -> dict[str, Any]:
+    symbol = str(config.data.symbols[0])
+    client = broker or AlpacaPaperBrokerClient()
+    account = client.get_account()
+    position = client.get_position(symbol)
+    return {
+        "account": account,
+        "position": position,
+    }
+
+
+def run_agent_approval_iteration(
+    config: ExperimentConfig,
+    *,
+    now: datetime | None = None,
+    broker: AlpacaPaperBrokerClient | None = None,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    state = _load_worker_state(config)
+    events: list[dict[str, Any]] = []
+
+    if config.paper.execution_mode != "agent_approval":
+        state["last_checked_at"] = _now_utc(now).isoformat()
+        state["last_result"] = "execution_mode_not_agent_approval"
+        state_path = _save_worker_state(config, state)
+        return {
+            "agent_state_path": str(state_path),
+            "events": [],
+            "processed_count": 0,
+        }
+
+    store = PaperStateStore(config)
+    proposals = sorted(
+        [
+            proposal
+            for proposal in store.list_proposals()
+            if proposal.get("approval_status", APPROVAL_PENDING) == APPROVAL_PENDING
+            and not store.trade_submission_path(proposal["effective_date"]).exists()
+        ],
+        key=lambda proposal: (
+            proposal.get("effective_date", ""),
+            proposal.get("proposal_id", ""),
+        ),
+    )
+    current_status = store.read_status()
+    account_context = (
+        _current_account_context(config, broker=broker)
+        if proposals
+        else {}
+    )
+
+    for proposal in proposals:
+        evidence = read_paper_evidence(config, proposal_id=proposal["proposal_id"])
+        decision = _evaluate_with_fallback(
+            config,
+            proposal=proposal,
+            evidence=evidence,
+            status=current_status,
+            account_context=account_context,
+        )
+        result = decide_paper_proposal(
+            config,
+            proposal_id=proposal["proposal_id"],
+            decision=decision.decision,
+            actor="agent",
+            rationale=decision.rationale,
+            provider=decision.provider,
+            model=decision.model,
+            fallback_used=decision.fallback_used,
+            fallback_reason=decision.fallback_reason,
+            now=now,
+        )
+        events.append(
+            {
+                "proposal_id": proposal["proposal_id"],
+                "decision": decision.decision,
+                "provider": decision.provider,
+                "model": decision.model,
+                "fallback_used": decision.fallback_used,
+                "fallback_reason": decision.fallback_reason,
+                "approval_path": result["approval_path"],
+            }
+        )
+
+    state["last_checked_at"] = _now_utc(now).isoformat()
+    state["last_processed_count"] = len(events)
+    state["last_result"] = "processed" if events else "no_pending_proposals"
+    state_path = _save_worker_state(config, state)
+    return {
+        "agent_state_path": str(state_path),
+        "events": events,
+        "processed_count": len(events),
+    }
+
+
+def run_agent_approval_loop(config: ExperimentConfig, *, once: bool = False) -> None:
+    while True:
+        summary = run_agent_approval_iteration(config)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        if once:
+            return
+        time.sleep(config.paper.poll_interval_seconds)

--- a/src/marketlab/paper/alpaca.py
+++ b/src/marketlab/paper/alpaca.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from marketlab.data.market import MarketDataProvider
+from marketlab.env import load_env_file
+
+DEFAULT_ALPACA_DATA_BASE_URL = "https://data.alpaca.markets"
+DEFAULT_ALPACA_TRADING_BASE_URL = "https://paper-api.alpaca.markets"
+PAPER_HOSTS = {"paper-api.alpaca.markets", "127.0.0.1", "localhost"}
+
+
+@dataclass(slots=True, frozen=True)
+class AlpacaCredentials:
+    api_key_id: str
+    api_secret_key: str
+    data_base_url: str = DEFAULT_ALPACA_DATA_BASE_URL
+    trading_base_url: str = DEFAULT_ALPACA_TRADING_BASE_URL
+    data_feed: str = "iex"
+    timeout_seconds: int = 30
+
+    @classmethod
+    def from_env(cls) -> "AlpacaCredentials":
+        import os
+
+        load_env_file()
+        api_key_id = os.environ.get("ALPACA_API_KEY_ID", "").strip()
+        api_secret_key = os.environ.get("ALPACA_API_SECRET_KEY", "").strip()
+        if not api_key_id or not api_secret_key:
+            raise RuntimeError(
+                "Alpaca credentials are required. Set ALPACA_API_KEY_ID and "
+                "ALPACA_API_SECRET_KEY in the environment or add them to a local .env file."
+            )
+
+        data_base_url = os.environ.get(
+            "ALPACA_DATA_BASE_URL",
+            DEFAULT_ALPACA_DATA_BASE_URL,
+        ).strip() or DEFAULT_ALPACA_DATA_BASE_URL
+        trading_base_url = os.environ.get(
+            "ALPACA_TRADING_BASE_URL",
+            DEFAULT_ALPACA_TRADING_BASE_URL,
+        ).strip() or DEFAULT_ALPACA_TRADING_BASE_URL
+        data_feed = os.environ.get("ALPACA_DATA_FEED", "iex").strip() or "iex"
+        timeout_seconds = int(os.environ.get("ALPACA_TIMEOUT_SECONDS", "30"))
+        return cls(
+            api_key_id=api_key_id,
+            api_secret_key=api_secret_key,
+            data_base_url=data_base_url.rstrip("/"),
+            trading_base_url=trading_base_url.rstrip("/"),
+            data_feed=data_feed,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+def _json_request(
+    *,
+    method: str,
+    base_url: str,
+    path: str,
+    api_key_id: str,
+    api_secret_key: str,
+    timeout_seconds: int,
+    params: dict[str, Any] | None = None,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    query = ""
+    if params:
+        query = "?" + urlencode(params, doseq=True)
+    url = f"{base_url.rstrip('/')}{path}{query}"
+    data = None
+    headers = {
+        "APCA-API-KEY-ID": api_key_id,
+        "APCA-API-SECRET-KEY": api_secret_key,
+        "Accept": "application/json",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = Request(url=url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8")
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Alpaca API request failed: {exc.code} {detail}") from exc
+
+    if body == "":
+        return {}
+    return json.loads(body)
+
+
+def _normalize_daily_timestamp(value: object) -> pd.Timestamp:
+    timestamp = pd.to_datetime(value, utc=True)
+    if isinstance(timestamp, pd.Timestamp):
+        return timestamp.tz_convert(None).normalize()
+    raise TypeError(f"Unsupported timestamp value: {value!r}")
+
+
+class AlpacaMarketDataProvider(MarketDataProvider):
+    def __init__(self, credentials: AlpacaCredentials | None = None) -> None:
+        self._credentials = credentials or AlpacaCredentials.from_env()
+
+    def download_symbol_history(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        interval: str,
+    ) -> pd.DataFrame:
+        if interval != "1d":
+            raise ValueError("The Alpaca paper-data path currently supports interval='1d' only.")
+
+        payload = _json_request(
+            method="GET",
+            base_url=self._credentials.data_base_url,
+            path="/v2/stocks/bars",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+            params={
+                "symbols": symbol,
+                "timeframe": "1Day",
+                "start": f"{start_date}T00:00:00Z",
+                "end": f"{end_date}T23:59:59Z",
+                "adjustment": "all",
+                "feed": self._credentials.data_feed,
+                "sort": "asc",
+                "limit": 10000,
+            },
+        )
+
+        bars = (payload.get("bars") or {}).get(symbol, [])
+        if not bars:
+            raise RuntimeError(f"No Alpaca market data returned for {symbol}.")
+
+        frame = pd.DataFrame(
+            [
+                {
+                    "Date": _normalize_daily_timestamp(bar["t"]),
+                    "Open": float(bar["o"]),
+                    "High": float(bar["h"]),
+                    "Low": float(bar["l"]),
+                    "Close": float(bar["c"]),
+                    "Adj Close": float(bar["c"]),
+                    "Volume": float(bar["v"]),
+                }
+                for bar in bars
+            ]
+        )
+        return frame.sort_values("Date").reset_index(drop=True)
+
+
+class AlpacaPaperBrokerClient:
+    def __init__(self, credentials: AlpacaCredentials | None = None) -> None:
+        self._credentials = credentials or AlpacaCredentials.from_env()
+        self._ensure_paper_endpoint()
+
+    def _ensure_paper_endpoint(self) -> None:
+        parsed = urlparse(self._credentials.trading_base_url)
+        if parsed.hostname not in PAPER_HOSTS and "paper" not in self._credentials.trading_base_url:
+            raise RuntimeError(
+                "The paper-trading path requires an Alpaca paper endpoint. "
+                f"Configured trading base URL: {self._credentials.trading_base_url}"
+            )
+
+    def get_calendar(
+        self,
+        *,
+        start_date: date,
+        end_date: date,
+    ) -> list[dict[str, Any]]:
+        payload = _json_request(
+            method="GET",
+            base_url=self._credentials.trading_base_url,
+            path="/v2/calendar",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+            params={
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+        )
+        if not isinstance(payload, list):
+            raise RuntimeError("Alpaca calendar response must be a list.")
+        return payload
+
+    def get_account(self) -> dict[str, Any]:
+        payload = _json_request(
+            method="GET",
+            base_url=self._credentials.trading_base_url,
+            path="/v2/account",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("Alpaca account response must be an object.")
+        return payload
+
+    def get_position(self, symbol: str) -> dict[str, Any] | None:
+        try:
+            payload = _json_request(
+                method="GET",
+                base_url=self._credentials.trading_base_url,
+                path=f"/v2/positions/{symbol}",
+                api_key_id=self._credentials.api_key_id,
+                api_secret_key=self._credentials.api_secret_key,
+                timeout_seconds=self._credentials.timeout_seconds,
+            )
+        except RuntimeError as exc:
+            if "404" in str(exc):
+                return None
+            raise
+
+        if not isinstance(payload, dict):
+            raise RuntimeError("Alpaca position response must be an object.")
+        return payload
+
+    def submit_fractional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        qty: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, Any]:
+        payload = _json_request(
+            method="POST",
+            base_url=self._credentials.trading_base_url,
+            path="/v2/orders",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+            payload={
+                "symbol": symbol,
+                "qty": f"{qty:.6f}",
+                "side": side,
+                "type": "market",
+                "time_in_force": "day",
+                "client_order_id": client_order_id,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("Alpaca order submission response must be an object.")
+        return payload
+
+    def get_order(self, order_id: str) -> dict[str, Any]:
+        payload = _json_request(
+            method="GET",
+            base_url=self._credentials.trading_base_url,
+            path=f"/v2/orders/{order_id}",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("Alpaca order response must be an object.")
+        return payload

--- a/src/marketlab/paper/report.py
+++ b/src/marketlab/paper/report.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from marketlab.config import ExperimentConfig
+from marketlab.paper.alpaca import AlpacaMarketDataProvider
+from marketlab.paper.service import (
+    PaperStateStore,
+    _paper_symbol,
+    validate_paper_trading_config,
+)
+
+
+def _json_load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _markdown_table(frame: pd.DataFrame) -> str:
+    columns = list(frame.columns)
+    header = "| " + " | ".join(columns) + " |"
+    separator = "| " + " | ".join(["---"] * len(columns)) + " |"
+    rows = [
+        "| " + " | ".join(str(value) for value in row) + " |"
+        for row in frame.itertuples(index=False, name=None)
+    ]
+    return "\n".join([header, separator, *rows])
+
+
+def _trade_rows(store: PaperStateStore) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for trade_dir in sorted(store.trades_root.glob("*")):
+        if not trade_dir.is_dir():
+            continue
+        proposal_path = trade_dir / "proposal.json"
+        evidence_path = trade_dir / "evidence.json"
+        if not proposal_path.exists() or not evidence_path.exists():
+            continue
+        proposal = _json_load(proposal_path)
+        evidence = _json_load(evidence_path)
+        approval_path = trade_dir / "approval.json"
+        submission_path = trade_dir / "submission.json"
+        approval = _json_load(approval_path) if approval_path.exists() else None
+        submission = _json_load(submission_path) if submission_path.exists() else None
+        rows.append(
+            {
+                "proposal": proposal,
+                "evidence": evidence,
+                "approval": approval,
+                "submission": submission,
+            }
+        )
+    return rows
+
+
+def _load_price_frame(
+    config: ExperimentConfig,
+    *,
+    symbol: str,
+    start_date: str,
+    end_date: str,
+    provider: AlpacaMarketDataProvider | None = None,
+) -> pd.DataFrame:
+    slow_window = int(config.baselines.sma.slow_window)
+    start_lookup = (pd.Timestamp(start_date) - timedelta(days=max(120, slow_window * 3))).date()
+    frame = (provider or AlpacaMarketDataProvider()).download_symbol_history(
+        symbol,
+        start_lookup.isoformat(),
+        end_date,
+        config.data.interval,
+    )
+    price_frame = frame.rename(columns={"Date": "date", "Open": "open", "Close": "close"}).copy()
+    price_frame["date"] = pd.to_datetime(price_frame["date"]).dt.normalize()
+    price_frame["open"] = price_frame["open"].astype(float)
+    price_frame["close"] = price_frame["close"].astype(float)
+    price_frame = price_frame.loc[
+        price_frame["date"].between(pd.Timestamp(start_date) - timedelta(days=120), pd.Timestamp(end_date))
+    ].copy()
+    price_frame["prev_close"] = price_frame["close"].shift(1)
+    price_frame["overnight_return"] = (
+        price_frame["open"] / price_frame["prev_close"]
+    ).where(price_frame["prev_close"].notna(), 1.0) - 1.0
+    price_frame["intraday_return"] = (price_frame["close"] / price_frame["open"]) - 1.0
+    return price_frame.reset_index(drop=True)
+
+
+def _replay_exposure(
+    price_frame: pd.DataFrame,
+    *,
+    target_by_date: dict[str, float],
+    default_exposure: float = 0.0,
+) -> pd.Series:
+    exposures: list[float] = []
+    current = float(default_exposure)
+    for timestamp in price_frame["date"]:
+        key = timestamp.date().isoformat()
+        if key in target_by_date:
+            current = float(target_by_date[key])
+        exposures.append(current)
+    return pd.Series(exposures, index=price_frame.index, dtype=float)
+
+
+def _strategy_frame(
+    price_frame: pd.DataFrame,
+    *,
+    strategy_name: str,
+    exposure: pd.Series,
+) -> pd.DataFrame:
+    current_exposure = exposure.astype(float)
+    previous_exposure = current_exposure.shift(1).fillna(0.0)
+    strategy_return = (
+        (1.0 + previous_exposure * price_frame["overnight_return"])
+        * (1.0 + current_exposure * price_frame["intraday_return"])
+        - 1.0
+    )
+    equity = (1.0 + strategy_return).cumprod()
+    return pd.DataFrame(
+        {
+            "date": price_frame["date"],
+            "strategy": strategy_name,
+            "exposure": current_exposure,
+            "return": strategy_return,
+            "equity": equity,
+        }
+    )
+
+
+def _buy_hold_exposure(price_frame: pd.DataFrame) -> pd.Series:
+    return pd.Series(1.0, index=price_frame.index, dtype=float)
+
+
+def _sma_exposure(config: ExperimentConfig, price_frame: pd.DataFrame) -> pd.Series:
+    fast_window = int(config.baselines.sma.fast_window)
+    slow_window = int(config.baselines.sma.slow_window)
+    fast = price_frame["close"].rolling(window=fast_window, min_periods=fast_window).mean()
+    slow = price_frame["close"].rolling(window=slow_window, min_periods=slow_window).mean()
+    signal = (fast > slow).astype(float).shift(1).fillna(0.0)
+    return signal.astype(float)
+
+
+def _realized_target_weight(submission: dict[str, Any] | None, proposal: dict[str, Any], current: float) -> float:
+    if submission is None:
+        return current
+    status = str(submission.get("status", ""))
+    if status == "no_trade_required":
+        return float(proposal.get("target_weight", current))
+    if status != "submitted":
+        return current
+    order_status = str(submission.get("order_status", "")).lower()
+    if order_status in {"rejected", "canceled", "expired"}:
+        return current
+    return float(proposal.get("target_weight", current))
+
+
+def _paper_target_maps(
+    rows: list[dict[str, Any]],
+) -> tuple[dict[str, float], dict[str, float], dict[str, dict[str, float]], list[dict[str, Any]]]:
+    consensus_targets: dict[str, float] = {}
+    realized_targets: dict[str, float] = {}
+    model_targets: dict[str, dict[str, float]] = {}
+    journal_rows: list[dict[str, Any]] = []
+    current_realized = 0.0
+
+    for row in sorted(rows, key=lambda item: item["proposal"]["effective_date"]):
+        proposal = row["proposal"]
+        evidence = row["evidence"]
+        submission = row["submission"] or {}
+        trade_date = str(proposal["effective_date"])
+        consensus_targets[trade_date] = float(proposal["target_weight"])
+        for model_row in evidence.get("models", []):
+            model_targets.setdefault(model_row["model_name"], {})[trade_date] = float(
+                model_row["target_weight"]
+            )
+        current_realized = _realized_target_weight(submission, proposal, current_realized)
+        realized_targets[trade_date] = current_realized
+        journal_rows.append(
+            {
+                "proposal_id": proposal["proposal_id"],
+                "symbol": proposal["symbol"],
+                "signal_date": proposal["signal_date"],
+                "effective_date": trade_date,
+                "consensus_decision": proposal["decision"],
+                "target_weight": proposal["target_weight"],
+                "long_vote_count": proposal["long_vote_count"],
+                "cash_vote_count": proposal["cash_vote_count"],
+                "approval_status": proposal.get("approval_status", ""),
+                "approval_actor": proposal.get("approval_actor", ""),
+                "approval_backend": proposal.get("approval_backend", ""),
+                "approval_model": proposal.get("approval_model", ""),
+                "approval_fallback_used": proposal.get("approval_fallback_used", False),
+                "approval_fallback_reason": proposal.get("approval_fallback_reason", ""),
+                "approval_rationale": proposal.get("approval_rationale", ""),
+                "submission_status": submission.get("status", ""),
+                "submission_reason": submission.get("reason", ""),
+                "realized_target_weight": current_realized,
+            }
+        )
+    return consensus_targets, realized_targets, model_targets, journal_rows
+
+
+def _summary_frame(performance: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for strategy_name, strategy_frame in performance.groupby("strategy", sort=True):
+        strategy_frame = strategy_frame.reset_index(drop=True)
+        cumulative_return = float(strategy_frame["equity"].iloc[-1] - 1.0)
+        periods = max(len(strategy_frame), 1)
+        annualized_return = float(strategy_frame["equity"].iloc[-1] ** (252 / periods) - 1.0)
+        rows.append(
+            {
+                "strategy": strategy_name,
+                "cumulative_return": cumulative_return,
+                "annualized_return": annualized_return,
+                "avg_exposure": float(strategy_frame["exposure"].mean()),
+                "days_long": int((strategy_frame["exposure"] > 0.0).sum()),
+                "final_equity": float(strategy_frame["equity"].iloc[-1]),
+            }
+        )
+    return pd.DataFrame(rows).sort_values(["cumulative_return", "strategy"], ascending=[False, True])
+
+
+def _write_report_markdown(
+    *,
+    path: Path,
+    config: ExperimentConfig,
+    summary: pd.DataFrame,
+    journal: pd.DataFrame,
+    start_date: str,
+    end_date: str,
+) -> Path:
+    lines = [
+        f"# {config.experiment_name} paper report",
+        "",
+        "## Scope",
+        "",
+        f"- Symbol: {_paper_symbol(config)}",
+        f"- Window: {start_date} to {end_date}",
+        "- Strategy shape: single-ETF, long-or-cash, daily paper loop",
+        "",
+        "## Summary",
+        "",
+        _markdown_table(summary.round(6)),
+        "",
+        "## Decision Journal",
+        "",
+        _markdown_table(journal.round(6) if not journal.empty else journal),
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def run_paper_report(
+    config: ExperimentConfig,
+    *,
+    start_date: str,
+    end_date: str,
+    provider: AlpacaMarketDataProvider | None = None,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    symbol = _paper_symbol(config)
+    store = PaperStateStore(config)
+    rows = _trade_rows(store)
+    if not rows:
+        raise RuntimeError("paper-report requires persisted proposal and evidence artifacts.")
+
+    price_frame = _load_price_frame(
+        config,
+        symbol=symbol,
+        start_date=start_date,
+        end_date=end_date,
+        provider=provider,
+    )
+    report_prices = price_frame.loc[
+        price_frame["date"].between(pd.Timestamp(start_date), pd.Timestamp(end_date))
+    ].reset_index(drop=True)
+    if report_prices.empty:
+        raise RuntimeError("paper-report found no price rows in the requested date range.")
+
+    consensus_targets, realized_targets, model_targets, journal_rows = _paper_target_maps(rows)
+    performance_frames = []
+
+    def _windowed_strategy_frame(strategy_name: str, exposure: pd.Series) -> pd.DataFrame:
+        full_frame = _strategy_frame(price_frame, strategy_name=strategy_name, exposure=exposure)
+        return full_frame.loc[
+            full_frame["date"].between(pd.Timestamp(start_date), pd.Timestamp(end_date))
+        ].reset_index(drop=True)
+
+    performance_frames.extend(
+        [
+            _windowed_strategy_frame(
+                "paper_realized",
+                _replay_exposure(price_frame, target_by_date=realized_targets),
+            ),
+            _windowed_strategy_frame(
+                "consensus",
+                _replay_exposure(price_frame, target_by_date=consensus_targets),
+            ),
+            _windowed_strategy_frame("buy_hold", _buy_hold_exposure(price_frame)),
+        ]
+    )
+    if config.baselines.sma.enabled:
+        performance_frames.append(
+            _windowed_strategy_frame("sma", _sma_exposure(config, price_frame))
+        )
+    for model_name, target_map in sorted(model_targets.items()):
+        performance_frames.append(
+            _windowed_strategy_frame(
+                f"model_{model_name}",
+                _replay_exposure(price_frame, target_by_date=target_map),
+            )
+        )
+
+    performance = pd.concat(performance_frames, ignore_index=True)
+    summary = _summary_frame(performance).reset_index(drop=True)
+    journal = pd.DataFrame(journal_rows).sort_values("effective_date").reset_index(drop=True)
+
+    output_dir = store.report_dir(start_date, end_date)
+    summary_path = output_dir / "summary.csv"
+    journal_path = output_dir / "decision_journal.csv"
+    performance_path = output_dir / "performance.csv"
+    report_path = output_dir / "report.md"
+    summary.to_csv(summary_path, index=False)
+    journal.to_csv(journal_path, index=False)
+    performance.to_csv(performance_path, index=False)
+    _write_report_markdown(
+        path=report_path,
+        config=config,
+        summary=summary,
+        journal=journal,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return {
+        "report_dir": str(output_dir),
+        "summary_path": str(summary_path),
+        "decision_journal_path": str(journal_path),
+        "performance_path": str(performance_path),
+        "report_path": str(report_path),
+        "summary_preview": summary.head(10).to_dict(orient="records"),
+    }

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from marketlab.config import ExperimentConfig
+from marketlab.paper.service import (
+    _clock_value,
+    _local_now,
+    _now_utc,
+    run_paper_decision,
+    run_paper_submit,
+)
+
+
+def _scheduler_state_path(config: ExperimentConfig) -> Path:
+    return config.paper_state_dir / "scheduler.json"
+
+
+def _load_scheduler_state(config: ExperimentConfig) -> dict[str, Any]:
+    path = _scheduler_state_path(config)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_scheduler_state(config: ExperimentConfig, payload: dict[str, Any]) -> Path:
+    path = _scheduler_state_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def run_scheduler_iteration(
+    config: ExperimentConfig,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    local_now = _local_now(config, now)
+    market_date = local_now.date().isoformat()
+    decision_clock = _clock_value(config.paper.decision_time)
+    submission_clock = _clock_value(config.paper.submission_time)
+    state = _load_scheduler_state(config)
+    events: list[dict[str, Any]] = []
+
+    if local_now.time() >= decision_clock and state.get("last_decision_market_date") != market_date:
+        result = run_paper_decision(config, now=now)
+        events.append({"phase": "decision", **result})
+        state["last_decision_market_date"] = market_date
+        state["last_decision_at"] = _now_utc(now).isoformat()
+
+    if local_now.time() >= submission_clock and state.get("last_submission_market_date") != market_date:
+        result = run_paper_submit(config, now=now)
+        events.append({"phase": "submission", **result})
+        state["last_submission_market_date"] = market_date
+        state["last_submission_at"] = _now_utc(now).isoformat()
+
+    state["last_checked_at"] = _now_utc(now).isoformat()
+    state["last_checked_market_date"] = market_date
+    state_path = _save_scheduler_state(config, state)
+    return {
+        "scheduler_state_path": str(state_path),
+        "market_date": market_date,
+        "events": events,
+    }
+
+
+def run_scheduler_loop(config: ExperimentConfig, *, once: bool = False) -> None:
+    while True:
+        summary = run_scheduler_iteration(config)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        if once:
+            return
+        time.sleep(config.paper.poll_interval_seconds)

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -1,0 +1,886 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import UTC, date, datetime, timedelta
+from datetime import time as dt_time
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+from pandas.tseries.frequencies import to_offset
+
+from marketlab.config import ExperimentConfig
+from marketlab.data.market import load_symbol_frames
+from marketlab.data.panel import build_market_panel
+from marketlab.features.engineering import add_feature_set
+from marketlab.models import (
+    build_model_estimator,
+    predict_direction_scores,
+    supported_model_names,
+)
+from marketlab.models.training import modeling_feature_columns
+from marketlab.paper.alpaca import (
+    AlpacaMarketDataProvider,
+    AlpacaPaperBrokerClient,
+)
+from marketlab.targets import add_forward_targets, build_rebalance_snapshots
+
+APPROVAL_PENDING = "pending"
+APPROVAL_APPROVED = "approved"
+APPROVAL_REJECTED = "rejected"
+APPROVAL_NOT_REQUIRED = "not_required"
+SUBMISSION_PENDING = "pending"
+SUBMISSION_SUBMITTED = "submitted"
+SUBMISSION_NOOP = "no_trade_required"
+SUBMISSION_SKIPPED = "skipped"
+CONSENSUS_POLICY = "consensus_vote"
+TERMINAL_ORDER_STATUSES = {"canceled", "expired", "filled", "rejected"}
+
+
+def _now_utc(now: datetime | None = None) -> datetime:
+    if now is None:
+        return datetime.now(UTC)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
+
+
+def _local_now(config: ExperimentConfig, now: datetime | None = None) -> datetime:
+    return _now_utc(now).astimezone(ZoneInfo(config.paper.schedule_timezone))
+
+
+def _clock_value(clock_text: str) -> dt_time:
+    hour, minute = (int(part) for part in clock_text.split(":"))
+    return dt_time(hour=hour, minute=minute)
+
+
+def _iso_date(value: pd.Timestamp | datetime | date | str) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, pd.Timestamp):
+        return value.date().isoformat()
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return value.isoformat()
+
+
+def _json_dump(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _json_load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _paper_symbol(config: ExperimentConfig) -> str:
+    symbols = [str(symbol).strip() for symbol in config.data.symbols if str(symbol).strip() != ""]
+    if len(symbols) != 1:
+        raise RuntimeError(
+            "Phase 7 paper trading requires exactly one configured symbol in data.symbols."
+        )
+    return symbols[0]
+
+
+def _paper_model_names(config: ExperimentConfig) -> list[str]:
+    configured = [spec.name for spec in config.models]
+    if not configured:
+        raise RuntimeError("Phase 7.1 paper trading requires configured models.")
+    if len(set(configured)) != len(configured):
+        raise RuntimeError("Phase 7.1 paper trading does not allow duplicate model names.")
+
+    required_models = set(supported_model_names())
+    configured_set = set(configured)
+    if configured_set != required_models or len(configured) != len(required_models):
+        required = ", ".join(sorted(required_models))
+        raise RuntimeError(
+            "Phase 7.1 paper trading requires config.models to include each supported "
+            f"direction model exactly once: {required}."
+        )
+    if config.paper.consensus_min_long_votes > len(configured):
+        raise RuntimeError(
+            "paper.consensus_min_long_votes cannot exceed the number of configured paper models."
+        )
+    return configured
+
+
+def validate_paper_trading_config(config: ExperimentConfig) -> None:
+    if not config.paper.enabled:
+        raise RuntimeError("paper.enabled must be true for Phase 7 paper-trading commands.")
+    _paper_symbol(config)
+    _paper_model_names(config)
+    if config.data.interval != "1d":
+        raise RuntimeError("Phase 7 paper trading requires data.interval='1d'.")
+    if config.target.type != "direction":
+        raise RuntimeError("Phase 7 paper trading requires target.type='direction'.")
+    if config.target.horizon_days != 1:
+        raise RuntimeError("Phase 7 paper trading requires target.horizon_days=1.")
+    if config.portfolio.ranking.rebalance_frequency != "D":
+        raise RuntimeError("Phase 7 paper trading requires portfolio.ranking.rebalance_frequency='D'.")
+    if config.portfolio.ranking.mode != "long_only":
+        raise RuntimeError("Phase 7 paper trading requires portfolio.ranking.mode='long_only'.")
+    if config.portfolio.ranking.long_n != 1 or config.portfolio.ranking.short_n != 1:
+        raise RuntimeError("Phase 7 paper trading requires long_n=1 and short_n=1.")
+
+
+class PaperStateStore:
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._config = config
+        self.inbox_root = config.paper_approval_inbox_dir
+        self.state_root = config.paper_state_dir
+        self.trades_root = self.state_root / "trades"
+        self.reports_root = self.state_root.parent / "reports"
+        self.status_path = self.state_root / "status.json"
+        for root in (self.inbox_root, self.state_root, self.trades_root, self.reports_root):
+            root.mkdir(parents=True, exist_ok=True)
+
+    def trade_dir(self, trade_date: str) -> Path:
+        path = self.trades_root / trade_date
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def trade_proposal_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "proposal.json"
+
+    def trade_evidence_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "evidence.json"
+
+    def trade_approval_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "approval.json"
+
+    def trade_submission_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "submission.json"
+
+    def trade_account_snapshot_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "account_snapshot.json"
+
+    def trade_order_preview_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "order_preview.json"
+
+    def trade_order_status_path(self, trade_date: str) -> Path:
+        return self.trade_dir(trade_date) / "order_status.json"
+
+    def inbox_proposal_path(self, proposal_id: str) -> Path:
+        return self.inbox_root / f"{proposal_id}.json"
+
+    def report_dir(self, start_date: str, end_date: str) -> Path:
+        path = self.reports_root / f"{start_date}_{end_date}"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def write_status(self, payload: dict[str, Any]) -> Path:
+        return _json_dump(self.status_path, payload)
+
+    def read_status(self) -> dict[str, Any] | None:
+        if not self.status_path.exists():
+            return None
+        return _json_load(self.status_path)
+
+    def save_evidence(self, evidence: dict[str, Any]) -> Path:
+        return _json_dump(self.trade_evidence_path(evidence["effective_date"]), evidence)
+
+    def load_evidence(self, trade_date: str) -> dict[str, Any]:
+        return _json_load(self.trade_evidence_path(trade_date))
+
+    def save_proposal(self, proposal: dict[str, Any]) -> Path:
+        trade_date = proposal["effective_date"]
+        proposal_path = self.trade_proposal_path(trade_date)
+        inbox_path = self.inbox_proposal_path(proposal["proposal_id"])
+        _json_dump(proposal_path, proposal)
+        _json_dump(inbox_path, proposal)
+        return proposal_path
+
+    def update_proposal(self, proposal: dict[str, Any]) -> Path:
+        return self.save_proposal(proposal)
+
+    def load_proposal(self, proposal_id: str) -> dict[str, Any]:
+        path = self.inbox_proposal_path(proposal_id)
+        if not path.exists():
+            raise FileNotFoundError(f"Unknown proposal_id: {proposal_id}")
+        return _json_load(path)
+
+    def list_proposals(self) -> list[dict[str, Any]]:
+        proposals = [_json_load(path) for path in sorted(self.inbox_root.glob("*.json"))]
+        return sorted(
+            proposals,
+            key=lambda proposal: (
+                proposal.get("effective_date", ""),
+                proposal.get("created_at", ""),
+                proposal.get("proposal_id", ""),
+            ),
+            reverse=True,
+        )
+
+    def latest_proposal(self) -> dict[str, Any] | None:
+        proposals = self.list_proposals()
+        if not proposals:
+            return None
+        return proposals[0]
+
+
+def _build_alpaca_panel(
+    config: ExperimentConfig,
+    provider: AlpacaMarketDataProvider | None = None,
+) -> pd.DataFrame:
+    frames = load_symbol_frames(
+        config,
+        provider=provider or AlpacaMarketDataProvider(),
+        force_refresh=True,
+    )
+    return build_market_panel(frames)
+
+
+def _is_trading_day(
+    broker: AlpacaPaperBrokerClient,
+    *,
+    market_date: date,
+) -> bool:
+    calendar = broker.get_calendar(start_date=market_date, end_date=market_date)
+    return any(item.get("date") == market_date.isoformat() for item in calendar)
+
+
+def _next_trading_date(
+    broker: AlpacaPaperBrokerClient,
+    *,
+    market_date: date,
+) -> date:
+    calendar = broker.get_calendar(
+        start_date=market_date,
+        end_date=market_date + timedelta(days=14),
+    )
+    future_dates = sorted(
+        pd.to_datetime(item["date"]).date()
+        for item in calendar
+        if item.get("date")
+    )
+    for candidate in future_dates:
+        if candidate > market_date:
+            return candidate
+    raise RuntimeError("The Alpaca calendar did not provide a future trading date for the paper decision.")
+
+
+def _proposal_id(signal_date: str, effective_date: str, symbol: str) -> str:
+    return f"{effective_date}-{symbol}-{signal_date}"
+
+
+def _training_rows_for_latest_signal(
+    labeled_dataset: pd.DataFrame,
+    config: ExperimentConfig,
+    latest_signal_date: pd.Timestamp,
+) -> pd.DataFrame:
+    label_cutoff = pd.Timestamp(latest_signal_date)
+    for _ in range(max(0, config.evaluation.walk_forward.embargo_periods)):
+        label_cutoff = pd.Timestamp(label_cutoff - to_offset(config.portfolio.ranking.rebalance_frequency))
+
+    train_start = pd.Timestamp(latest_signal_date) - pd.DateOffset(
+        years=config.evaluation.walk_forward.train_years
+    )
+    train_rows = labeled_dataset.loc[
+        labeled_dataset["signal_date"].ge(train_start)
+        & labeled_dataset["signal_date"].lt(label_cutoff)
+        & labeled_dataset["target_end_date"].le(label_cutoff)
+    ].copy()
+    return train_rows.reset_index(drop=True)
+
+
+def _latest_snapshot_row(
+    featured_panel: pd.DataFrame,
+    feature_columns: list[str],
+    latest_signal_date: pd.Timestamp,
+    effective_date: str,
+) -> pd.DataFrame:
+    latest_snapshot = featured_panel.loc[
+        featured_panel["timestamp"] == latest_signal_date,
+        ["symbol", "timestamp", *feature_columns],
+    ].copy()
+    latest_snapshot = latest_snapshot.rename(columns={"timestamp": "signal_date"})
+    latest_snapshot["effective_date"] = effective_date
+    latest_snapshot = latest_snapshot[
+        ["symbol", "signal_date", "effective_date", *feature_columns]
+    ].reset_index(drop=True)
+    if len(latest_snapshot) != 1:
+        raise RuntimeError("The Phase 7.1 paper decision path expects exactly one latest snapshot row.")
+    return latest_snapshot
+
+
+def _train_and_score_models(
+    config: ExperimentConfig,
+    *,
+    train_rows: pd.DataFrame,
+    latest_snapshot: pd.DataFrame,
+    feature_columns: list[str],
+) -> list[dict[str, Any]]:
+    threshold = float(config.portfolio.ranking.min_score_threshold)
+    rows: list[dict[str, Any]] = []
+    target = train_rows["target"].astype(int)
+
+    for model_name in _paper_model_names(config):
+        definition, estimator = build_model_estimator(model_name, config.target.type)
+        estimator.fit(train_rows[feature_columns], target)
+        score = float(predict_direction_scores(estimator, latest_snapshot[feature_columns]).iloc[0])
+        vote = "long" if score >= threshold else "cash"
+        rows.append(
+            {
+                "model_name": model_name,
+                "estimator_label": definition.estimator_label,
+                "score": score,
+                "vote": vote,
+                "target_weight": 1.0 if vote == "long" else 0.0,
+            }
+        )
+
+    return rows
+
+
+def _proposal_consensus(
+    config: ExperimentConfig,
+    *,
+    model_rows: list[dict[str, Any]],
+) -> tuple[dict[str, Any], float]:
+    long_vote_count = sum(1 for row in model_rows if row["vote"] == "long")
+    cash_vote_count = len(model_rows) - long_vote_count
+    consensus_rule = {
+        "type": CONSENSUS_POLICY,
+        "min_long_votes": int(config.paper.consensus_min_long_votes),
+        "model_count": len(model_rows),
+    }
+    target_weight = 1.0 if long_vote_count >= config.paper.consensus_min_long_votes else 0.0
+    return (
+        {
+            "decision_policy": CONSENSUS_POLICY,
+            "consensus_rule": consensus_rule,
+            "long_vote_count": long_vote_count,
+            "cash_vote_count": cash_vote_count,
+            "decision": "long" if target_weight > 0.0 else "cash",
+            "target_weight": target_weight,
+        },
+        target_weight,
+    )
+
+
+def _reference_price_for_signal(
+    featured_panel: pd.DataFrame,
+    *,
+    symbol: str,
+    latest_signal_date: pd.Timestamp,
+) -> float:
+    latest_price_row = featured_panel.loc[
+        (featured_panel["symbol"] == symbol)
+        & (featured_panel["timestamp"] == latest_signal_date)
+    ]
+    if latest_price_row.empty:
+        raise RuntimeError("The paper decision path could not resolve the latest reference price.")
+    return float(latest_price_row.iloc[-1]["adj_close"])
+
+
+def run_paper_decision(
+    config: ExperimentConfig,
+    *,
+    now: datetime | None = None,
+    provider: AlpacaMarketDataProvider | None = None,
+    broker: AlpacaPaperBrokerClient | None = None,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    paper_symbol = _paper_symbol(config)
+    store = PaperStateStore(config)
+    local_now = _local_now(config, now)
+    broker_client = broker or AlpacaPaperBrokerClient()
+    market_date = local_now.date()
+
+    if not _is_trading_day(broker_client, market_date=market_date):
+        status = {
+            "event": "paper-decision",
+            "status": SUBMISSION_SKIPPED,
+            "reason": "non_trading_day",
+            "market_date": market_date.isoformat(),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {"status_path": str(status_path), "status": status}
+
+    panel = _build_alpaca_panel(config, provider=provider)
+    featured_panel = add_feature_set(panel=panel, **asdict(config.features))
+    historical_snapshots = build_rebalance_snapshots(
+        featured_panel,
+        frequency=config.portfolio.ranking.rebalance_frequency,
+    )
+    if historical_snapshots.empty:
+        raise RuntimeError("The paper decision path produced no rebalance snapshots.")
+
+    latest_signal_date = pd.Timestamp(featured_panel["timestamp"].max())
+    if latest_signal_date.date() != market_date:
+        status = {
+            "event": "paper-decision",
+            "status": SUBMISSION_SKIPPED,
+            "reason": "stale_signal_date",
+            "market_date": market_date.isoformat(),
+            "latest_signal_date": latest_signal_date.date().isoformat(),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {"status_path": str(status_path), "status": status}
+
+    labeled_dataset = add_forward_targets(
+        snapshots=historical_snapshots,
+        panel=featured_panel,
+        horizon_days=config.target.horizon_days,
+        target_type=config.target.type,
+    )
+    if labeled_dataset.empty:
+        raise RuntimeError("The paper decision path produced no labeled historical rows.")
+
+    feature_columns = modeling_feature_columns(labeled_dataset)
+    effective_date = _next_trading_date(
+        broker_client,
+        market_date=market_date,
+    ).isoformat()
+    latest_snapshot = _latest_snapshot_row(
+        featured_panel,
+        feature_columns,
+        latest_signal_date,
+        effective_date,
+    )
+    proposal_id = _proposal_id(
+        signal_date=_iso_date(latest_signal_date),
+        effective_date=effective_date,
+        symbol=paper_symbol,
+    )
+
+    try:
+        existing = store.load_proposal(proposal_id)
+    except FileNotFoundError:
+        existing = None
+    if existing is not None:
+        evidence_path = store.trade_evidence_path(existing["effective_date"])
+        status = {
+            "event": "paper-decision",
+            "status": "existing_proposal",
+            "proposal_id": proposal_id,
+            "proposal_path": str(store.inbox_proposal_path(proposal_id)),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {
+            "proposal_id": proposal_id,
+            "proposal_path": str(store.inbox_proposal_path(proposal_id)),
+            "evidence_path": str(evidence_path),
+            "status_path": str(status_path),
+            "status": status,
+        }
+
+    train_rows = _training_rows_for_latest_signal(labeled_dataset, config, latest_signal_date)
+    if len(train_rows) < max(1, config.evaluation.walk_forward.min_train_rows):
+        raise RuntimeError(
+            "The paper decision path does not have enough historical rows for the Phase 7.1 model set."
+        )
+    train_target = train_rows["target"].astype(int)
+    train_positive_rate = float(train_target.mean())
+    if train_positive_rate < float(config.evaluation.walk_forward.min_train_positive_rate):
+        raise RuntimeError(
+            "The paper decision path does not meet the configured minimum positive-rate floor."
+        )
+    if train_target.nunique() < 2:
+        raise RuntimeError("The paper decision path needs both target classes in the training slice.")
+
+    model_rows = _train_and_score_models(
+        config,
+        train_rows=train_rows,
+        latest_snapshot=latest_snapshot,
+        feature_columns=feature_columns,
+    )
+    consensus_summary, _ = _proposal_consensus(config, model_rows=model_rows)
+    reference_price = _reference_price_for_signal(
+        featured_panel,
+        symbol=paper_symbol,
+        latest_signal_date=latest_signal_date,
+    )
+
+    approval_status = (
+        APPROVAL_NOT_REQUIRED
+        if config.paper.execution_mode == "autonomous"
+        else APPROVAL_PENDING
+    )
+    evidence = {
+        "proposal_id": proposal_id,
+        "experiment_name": config.experiment_name,
+        "symbol": paper_symbol,
+        "signal_date": _iso_date(latest_signal_date),
+        "effective_date": effective_date,
+        "feature_columns": feature_columns,
+        "train_rows": int(len(train_rows)),
+        "train_start": _iso_date(pd.Timestamp(train_rows["signal_date"].min())),
+        "train_end": _iso_date(pd.Timestamp(train_rows["signal_date"].max())),
+        "train_positive_rate": train_positive_rate,
+        "min_score_threshold": float(config.portfolio.ranking.min_score_threshold),
+        "reference_price": reference_price,
+        "models": model_rows,
+        **consensus_summary,
+        "created_at": _now_utc(now).isoformat(),
+    }
+    evidence_path = store.save_evidence(evidence)
+
+    proposal = {
+        "proposal_id": proposal_id,
+        "experiment_name": config.experiment_name,
+        "symbol": paper_symbol,
+        "signal_date": _iso_date(latest_signal_date),
+        "effective_date": effective_date,
+        "reference_price": reference_price,
+        "execution_mode": config.paper.execution_mode,
+        "approval_status": approval_status,
+        "submission_status": SUBMISSION_PENDING,
+        "min_score_threshold": float(config.portfolio.ranking.min_score_threshold),
+        "train_rows": int(len(train_rows)),
+        "train_start": evidence["train_start"],
+        "train_end": evidence["train_end"],
+        "train_positive_rate": train_positive_rate,
+        "created_at": _now_utc(now).isoformat(),
+        "data_provider": config.paper.data_provider,
+        "broker": config.paper.broker,
+        "evidence_path": str(evidence_path),
+        **consensus_summary,
+    }
+    proposal_path = store.save_proposal(proposal)
+    status = {
+        "event": "paper-decision",
+        "status": "proposal_created",
+        "proposal_id": proposal_id,
+        "proposal_path": str(proposal_path),
+        "evidence_path": str(evidence_path),
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    status_path = store.write_status(status)
+    return {
+        "proposal_id": proposal_id,
+        "proposal_path": str(proposal_path),
+        "evidence_path": str(evidence_path),
+        "status_path": str(status_path),
+        "status": status,
+    }
+
+
+def list_paper_proposals(config: ExperimentConfig) -> list[dict[str, Any]]:
+    validate_paper_trading_config(config)
+    return PaperStateStore(config).list_proposals()
+
+
+def read_paper_proposal(
+    config: ExperimentConfig,
+    *,
+    proposal_id: str,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    return PaperStateStore(config).load_proposal(proposal_id)
+
+
+def read_paper_evidence(
+    config: ExperimentConfig,
+    *,
+    proposal_id: str,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_id)
+    return store.load_evidence(proposal["effective_date"])
+
+
+def decide_paper_proposal(
+    config: ExperimentConfig,
+    *,
+    proposal_id: str,
+    decision: str,
+    actor: str,
+    rationale: str | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+    fallback_used: bool = False,
+    fallback_reason: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    if decision not in {"approve", "reject"}:
+        raise RuntimeError("paper-approve requires decision to be either approve or reject.")
+    if actor not in {"agent", "manual"}:
+        raise RuntimeError("paper-approve requires actor to be either agent or manual.")
+
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_id)
+    trade_date = proposal["effective_date"]
+    submission_path = store.trade_submission_path(trade_date)
+    if submission_path.exists():
+        raise RuntimeError("Cannot change approval after paper-submit has already persisted state.")
+
+    required_actor = None
+    if config.paper.execution_mode == "agent_approval":
+        required_actor = "agent"
+    elif config.paper.execution_mode == "manual_approval":
+        required_actor = "manual"
+    else:
+        raise RuntimeError("paper-approve is not used when execution_mode='autonomous'.")
+
+    if actor != required_actor:
+        raise RuntimeError(
+            f"paper-approve for execution_mode='{config.paper.execution_mode}' requires actor='{required_actor}'."
+        )
+
+    approval_status = APPROVAL_APPROVED if decision == "approve" else APPROVAL_REJECTED
+    approval_timestamp = _now_utc(now).isoformat()
+    proposal["approval_status"] = approval_status
+    proposal["approval_actor"] = actor
+    proposal["approval_decision"] = decision
+    proposal["approval_timestamp"] = approval_timestamp
+    if rationale is not None:
+        proposal["approval_rationale"] = rationale
+    if provider is not None:
+        proposal["approval_backend"] = provider
+    if model is not None:
+        proposal["approval_model"] = model
+    proposal["approval_fallback_used"] = bool(fallback_used)
+    if fallback_reason:
+        proposal["approval_fallback_reason"] = fallback_reason
+    proposal_path = store.update_proposal(proposal)
+    approval_record = {
+        "proposal_id": proposal_id,
+        "trade_date": trade_date,
+        "decision": decision,
+        "approval_status": approval_status,
+        "actor": actor,
+        "timestamp": approval_timestamp,
+        "provider": provider,
+        "model": model,
+        "fallback_used": bool(fallback_used),
+        "fallback_reason": fallback_reason,
+        "rationale": rationale,
+    }
+    approval_path = _json_dump(store.trade_approval_path(trade_date), approval_record)
+    status = {
+        "event": "paper-approve",
+        "status": approval_status,
+        "proposal_id": proposal_id,
+        "proposal_path": str(proposal_path),
+        "approval_path": str(approval_path),
+        "updated_at": approval_timestamp,
+    }
+    status_path = store.write_status(status)
+    return {
+        "proposal_id": proposal_id,
+        "proposal_path": str(proposal_path),
+        "approval_path": str(approval_path),
+        "status_path": str(status_path),
+        "status": status,
+    }
+
+
+def _submission_gate_status(
+    config: ExperimentConfig,
+    proposal: dict[str, Any],
+) -> tuple[str, str]:
+    if config.paper.execution_mode == "autonomous":
+        return "ready", ""
+
+    approval_status = proposal.get("approval_status", APPROVAL_PENDING)
+    if approval_status == APPROVAL_REJECTED:
+        return SUBMISSION_SKIPPED, "rejected"
+    if approval_status != APPROVAL_APPROVED:
+        return SUBMISSION_SKIPPED, "missing_approval"
+
+    required_actor = "agent" if config.paper.execution_mode == "agent_approval" else "manual"
+    if proposal.get("approval_actor") != required_actor:
+        return SUBMISSION_SKIPPED, "wrong_actor"
+    return "ready", ""
+
+
+def run_paper_submit(
+    config: ExperimentConfig,
+    *,
+    now: datetime | None = None,
+    broker: AlpacaPaperBrokerClient | None = None,
+) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    paper_symbol = _paper_symbol(config)
+    store = PaperStateStore(config)
+    proposal = store.latest_proposal()
+    if proposal is None:
+        status = {
+            "event": "paper-submit",
+            "status": SUBMISSION_SKIPPED,
+            "reason": "no_proposal",
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {"status_path": str(status_path), "status": status}
+
+    local_now = _local_now(config, now)
+    submission_clock = _clock_value(config.paper.submission_time)
+    if local_now.time() < submission_clock:
+        raise RuntimeError(
+            "paper-submit is only allowed at or after "
+            f"{config.paper.submission_time} {config.paper.schedule_timezone}."
+        )
+
+    trade_date = proposal["effective_date"]
+    submission_path = store.trade_submission_path(trade_date)
+    if submission_path.exists():
+        submission = _json_load(submission_path)
+        status = {
+            "event": "paper-submit",
+            "status": "existing_submission",
+            "proposal_id": proposal["proposal_id"],
+            "submission_path": str(submission_path),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {
+            "submission_path": str(submission_path),
+            "status_path": str(status_path),
+            "status": status,
+            "submission": submission,
+        }
+
+    broker_client = broker or AlpacaPaperBrokerClient()
+    gate_status, gate_reason = _submission_gate_status(config, proposal)
+    if gate_status != "ready":
+        submission = {
+            "proposal_id": proposal["proposal_id"],
+            "trade_date": trade_date,
+            "status": gate_status,
+            "reason": gate_reason,
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        _json_dump(submission_path, submission)
+        status = {
+            "event": "paper-submit",
+            "status": gate_status,
+            "reason": gate_reason,
+            "proposal_id": proposal["proposal_id"],
+            "submission_path": str(submission_path),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {
+            "submission_path": str(submission_path),
+            "status_path": str(status_path),
+            "status": status,
+            "submission": submission,
+        }
+
+    account = broker_client.get_account()
+    _json_dump(store.trade_account_snapshot_path(trade_date), account)
+    position = broker_client.get_position(paper_symbol)
+    current_qty = float(position["qty"]) if position is not None else 0.0
+    equity = float(account["equity"])
+    reference_price = float(proposal["reference_price"])
+    desired_qty = 0.0
+    if float(proposal["target_weight"]) > 0.0:
+        desired_qty = equity / reference_price
+
+    delta_qty = round(desired_qty - current_qty, 6)
+    side = "buy" if delta_qty > 0.0 else "sell"
+    order_preview = {
+        "proposal_id": proposal["proposal_id"],
+        "trade_date": trade_date,
+        "symbol": paper_symbol,
+        "equity": equity,
+        "reference_price": reference_price,
+        "current_qty": current_qty,
+        "desired_qty": desired_qty,
+        "delta_qty": delta_qty,
+        "side": side if abs(delta_qty) > 0.0 else "none",
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    _json_dump(store.trade_order_preview_path(trade_date), order_preview)
+
+    if abs(delta_qty) < 1e-6:
+        submission = {
+            "proposal_id": proposal["proposal_id"],
+            "trade_date": trade_date,
+            "status": SUBMISSION_NOOP,
+            "reason": "already_at_target",
+            "order_preview_path": str(store.trade_order_preview_path(trade_date)),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        _json_dump(submission_path, submission)
+        status = {
+            "event": "paper-submit",
+            "status": SUBMISSION_NOOP,
+            "proposal_id": proposal["proposal_id"],
+            "submission_path": str(submission_path),
+            "updated_at": _now_utc(now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        return {
+            "submission_path": str(submission_path),
+            "status_path": str(status_path),
+            "status": status,
+            "submission": submission,
+        }
+
+    client_order_id = f"marketlab-{proposal['proposal_id']}".replace("_", "-")[:48]
+    order = broker_client.submit_fractional_day_market_order(
+        symbol=paper_symbol,
+        qty=abs(delta_qty),
+        side=side,
+        client_order_id=client_order_id,
+    )
+    try:
+        order_status = broker_client.get_order(str(order["id"]))
+        poll_status = "observed"
+    except RuntimeError as exc:
+        order_status = {
+            "id": order.get("id"),
+            "client_order_id": order.get("client_order_id", client_order_id),
+            "status": order.get("status", "unknown"),
+            "poll_error": str(exc),
+        }
+        poll_status = "timeout"
+    _json_dump(store.trade_order_status_path(trade_date), order_status)
+
+    submission = {
+        "proposal_id": proposal["proposal_id"],
+        "trade_date": trade_date,
+        "status": SUBMISSION_SUBMITTED,
+        "order_id": order["id"],
+        "client_order_id": order.get("client_order_id", client_order_id),
+        "order_status": order_status.get("status", order.get("status", "unknown")),
+        "poll_status": poll_status,
+        "order_preview_path": str(store.trade_order_preview_path(trade_date)),
+        "account_snapshot_path": str(store.trade_account_snapshot_path(trade_date)),
+        "order_status_path": str(store.trade_order_status_path(trade_date)),
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    _json_dump(submission_path, submission)
+    status = {
+        "event": "paper-submit",
+        "status": SUBMISSION_SUBMITTED,
+        "proposal_id": proposal["proposal_id"],
+        "submission_path": str(submission_path),
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    status_path = store.write_status(status)
+    return {
+        "submission_path": str(submission_path),
+        "status_path": str(status_path),
+        "status": status,
+        "submission": submission,
+    }
+
+
+def get_paper_status(config: ExperimentConfig) -> dict[str, Any]:
+    validate_paper_trading_config(config)
+    store = PaperStateStore(config)
+    latest_proposal = store.latest_proposal()
+    proposals = store.list_proposals()
+    pending_proposals = [
+        proposal
+        for proposal in proposals
+        if proposal.get("approval_status", APPROVAL_PENDING) == APPROVAL_PENDING
+    ]
+    return {
+        "status_path": str(store.status_path),
+        "status": store.read_status(),
+        "latest_proposal": latest_proposal,
+        "pending_proposal_count": len(pending_proposals),
+    }

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -62,7 +62,7 @@ from marketlab.strategies.optimized import (
 )
 from marketlab.strategies.ranking import generate_weights as ranking_weights
 from marketlab.strategies.sma import generate_weights as sma_weights
-from marketlab.targets.weekly import build_weekly_modeling_dataset
+from marketlab.targets import build_modeling_dataset
 
 LOGGER = logging.getLogger(__name__)
 
@@ -709,9 +709,9 @@ def train_models(config: ExperimentConfig) -> TrainModelsArtifacts:
         raise RuntimeError("No models are configured for train-models.")
 
     panel, panel_path = prepare_data(config)
-    modeling_dataset = build_weekly_modeling_dataset(panel, config)
+    modeling_dataset = build_modeling_dataset(panel, config)
     if modeling_dataset.empty:
-        raise RuntimeError("Weekly modeling dataset is empty.")
+        raise RuntimeError("Modeling dataset is empty.")
 
     run_dir = _run_dir(config)
     fold_diagnostics = build_walk_forward_diagnostics(
@@ -854,9 +854,9 @@ def run_experiment(config: ExperimentConfig) -> ExperimentArtifacts:
             black_litterman_assumptions=black_litterman_assumptions,
         )
 
-    modeling_dataset = build_weekly_modeling_dataset(panel, config)
+    modeling_dataset = build_modeling_dataset(panel, config)
     if modeling_dataset.empty:
-        raise RuntimeError("Weekly modeling dataset is empty.")
+        raise RuntimeError("Modeling dataset is empty.")
 
     run_dir = _run_dir(config)
     fold_diagnostics = build_walk_forward_diagnostics(

--- a/src/marketlab/rebalance.py
+++ b/src/marketlab/rebalance.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import pandas as pd
 
 
-def weekly_signal_dates(
+def rebalance_signal_dates(
     panel: pd.DataFrame,
     frequency: str = "W-FRI",
 ) -> list[pd.Timestamp]:
     calendar = pd.DataFrame({"timestamp": sorted(panel["timestamp"].drop_duplicates())})
     calendar["rebalance_period"] = calendar["timestamp"].dt.to_period(frequency)
     return calendar.groupby("rebalance_period")["timestamp"].max().sort_values().tolist()
+
+
+def weekly_signal_dates(
+    panel: pd.DataFrame,
+    frequency: str = "W-FRI",
+) -> list[pd.Timestamp]:
+    return rebalance_signal_dates(panel, frequency)
 
 
 def next_effective_dates(
@@ -39,7 +46,7 @@ def signal_effective_dates(
     panel: pd.DataFrame,
     frequency: str = "W-FRI",
 ) -> pd.Series:
-    return next_effective_dates(panel, weekly_signal_dates(panel, frequency))
+    return next_effective_dates(panel, rebalance_signal_dates(panel, frequency))
 
 
 def next_rebalance_effective_date(

--- a/src/marketlab/targets/__init__.py
+++ b/src/marketlab/targets/__init__.py
@@ -1,11 +1,17 @@
-from .weekly import (
+from .timing import (
     add_forward_targets,
+    build_modeling_dataset,
+    build_rebalance_snapshots,
+)
+from .weekly import (
     build_weekly_modeling_dataset,
     build_weekly_snapshots,
 )
 
 __all__ = [
     "add_forward_targets",
+    "build_modeling_dataset",
+    "build_rebalance_snapshots",
     "build_weekly_modeling_dataset",
     "build_weekly_snapshots",
 ]

--- a/src/marketlab/targets/timing.py
+++ b/src/marketlab/targets/timing.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import pandas as pd
+
+from marketlab.config import ExperimentConfig
+from marketlab.data.panel import PANEL_COLUMNS
+from marketlab.features.engineering import add_feature_set
+from marketlab.rebalance import next_effective_dates, rebalance_signal_dates
+
+
+def _resolve_feature_columns(
+    featured_panel: pd.DataFrame,
+    feature_columns: list[str] | None,
+) -> list[str]:
+    if feature_columns is None:
+        excluded = set(PANEL_COLUMNS)
+        return [column for column in featured_panel.columns if column not in excluded]
+
+    missing = [column for column in feature_columns if column not in featured_panel.columns]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"Snapshots are missing feature columns: {joined}")
+    return list(feature_columns)
+
+
+def build_rebalance_snapshots(
+    featured_panel: pd.DataFrame,
+    feature_columns: list[str] | None = None,
+    frequency: str = "W-FRI",
+) -> pd.DataFrame:
+    required = {"symbol", "timestamp"}
+    missing = required - set(featured_panel.columns)
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise ValueError(f"Featured panel is missing required columns: {joined}")
+
+    working = featured_panel.sort_values(["symbol", "timestamp"]).copy()
+    feature_names = _resolve_feature_columns(working, feature_columns)
+    effective_dates = next_effective_dates(working, rebalance_signal_dates(working, frequency))
+
+    if effective_dates.empty:
+        columns = ["symbol", "signal_date", "effective_date", *feature_names]
+        return pd.DataFrame(columns=columns)
+
+    snapshots = working.loc[
+        working["timestamp"].isin(effective_dates.index),
+        ["symbol", "timestamp", *feature_names],
+    ].copy()
+    snapshots = snapshots.rename(columns={"timestamp": "signal_date"})
+    snapshots["effective_date"] = snapshots["signal_date"].map(effective_dates)
+    snapshots = snapshots[["symbol", "signal_date", "effective_date", *feature_names]]
+    return snapshots.sort_values(["signal_date", "symbol"]).reset_index(drop=True)
+
+
+def add_forward_targets(
+    snapshots: pd.DataFrame,
+    panel: pd.DataFrame,
+    horizon_days: int,
+    target_type: str = "direction",
+) -> pd.DataFrame:
+    if horizon_days < 1:
+        raise ValueError("horizon_days must be at least 1.")
+
+    required_snapshot_columns = {"symbol", "signal_date", "effective_date"}
+    missing_snapshot_columns = required_snapshot_columns - set(snapshots.columns)
+    if missing_snapshot_columns:
+        joined = ", ".join(sorted(missing_snapshot_columns))
+        raise ValueError(f"Snapshots are missing required columns: {joined}")
+
+    required_panel_columns = {"symbol", "timestamp", "adj_open", "adj_close"}
+    missing_panel_columns = required_panel_columns - set(panel.columns)
+    if missing_panel_columns:
+        joined = ", ".join(sorted(missing_panel_columns))
+        raise ValueError(f"Panel is missing required columns: {joined}")
+
+    if snapshots.empty:
+        columns = [*snapshots.columns, "target_end_date", "forward_return", "target"]
+        return pd.DataFrame(columns=columns)
+
+    prices = panel.loc[:, ["symbol", "timestamp", "adj_open", "adj_close"]].copy()
+    unique_dates = pd.Index(sorted(prices["timestamp"].drop_duplicates()))
+    date_positions = pd.Series(range(len(unique_dates)), index=unique_dates)
+
+    working = snapshots.copy()
+    effective_positions = working["effective_date"].map(date_positions)
+    working = working.loc[effective_positions.notna()].copy()
+    effective_positions = effective_positions.loc[working.index].astype(int)
+
+    horizon_positions = effective_positions + (horizon_days - 1)
+    valid_horizon = horizon_positions < len(unique_dates)
+    working = working.loc[valid_horizon].copy()
+    horizon_positions = horizon_positions.loc[valid_horizon].astype(int)
+    working["target_end_date"] = unique_dates.take(horizon_positions.to_numpy())
+
+    entry_prices = prices.rename(
+        columns={"timestamp": "effective_date", "adj_open": "entry_adj_open"}
+    )[["symbol", "effective_date", "entry_adj_open"]]
+    exit_prices = prices.rename(
+        columns={"timestamp": "target_end_date", "adj_close": "exit_adj_close"}
+    )[["symbol", "target_end_date", "exit_adj_close"]]
+
+    working = working.merge(entry_prices, on=["symbol", "effective_date"], how="left")
+    working = working.merge(exit_prices, on=["symbol", "target_end_date"], how="left")
+    working = working.dropna(subset=["entry_adj_open", "exit_adj_close"]).copy()
+
+    working["forward_return"] = (working["exit_adj_close"] / working["entry_adj_open"]) - 1.0
+
+    if target_type == "direction":
+        working["target"] = working["forward_return"].gt(0.0).astype(int)
+    elif target_type == "return":
+        working["target"] = working["forward_return"]
+    else:
+        raise ValueError(f"Unsupported target_type: {target_type}")
+
+    working = working.drop(columns=["entry_adj_open", "exit_adj_close"])
+    return working.sort_values(["signal_date", "symbol"]).reset_index(drop=True)
+
+
+def build_modeling_dataset(
+    panel: pd.DataFrame,
+    config: ExperimentConfig,
+) -> pd.DataFrame:
+    featured_panel = add_feature_set(
+        panel=panel,
+        **asdict(config.features),
+    )
+    feature_columns = _resolve_feature_columns(featured_panel, feature_columns=None)
+    snapshots = build_rebalance_snapshots(
+        featured_panel,
+        feature_columns=feature_columns,
+        frequency=config.portfolio.ranking.rebalance_frequency,
+    )
+    dataset = add_forward_targets(
+        snapshots,
+        panel=featured_panel,
+        horizon_days=config.target.horizon_days,
+        target_type=config.target.type,
+    )
+    required_columns = [*feature_columns, "forward_return", "target"]
+    dataset = dataset.dropna(subset=required_columns).reset_index(drop=True)
+    return dataset

--- a/src/marketlab/targets/weekly.py
+++ b/src/marketlab/targets/weekly.py
@@ -1,28 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import asdict
-
 import pandas as pd
 
 from marketlab.config import ExperimentConfig
-from marketlab.data.panel import PANEL_COLUMNS
-from marketlab.features.engineering import add_feature_set
-from marketlab.rebalance import next_effective_dates, weekly_signal_dates
+from marketlab.targets import timing as timing_targets
 
-
-def _resolve_feature_columns(
-    featured_panel: pd.DataFrame,
-    feature_columns: list[str] | None,
-) -> list[str]:
-    if feature_columns is None:
-        excluded = set(PANEL_COLUMNS)
-        return [column for column in featured_panel.columns if column not in excluded]
-
-    missing = [column for column in feature_columns if column not in featured_panel.columns]
-    if missing:
-        joined = ", ".join(missing)
-        raise ValueError(f"Weekly snapshots are missing feature columns: {joined}")
-    return list(feature_columns)
+add_forward_targets = timing_targets.add_forward_targets
 
 
 def build_weekly_snapshots(
@@ -30,114 +13,15 @@ def build_weekly_snapshots(
     feature_columns: list[str] | None = None,
     frequency: str = "W-FRI",
 ) -> pd.DataFrame:
-    required = {"symbol", "timestamp"}
-    missing = required - set(featured_panel.columns)
-    if missing:
-        joined = ", ".join(sorted(missing))
-        raise ValueError(f"Featured panel is missing required columns: {joined}")
-
-    working = featured_panel.sort_values(["symbol", "timestamp"]).copy()
-    feature_names = _resolve_feature_columns(working, feature_columns)
-    effective_dates = next_effective_dates(working, weekly_signal_dates(working, frequency))
-
-    if effective_dates.empty:
-        columns = ["symbol", "signal_date", "effective_date", *feature_names]
-        return pd.DataFrame(columns=columns)
-
-    snapshots = working.loc[
-        working["timestamp"].isin(effective_dates.index),
-        ["symbol", "timestamp", *feature_names],
-    ].copy()
-    snapshots = snapshots.rename(columns={"timestamp": "signal_date"})
-    snapshots["effective_date"] = snapshots["signal_date"].map(effective_dates)
-    snapshots = snapshots[["symbol", "signal_date", "effective_date", *feature_names]]
-    return snapshots.sort_values(["signal_date", "symbol"]).reset_index(drop=True)
-
-
-def add_forward_targets(
-    snapshots: pd.DataFrame,
-    panel: pd.DataFrame,
-    horizon_days: int,
-    target_type: str = "direction",
-) -> pd.DataFrame:
-    if horizon_days < 1:
-        raise ValueError("horizon_days must be at least 1.")
-
-    required_snapshot_columns = {"symbol", "signal_date", "effective_date"}
-    missing_snapshot_columns = required_snapshot_columns - set(snapshots.columns)
-    if missing_snapshot_columns:
-        joined = ", ".join(sorted(missing_snapshot_columns))
-        raise ValueError(f"Snapshots are missing required columns: {joined}")
-
-    required_panel_columns = {"symbol", "timestamp", "adj_open", "adj_close"}
-    missing_panel_columns = required_panel_columns - set(panel.columns)
-    if missing_panel_columns:
-        joined = ", ".join(sorted(missing_panel_columns))
-        raise ValueError(f"Panel is missing required columns: {joined}")
-
-    if snapshots.empty:
-        columns = [*snapshots.columns, "target_end_date", "forward_return", "target"]
-        return pd.DataFrame(columns=columns)
-
-    prices = panel.loc[:, ["symbol", "timestamp", "adj_open", "adj_close"]].copy()
-    unique_dates = pd.Index(sorted(prices["timestamp"].drop_duplicates()))
-    date_positions = pd.Series(range(len(unique_dates)), index=unique_dates)
-
-    working = snapshots.copy()
-    effective_positions = working["effective_date"].map(date_positions)
-    working = working.loc[effective_positions.notna()].copy()
-    effective_positions = effective_positions.loc[working.index].astype(int)
-
-    horizon_positions = effective_positions + (horizon_days - 1)
-    valid_horizon = horizon_positions < len(unique_dates)
-    working = working.loc[valid_horizon].copy()
-    horizon_positions = horizon_positions.loc[valid_horizon].astype(int)
-    working["target_end_date"] = unique_dates.take(horizon_positions.to_numpy())
-
-    entry_prices = prices.rename(
-        columns={"timestamp": "effective_date", "adj_open": "entry_adj_open"}
-    )[["symbol", "effective_date", "entry_adj_open"]]
-    exit_prices = prices.rename(
-        columns={"timestamp": "target_end_date", "adj_close": "exit_adj_close"}
-    )[["symbol", "target_end_date", "exit_adj_close"]]
-
-    working = working.merge(entry_prices, on=["symbol", "effective_date"], how="left")
-    working = working.merge(exit_prices, on=["symbol", "target_end_date"], how="left")
-    working = working.dropna(subset=["entry_adj_open", "exit_adj_close"]).copy()
-
-    working["forward_return"] = (working["exit_adj_close"] / working["entry_adj_open"]) - 1.0
-
-    if target_type == "direction":
-        working["target"] = working["forward_return"].gt(0.0).astype(int)
-    elif target_type == "return":
-        working["target"] = working["forward_return"]
-    else:
-        raise ValueError(f"Unsupported target_type: {target_type}")
-
-    working = working.drop(columns=["entry_adj_open", "exit_adj_close"])
-    return working.sort_values(["signal_date", "symbol"]).reset_index(drop=True)
+    return timing_targets.build_rebalance_snapshots(
+        featured_panel,
+        feature_columns=feature_columns,
+        frequency=frequency,
+    )
 
 
 def build_weekly_modeling_dataset(
     panel: pd.DataFrame,
     config: ExperimentConfig,
 ) -> pd.DataFrame:
-    featured_panel = add_feature_set(
-        panel=panel,
-        **asdict(config.features),
-    )
-    feature_columns = _resolve_feature_columns(featured_panel, feature_columns=None)
-    snapshots = build_weekly_snapshots(
-        featured_panel,
-        feature_columns=feature_columns,
-        frequency=config.portfolio.ranking.rebalance_frequency,
-    )
-    dataset = add_forward_targets(
-        snapshots,
-        panel=featured_panel,
-        horizon_days=config.target.horizon_days,
-        target_type=config.target.type,
-    )
-    required_columns = [*feature_columns, "forward_return", "target"]
-    dataset = dataset.dropna(subset=required_columns).reset_index(drop=True)
-    return dataset
+    return timing_targets.build_modeling_dataset(panel, config)

--- a/tests/_paper_fakes.py
+++ b/tests/_paper_fakes.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from marketlab.config import (
+    DataConfig,
+    EvaluationConfig,
+    ExperimentConfig,
+    FeaturesConfig,
+    ModelSpec,
+    PaperConfig,
+    PortfolioConfig,
+    RankingConfig,
+    TargetConfig,
+    WalkForwardConfig,
+)
+
+
+def build_paper_history_frame(
+    *,
+    start_date: str = "2022-01-03",
+    end_date: str = "2026-04-10",
+) -> pd.DataFrame:
+    trading_dates = pd.bdate_range(start_date, end_date)
+    rows: list[dict[str, object]] = []
+    close_price = 100.0
+
+    for index, timestamp in enumerate(trading_dates):
+        open_price = close_price
+        cycle = index % 4
+        if cycle in {0, 1}:
+            close_price = open_price + 0.9
+        else:
+            close_price = max(10.0, open_price - 0.7)
+        rows.append(
+            {
+                "Date": timestamp,
+                "Open": round(open_price, 4),
+                "High": round(max(open_price, close_price) + 0.2, 4),
+                "Low": round(min(open_price, close_price) - 0.2, 4),
+                "Close": round(close_price, 4),
+                "Adj Close": round(close_price, 4),
+                "Volume": 1_000_000 + index,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_phase7_paper_config(
+    base_dir: Path,
+    *,
+    execution_mode: str = "agent_approval",
+    symbol: str = "VOO",
+    agent_backend: str = "deterministic_consensus",
+    agent_model: str = "",
+) -> ExperimentConfig:
+    return ExperimentConfig(
+        experiment_name="phase7_paper_fixture",
+        base_dir=base_dir,
+        data=DataConfig(
+            symbols=[symbol],
+            start_date="2022-01-03",
+            end_date="2026-04-10",
+            interval="1d",
+            cache_dir="artifacts/data-voo-paper-daily",
+            prepared_panel_filename="panel.csv",
+        ),
+        features=FeaturesConfig(
+            return_windows=[5, 10, 20, 40],
+            ma_windows=[10, 20, 50],
+            vol_windows=[10, 20],
+            momentum_window=20,
+        ),
+        target=TargetConfig(horizon_days=1, type="direction"),
+        portfolio=PortfolioConfig(
+            ranking=RankingConfig(
+                long_n=1,
+                short_n=1,
+                rebalance_frequency="D",
+                weighting="equal",
+                mode="long_only",
+                min_score_threshold=0.55,
+                cash_when_underfilled=True,
+            )
+        ),
+        models=[
+            ModelSpec("logistic_regression"),
+            ModelSpec("logistic_l1"),
+            ModelSpec("random_forest"),
+            ModelSpec("extra_trees"),
+            ModelSpec("gradient_boosting"),
+            ModelSpec("hist_gradient_boosting"),
+        ],
+        evaluation=EvaluationConfig(
+            walk_forward=WalkForwardConfig(
+                train_years=3,
+                test_months=1,
+                step_months=1,
+                min_train_rows=200,
+                min_test_rows=15,
+                min_train_positive_rate=0.05,
+                min_test_positive_rate=0.05,
+                embargo_periods=1,
+            )
+        ),
+        paper=PaperConfig(
+            enabled=True,
+            execution_mode=execution_mode,
+            agent_backend=agent_backend,
+            agent_model=agent_model,
+            poll_interval_seconds=1,
+            approval_inbox_dir="artifacts/paper/inbox",
+            state_dir="artifacts/paper/state",
+        ),
+    )
+
+
+class FakeAlpacaProvider:
+    def __init__(self, frame: pd.DataFrame | None = None, *, symbol: str = "VOO") -> None:
+        self.frame = frame if frame is not None else build_paper_history_frame()
+        self.symbol = symbol
+
+    def download_symbol_history(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        interval: str,
+    ) -> pd.DataFrame:
+        if symbol != self.symbol:
+            raise ValueError(f"Unexpected symbol: {symbol}")
+        if interval != "1d":
+            raise ValueError(f"Unexpected interval: {interval}")
+        return self.frame.copy()
+
+
+class FakeAlpacaBroker:
+    def __init__(
+        self,
+        *,
+        trading_days: Sequence[date] | None = None,
+        equity: float = 10_000.0,
+        current_qty: float = 0.0,
+        order_status: str = "accepted",
+        symbol: str = "VOO",
+    ) -> None:
+        if trading_days is None:
+            trading_days = tuple(
+                pd.bdate_range("2026-04-10", "2026-04-24").date
+            )
+        self.trading_days = list(trading_days)
+        self.equity = equity
+        self.current_qty = current_qty
+        self.order_status = order_status
+        self.symbol = symbol
+        self.submitted_orders: list[dict[str, object]] = []
+
+    def get_calendar(self, *, start_date: date, end_date: date) -> list[dict[str, object]]:
+        return [
+            {"date": trading_day.isoformat()}
+            for trading_day in self.trading_days
+            if start_date <= trading_day <= end_date
+        ]
+
+    def get_account(self) -> dict[str, object]:
+        return {
+            "account_number": "PA123456",
+            "equity": f"{self.equity:.2f}",
+            "status": "ACTIVE",
+        }
+
+    def get_position(self, symbol: str) -> dict[str, object] | None:
+        if symbol != self.symbol or self.current_qty == 0.0:
+            return None
+        return {"symbol": symbol, "qty": f"{self.current_qty:.6f}"}
+
+    def submit_fractional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        qty: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, object]:
+        order = {
+            "id": f"order-{len(self.submitted_orders) + 1}",
+            "symbol": symbol,
+            "qty": f"{qty:.6f}",
+            "side": side,
+            "client_order_id": client_order_id,
+            "status": self.order_status,
+        }
+        self.submitted_orders.append(order)
+        if side == "buy":
+            self.current_qty += qty
+        else:
+            self.current_qty = max(0.0, self.current_qty - qty)
+        return order
+
+    def get_order(self, order_id: str) -> dict[str, object]:
+        return {
+            "id": order_id,
+            "status": self.order_status,
+            "client_order_id": self.submitted_orders[-1]["client_order_id"],
+        }
+
+
+def write_phase7_paper_config(
+    path: Path,
+    *,
+    execution_mode: str = "agent_approval",
+    symbol: str = "VOO",
+    agent_backend: str = "deterministic_consensus",
+    agent_model: str = "",
+) -> Path:
+    payload = {
+        "experiment_name": "phase7_paper_fixture",
+        "data": {
+            "symbols": [symbol],
+            "start_date": "2022-01-03",
+            "end_date": "2026-04-10",
+            "interval": "1d",
+            "cache_dir": "artifacts/data-voo-paper-daily",
+            "prepared_panel_filename": "panel.csv",
+        },
+        "features": {
+            "return_windows": [5, 10, 20, 40],
+            "ma_windows": [10, 20, 50],
+            "vol_windows": [10, 20],
+            "momentum_window": 20,
+        },
+        "target": {
+            "horizon_days": 1,
+            "type": "direction",
+        },
+        "portfolio": {
+            "ranking": {
+                "long_n": 1,
+                "short_n": 1,
+                "rebalance_frequency": "D",
+                "weighting": "equal",
+                "mode": "long_only",
+                "min_score_threshold": 0.55,
+                "cash_when_underfilled": True,
+            }
+        },
+        "models": [
+            {"name": "logistic_regression"},
+            {"name": "logistic_l1"},
+            {"name": "random_forest"},
+            {"name": "extra_trees"},
+            {"name": "gradient_boosting"},
+            {"name": "hist_gradient_boosting"},
+        ],
+        "evaluation": {
+            "walk_forward": {
+                "train_years": 3,
+                "test_months": 1,
+                "step_months": 1,
+                "min_train_rows": 200,
+                "min_test_rows": 15,
+                "min_train_positive_rate": 0.05,
+                "min_test_positive_rate": 0.05,
+                "embargo_periods": 1,
+            }
+        },
+        "paper": {
+            "enabled": True,
+            "data_provider": "alpaca",
+            "broker": "alpaca",
+            "execution_mode": execution_mode,
+            "agent_backend": agent_backend,
+            "agent_model": agent_model,
+            "agent_timeout_seconds": 30,
+            "agent_fallback_backend": "deterministic_consensus",
+            "consensus_min_long_votes": 4,
+            "schedule_timezone": "America/New_York",
+            "decision_time": "16:10",
+            "submission_time": "19:05",
+            "order_type": "day_market",
+            "position_sizing": "full_equity_fractional",
+            "approval_inbox_dir": "artifacts/paper/inbox",
+            "state_dir": "artifacts/paper/state",
+            "poll_interval_seconds": 1,
+        },
+        "artifacts": {
+            "output_dir": "artifacts/runs",
+            "save_predictions": True,
+            "save_metrics_csv": True,
+            "save_report_md": True,
+            "save_plots": False,
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 import os
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import anyio
 import pytest
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    write_phase7_paper_config,
+)
 from tests.integration._cli_harness import build_synthetic_panel, write_raw_symbol_cache
+
+from marketlab.config import load_config
+from marketlab.paper.service import run_paper_decision
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MCP_LAUNCHER = REPO_ROOT / "scripts" / "run_marketlab_mcp.py"
@@ -190,3 +199,103 @@ async def test_mcp_server_supports_config_generation_run_execution_and_artifact_
                 {"path": str(run_dir / "report.md"), "max_chars": 4000},
             )
             assert "Strategy Summary" in report_text["content"]
+
+
+@pytest.mark.anyio
+async def test_mcp_server_supports_paper_proposal_listing_reading_and_agent_approval(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    artifact_root = workspace / "artifacts"
+    workspace.mkdir(parents=True)
+    artifact_root.mkdir(parents=True)
+
+    config_path = write_phase7_paper_config(
+        workspace / "configs" / "phase7_paper.yaml",
+        execution_mode="agent_approval",
+    )
+    config = load_config(config_path)
+    decision = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(),
+        broker=FakeAlpacaBroker(),
+    )
+    proposal_id = decision["proposal_id"]
+
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    repo_src = str(REPO_ROOT / "src")
+    env["PYTHONPATH"] = repo_src if not existing_pythonpath else os.pathsep.join(
+        [repo_src, existing_pythonpath]
+    )
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            str(MCP_LAUNCHER),
+            "--workspace-root",
+            str(workspace),
+            "--artifact-root",
+            str(artifact_root),
+            "--repo-root",
+            str(REPO_ROOT),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            tool_names = sorted(tool.name for tool in tools.tools)
+            assert "marketlab_list_paper_proposals" in tool_names
+            assert "marketlab_decide_paper_proposal" in tool_names
+
+            listed = await _call_tool(
+                session,
+                "marketlab_list_paper_proposals",
+                {"config_path": "configs/phase7_paper.yaml"},
+            )
+            assert len(listed["proposals"]) == 1
+            assert listed["proposals"][0]["proposal_id"] == proposal_id
+
+            proposal = await _call_tool(
+                session,
+                "marketlab_read_paper_proposal",
+                {
+                    "config_path": "configs/phase7_paper.yaml",
+                    "proposal_id": proposal_id,
+                },
+            )
+            assert proposal["proposal"]["approval_status"] == "pending"
+
+            status = await _call_tool(
+                session,
+                "marketlab_get_paper_status",
+                {"config_path": "configs/phase7_paper.yaml"},
+            )
+            assert status["latest_proposal"]["proposal_id"] == proposal_id
+
+            approved = await _call_tool(
+                session,
+                "marketlab_decide_paper_proposal",
+                {
+                    "config_path": "configs/phase7_paper.yaml",
+                    "proposal_id": proposal_id,
+                    "decision": "approve",
+                    "actor": "agent",
+                },
+            )
+            assert approved["status"]["status"] == "approved"
+
+            reread = await _call_tool(
+                session,
+                "marketlab_read_paper_proposal",
+                {
+                    "config_path": "configs/phase7_paper.yaml",
+                    "proposal_id": proposal_id,
+                },
+            )
+            assert reread["proposal"]["approval_status"] == "approved"

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -792,6 +792,57 @@ def test_run_experiment_supports_single_symbol_long_only_timing_runs(tmp_path: P
     assert "- Best model by mean top-bucket return:" in report_text
 
 
+def test_run_experiment_supports_daily_one_day_single_symbol_timing_runs(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_run_experiment_config(
+        tmp_path,
+        models=[{"name": "logistic_regression"}],
+        ranking={
+            "mode": "long_only",
+            "long_n": 1,
+            "short_n": 1,
+            "rebalance_frequency": "D",
+            "min_score_threshold": 0.55,
+            "cash_when_underfilled": True,
+        },
+        walk_forward={
+            "train_years": 3,
+            "test_months": 1,
+            "step_months": 1,
+            "min_train_rows": 200,
+            "min_test_rows": 15,
+            "min_train_positive_rate": 0.05,
+            "min_test_positive_rate": 0.05,
+            "embargo_periods": 1,
+        },
+        symbol_specs=(("VOO", 100.0, 0.45),),
+    )
+    config_text = config_path.read_text(encoding="utf-8").replace(
+        'horizon_days: 5',
+        'horizon_days: 1',
+    )
+    config_path.write_text(config_text, encoding="utf-8")
+
+    result = run_marketlab_cli("run-experiment", config_path)
+    assert_command_ok(result)
+
+    run_root = tmp_path / "runs" / "integration_fixture"
+    run_dir = latest_run_dir(run_root)
+    metrics = pd.read_csv(run_dir / "metrics.csv")
+    ranking_diagnostics = pd.read_csv(run_dir / "ranking_diagnostics.csv")
+    report_text = (run_dir / "report.md").read_text(encoding="utf-8")
+
+    assert set(metrics["strategy"]) == {
+        "buy_hold",
+        "sma",
+        "ml_logistic_regression__long_only__thr0p55__cash",
+    }
+    assert set(ranking_diagnostics["evaluation_mode"]) == {"long_only"}
+    assert ranking_diagnostics["top_bucket_size"].eq(1).all()
+    assert "ml_logistic_regression__long_only__thr0p55__cash" in report_text
+
+
 
 
 def test_run_experiment_supports_capped_long_short_strategy_variants(tmp_path: Path) -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -541,3 +541,95 @@ def test_load_config_resolves_relative_optimized_external_paths(tmp_path: Path) 
 
     assert config.optimized_external_covariance_path == (config_dir / "inputs" / "covariance.csv").resolve()
     assert config.optimized_external_expected_returns_path == (config_dir / "inputs" / "expected.csv").resolve()
+
+
+def test_load_config_accepts_phase7_paper_settings(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        data={
+            "symbols": ["VOO"],
+            "interval": "1d",
+        },
+    )
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["target"] = {"horizon_days": 1, "type": "direction"}
+    payload["portfolio"] = {
+        "ranking": {
+            "long_n": 1,
+            "short_n": 1,
+            "rebalance_frequency": "D",
+            "mode": "long_only",
+        }
+    }
+    payload["models"] = [
+        {"name": "logistic_regression"},
+        {"name": "logistic_l1"},
+        {"name": "random_forest"},
+        {"name": "extra_trees"},
+        {"name": "gradient_boosting"},
+        {"name": "hist_gradient_boosting"},
+    ]
+    payload["paper"] = {
+        "enabled": True,
+        "data_provider": "alpaca",
+        "broker": "alpaca",
+        "execution_mode": "agent_approval",
+        "agent_backend": "openai",
+        "agent_model": "gpt-4o-mini",
+        "agent_timeout_seconds": 45,
+        "agent_fallback_backend": "deterministic_consensus",
+        "consensus_min_long_votes": 4,
+        "schedule_timezone": "America/New_York",
+        "decision_time": "16:10",
+        "submission_time": "19:05",
+        "order_type": "day_market",
+        "position_sizing": "full_equity_fractional",
+        "approval_inbox_dir": "artifacts/paper/inbox",
+        "state_dir": "artifacts/paper/state",
+        "poll_interval_seconds": 15,
+    }
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    config = load_config(config_path)
+
+    assert config.paper.enabled is True
+    assert config.paper.execution_mode == "agent_approval"
+    assert config.paper.agent_backend == "openai"
+    assert config.paper.agent_model == "gpt-4o-mini"
+    assert config.paper.agent_timeout_seconds == 45
+    assert config.paper.consensus_min_long_votes == 4
+    assert config.paper_approval_inbox_dir == (tmp_path / "artifacts" / "paper" / "inbox").resolve()
+    assert config.paper_state_dir == (tmp_path / "artifacts" / "paper" / "state").resolve()
+
+
+def test_load_config_rejects_unknown_paper_agent_backend(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        data={"symbols": ["QQQ"], "interval": "1d"},
+    )
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["paper"] = {
+        "enabled": True,
+        "agent_backend": "unknown",
+    }
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="paper.agent_backend must be one of"):
+        load_config(config_path)
+
+
+def test_load_config_rejects_openai_backend_without_model(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        data={"symbols": ["QQQ"], "interval": "1d"},
+    )
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["paper"] = {
+        "enabled": True,
+        "agent_backend": "openai",
+        "agent_model": "",
+    }
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="paper.agent_model must be set"):
+        load_config(config_path)

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    build_phase7_paper_config,
+)
+
+from marketlab.paper.agent import run_agent_approval_iteration
+from marketlab.paper.service import PaperStateStore, run_paper_decision
+
+
+def test_agent_worker_approves_with_openai_backend(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="openai",
+        agent_model="gpt-4o-mini",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                output_text='{"decision":"approve","rationale":"Approve the consensus proposal."}'
+            )
+
+    class FakeOpenAIClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.responses = FakeResponses()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAIClient))
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_backend"] == "openai"
+    assert proposal["approval_model"] == "gpt-4o-mini"
+    assert proposal["approval_fallback_used"] is False
+
+
+def test_agent_worker_approves_with_claude_backend(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="claude",
+        agent_model="claude-sonnet-4-5",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    types.SimpleNamespace(
+                        text='{"decision":"approve","rationale":"Claude approves the proposal."}'
+                    )
+                ]
+            )
+
+    class FakeAnthropicClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.messages = FakeMessages()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        types.SimpleNamespace(Anthropic=FakeAnthropicClient),
+    )
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_backend"] == "claude"
+    assert proposal["approval_model"] == "claude-sonnet-4-5"
+    assert proposal["approval_fallback_used"] is False
+
+
+def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="openai",
+        agent_model="gpt-4o-mini",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(output_text="not-json")
+
+    class FakeOpenAIClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.responses = FakeResponses()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAIClient))
+
+    run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert proposal is not None
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_backend"] == "deterministic_consensus"
+    assert proposal["approval_fallback_used"] is True
+    assert "openai backend failed" in proposal["approval_fallback_reason"]
+
+
+def test_agent_worker_is_idempotent_after_first_approval(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    first = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+    second = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 31, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    assert first["processed_count"] == 1
+    assert second["processed_count"] == 0

--- a/tests/unit/test_paper_alpaca.py
+++ b/tests/unit/test_paper_alpaca.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from marketlab.paper.alpaca import (
+    AlpacaCredentials,
+    AlpacaMarketDataProvider,
+    AlpacaPaperBrokerClient,
+)
+
+
+class _FakeAlpacaHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/v2/stocks/bars":
+            _ = parse_qs(parsed.query)
+            self._json_response(
+                {
+                    "bars": {
+                        "VOO": [
+                            {
+                                "t": "2026-04-09T00:00:00Z",
+                                "o": 100.0,
+                                "h": 101.0,
+                                "l": 99.0,
+                                "c": 100.5,
+                                "v": 1000,
+                            },
+                            {
+                                "t": "2026-04-10T00:00:00Z",
+                                "o": 100.5,
+                                "h": 101.5,
+                                "l": 100.0,
+                                "c": 101.0,
+                                "v": 1200,
+                            },
+                        ]
+                    }
+                }
+            )
+            return
+        if parsed.path == "/v2/calendar":
+            self._json_response(
+                [
+                    {"date": "2026-04-10"},
+                    {"date": "2026-04-13"},
+                ]
+            )
+            return
+        if parsed.path == "/v2/account":
+            self._json_response({"equity": "10000.00", "status": "ACTIVE"})
+            return
+        if parsed.path == "/v2/positions/VOO":
+            self._json_response({"symbol": "VOO", "qty": "0.250000"})
+            return
+        if parsed.path == "/v2/orders/order-1":
+            self._json_response(
+                {
+                    "id": "order-1",
+                    "status": "accepted",
+                    "client_order_id": "marketlab-test-order",
+                }
+            )
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/v2/orders":
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length).decode("utf-8"))
+            self._json_response(
+                {
+                    "id": "order-1",
+                    "status": "accepted",
+                    "client_order_id": payload["client_order_id"],
+                }
+            )
+            return
+        self.send_error(404)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+    def _json_response(self, payload: object) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def fake_alpaca_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeAlpacaHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_alpaca_clients_parse_local_fake_server(
+    fake_alpaca_server: str,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ALPACA_API_KEY_ID", "test-key")
+    monkeypatch.setenv("ALPACA_API_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("ALPACA_DATA_BASE_URL", fake_alpaca_server)
+    monkeypatch.setenv("ALPACA_TRADING_BASE_URL", fake_alpaca_server)
+
+    provider = AlpacaMarketDataProvider()
+    broker = AlpacaPaperBrokerClient()
+
+    frame = provider.download_symbol_history("VOO", "2026-04-09", "2026-04-10", "1d")
+    calendar = broker.get_calendar(start_date=frame["Date"].min().date(), end_date=frame["Date"].max().date())
+    account = broker.get_account()
+    position = broker.get_position("VOO")
+    order = broker.submit_fractional_day_market_order(
+        symbol="VOO",
+        qty=0.5,
+        side="buy",
+        client_order_id="marketlab-test-order",
+    )
+    order_status = broker.get_order("order-1")
+
+    assert list(frame.columns) == ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
+    assert len(frame) == 2
+    assert [item["date"] for item in calendar] == ["2026-04-10", "2026-04-13"]
+    assert account["equity"] == "10000.00"
+    assert position["qty"] == "0.250000"
+    assert order["id"] == "order-1"
+    assert order_status["status"] == "accepted"
+
+
+def test_alpaca_client_reads_configured_symbol_position(
+    fake_alpaca_server: str,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ALPACA_API_KEY_ID", "test-key")
+    monkeypatch.setenv("ALPACA_API_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("ALPACA_DATA_BASE_URL", fake_alpaca_server)
+    monkeypatch.setenv("ALPACA_TRADING_BASE_URL", fake_alpaca_server)
+
+    broker = AlpacaPaperBrokerClient()
+    position = broker.get_position("VOO")
+
+    assert position is not None
+    assert position["symbol"] == "VOO"
+
+
+def test_paper_broker_rejects_live_endpoint() -> None:
+    credentials = AlpacaCredentials(
+        api_key_id="test-key",
+        api_secret_key="test-secret",
+        trading_base_url="https://api.alpaca.markets",
+    )
+
+    with pytest.raises(RuntimeError, match="paper endpoint"):
+        AlpacaPaperBrokerClient(credentials)
+
+
+def test_alpaca_credentials_load_local_env_file(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "\n".join(
+            [
+                "ALPACA_API_KEY_ID=from-env-file-key",
+                "ALPACA_API_SECRET_KEY=from-env-file-secret",
+                "ALPACA_TRADING_BASE_URL=https://paper-api.alpaca.markets",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ALPACA_API_KEY_ID", raising=False)
+    monkeypatch.delenv("ALPACA_API_SECRET_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_TRADING_BASE_URL", raising=False)
+    monkeypatch.delenv("MARKETLAB_ENV_FILE", raising=False)
+
+    credentials = AlpacaCredentials.from_env()
+
+    assert credentials.api_key_id == "from-env-file-key"
+    assert credentials.api_secret_key == "from-env-file-secret"
+    assert credentials.trading_base_url == "https://paper-api.alpaca.markets"

--- a/tests/unit/test_paper_compose.py
+++ b/tests/unit/test_paper_compose.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_paper_compose_includes_scheduler_agent_and_mcp_sidecar() -> None:
+    compose_text = Path("docker/compose.paper.yml").read_text(encoding="utf-8")
+
+    assert "marketlab-paper-scheduler:" in compose_text
+    assert "marketlab-paper-agent:" in compose_text
+    assert "marketlab-paper-mcp:" in compose_text
+    assert "paper-scheduler" in compose_text
+    assert "paper-agent-approve" in compose_text
+    assert "/app/repo/configs/experiment.qqq_paper_daily.yaml" in compose_text
+    assert "../artifacts:/app/repo/artifacts" in compose_text
+    assert "..:/app/repo:ro" in compose_text
+    assert "OPENAI_API_KEY" in compose_text
+    assert "ANTHROPIC_API_KEY" in compose_text

--- a/tests/unit/test_paper_report.py
+++ b/tests/unit/test_paper_report.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    build_paper_history_frame,
+    build_phase7_paper_config,
+)
+
+from marketlab.paper.report import run_paper_report
+from marketlab.paper.service import (
+    decide_paper_proposal,
+    run_paper_decision,
+    run_paper_submit,
+)
+
+
+def test_run_paper_report_writes_summary_and_decision_journal(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ")
+    provider = FakeAlpacaProvider(symbol="QQQ")
+    report_provider = FakeAlpacaProvider(
+        frame=build_paper_history_frame(end_date="2026-04-13"),
+        symbol="QQQ",
+    )
+    decision = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+    )
+    decide_paper_proposal(
+        config,
+        proposal_id=decision["proposal_id"],
+        decision="approve",
+        actor="agent",
+        provider="deterministic_consensus",
+        model="deterministic_consensus",
+        rationale="Approve the consensus proposal.",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    report = run_paper_report(
+        config,
+        start_date="2026-04-13",
+        end_date="2026-04-13",
+        provider=report_provider,
+    )
+
+    summary_path = Path(report["summary_path"])
+    journal_path = Path(report["decision_journal_path"])
+    report_path = Path(report["report_path"])
+
+    summary_text = summary_path.read_text(encoding="utf-8")
+    journal_text = journal_path.read_text(encoding="utf-8")
+    markdown_text = report_path.read_text(encoding="utf-8")
+
+    assert "paper_realized" in summary_text
+    assert "consensus" in summary_text
+    assert "buy_hold" in summary_text
+    assert "sma" in summary_text
+    assert "model_logistic_regression" in summary_text
+    assert decision["proposal_id"] in journal_text
+    assert "Decision Journal" in markdown_text

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import build_phase7_paper_config
+
+from marketlab.paper import scheduler
+
+
+def test_scheduler_iteration_runs_each_phase_once_per_market_date(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path)
+    events: list[str] = []
+
+    def _fake_decision(*args, **kwargs):
+        events.append("decision")
+        return {"proposal_path": "proposal.json", "status_path": "status.json", "status": {}}
+
+    def _fake_submit(*args, **kwargs):
+        events.append("submission")
+        return {"submission_path": "submission.json", "status_path": "status.json", "status": {}}
+
+    monkeypatch.setattr(scheduler, "run_paper_decision", _fake_decision)
+    monkeypatch.setattr(scheduler, "run_paper_submit", _fake_submit)
+
+    first = scheduler.run_scheduler_iteration(
+        config,
+        now=datetime(2026, 4, 10, 23, 10, tzinfo=UTC),
+    )
+    second = scheduler.run_scheduler_iteration(
+        config,
+        now=datetime(2026, 4, 10, 23, 20, tzinfo=UTC),
+    )
+
+    assert [event["phase"] for event in first["events"]] == ["decision", "submission"]
+    assert second["events"] == []
+    assert events == ["decision", "submission"]

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    build_phase7_paper_config,
+)
+
+from marketlab.paper.service import (
+    PaperStateStore,
+    decide_paper_proposal,
+    get_paper_status,
+    read_paper_evidence,
+    run_paper_decision,
+    run_paper_submit,
+)
+
+
+def test_run_paper_decision_writes_latest_daily_proposal(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    provider = FakeAlpacaProvider(symbol="VOO")
+    broker = FakeAlpacaBroker(symbol="VOO")
+
+    result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+    )
+
+    proposal_path = Path(result["proposal_path"])
+    proposal = json.loads(proposal_path.read_text(encoding="utf-8"))
+    evidence = read_paper_evidence(config, proposal_id=result["proposal_id"])
+
+    assert proposal["proposal_id"].startswith("2026-04-13-VOO-2026-04-10")
+    assert proposal["signal_date"] == "2026-04-10"
+    assert proposal["effective_date"] == "2026-04-13"
+    assert proposal["approval_status"] == "pending"
+    assert proposal["decision_policy"] == "consensus_vote"
+    assert proposal["decision"] in {"long", "cash"}
+    assert proposal["target_weight"] in {0.0, 1.0}
+    assert proposal["long_vote_count"] + proposal["cash_vote_count"] == 6
+    assert proposal["train_rows"] >= 200
+    assert len(evidence["models"]) == 6
+    assert evidence["decision"] == proposal["decision"]
+
+
+def test_run_paper_decision_supports_configured_single_symbol(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    provider = FakeAlpacaProvider(symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ")
+
+    result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+    )
+
+    proposal_path = Path(result["proposal_path"])
+    proposal = json.loads(proposal_path.read_text(encoding="utf-8"))
+
+    assert proposal["proposal_id"].startswith("2026-04-13-QQQ-2026-04-10")
+    assert proposal["symbol"] == "QQQ"
+    assert proposal["evidence_path"].endswith("evidence.json")
+
+
+def test_run_paper_decision_rejects_non_single_symbol_config(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    config.data.symbols = ["QQQ", "VOO"]
+
+    with pytest.raises(RuntimeError, match="exactly one configured symbol"):
+        run_paper_decision(
+            config,
+            now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+            provider=FakeAlpacaProvider(symbol="QQQ"),
+            broker=FakeAlpacaBroker(symbol="QQQ"),
+        )
+
+
+def test_run_paper_decision_rejects_empty_symbol_config(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    config.data.symbols = []
+
+    with pytest.raises(RuntimeError, match="exactly one configured symbol"):
+        run_paper_decision(
+            config,
+            now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+            provider=FakeAlpacaProvider(symbol="QQQ"),
+            broker=FakeAlpacaBroker(symbol="QQQ"),
+        )
+
+
+def test_decide_paper_proposal_records_agent_approval(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    decision_result = decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    approval_path = Path(decision_result["approval_path"])
+    approval = json.loads(approval_path.read_text(encoding="utf-8"))
+    proposal = PaperStateStore(config).load_proposal(proposal_result["proposal_id"])
+
+    assert approval["decision"] == "approve"
+    assert approval["actor"] == "agent"
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_actor"] == "agent"
+
+
+def test_run_paper_submit_skips_missing_agent_approval(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    submission_result = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    submission = submission_result["submission"]
+
+    assert submission["proposal_id"] == proposal_result["proposal_id"]
+    assert submission["status"] == "skipped"
+    assert submission["reason"] == "missing_approval"
+
+
+def test_run_paper_submit_places_fractional_order_after_agent_approval(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    provider = FakeAlpacaProvider(symbol="VOO")
+    broker = FakeAlpacaBroker(symbol="VOO")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+    )
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission_result = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    submission = submission_result["submission"]
+
+    assert submission["status"] in {"submitted", "no_trade_required"}
+    if submission["status"] == "submitted":
+        assert broker.submitted_orders
+        assert submission["order_status"] == "accepted"
+
+
+def test_get_paper_status_returns_latest_proposal_summary(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="autonomous", symbol="QQQ")
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=FakeAlpacaBroker(symbol="QQQ"),
+    )
+
+    status = get_paper_status(config)
+
+    assert status["latest_proposal"] is not None
+    assert status["latest_proposal"]["symbol"] == "QQQ"

--- a/tests/unit/test_phase7_issue_seed.py
+++ b/tests/unit/test_phase7_issue_seed.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_phase7_issue_seed_covers_expected_epic_and_child_issues() -> None:
+    document = json.loads(
+        Path(".github/issue-seeds/phase7-voo-paper.json").read_text(encoding="utf-8")
+    )
+
+    label_names = {label["name"] for label in document["labels"]}
+    issue_titles = [issue["title"] for issue in document["issues"]]
+
+    assert document["project"]["number"] == 3
+    assert {"phase-7", "track:broker", "track:ops"} <= label_names
+    assert issue_titles == [
+        "Phase 7.1: autonomous single-ETF paper loop with OpenAI and Claude backends",
+        "Add six-model paper decision and consensus proposal artifacts",
+        "Add autonomous paper agent worker and deterministic approval backend",
+        "Add OpenAI and Claude approval backends with structured fallback",
+        "Add tracked QQQ and VOO paper configs plus month-run paper reporting",
+    ]

--- a/tests/unit/test_targets.py
+++ b/tests/unit/test_targets.py
@@ -13,7 +13,8 @@ from marketlab.config import (
     TargetConfig,
 )
 from marketlab.data.panel import load_panel_csv
-from marketlab.rebalance import weekly_signal_dates
+from marketlab.rebalance import rebalance_signal_dates, weekly_signal_dates
+from marketlab.targets.timing import build_modeling_dataset, build_rebalance_snapshots
 from marketlab.targets.weekly import (
     add_forward_targets,
     build_weekly_modeling_dataset,
@@ -235,3 +236,48 @@ def test_build_weekly_modeling_dataset_uses_fixture_panel_contract() -> None:
         }
     ]
     assert dataset[feature_columns].notna().all().all()
+
+
+def test_daily_snapshots_use_each_trading_day_as_signal_date(
+    featured_panel: pd.DataFrame,
+) -> None:
+    snapshots = build_rebalance_snapshots(
+        featured_panel,
+        feature_columns=["feature_a", "feature_b"],
+        frequency="D",
+    )
+
+    assert snapshots["signal_date"].nunique() == len(TRADING_DATES) - 1
+    assert set(snapshots["signal_date"]) == set(TRADING_DATES[:-1])
+
+    aaa_row = snapshots.loc[
+        (snapshots["symbol"] == "AAA")
+        & (snapshots["signal_date"] == pd.Timestamp("2024-01-18"))
+    ].iloc[0]
+    assert aaa_row["effective_date"] == pd.Timestamp("2024-01-22")
+    assert aaa_row["feature_a"] == 11
+
+
+def test_daily_modeling_dataset_respects_daily_frequency_and_one_day_target() -> None:
+    fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / "market_panel.csv"
+    panel = load_panel_csv(fixture_path)
+    config = ExperimentConfig(
+        features=FeaturesConfig(
+            return_windows=[2],
+            ma_windows=[2, 3],
+            vol_windows=[2],
+            momentum_window=2,
+        ),
+        target=TargetConfig(horizon_days=1, type="direction"),
+        portfolio=PortfolioConfig(
+            ranking=RankingConfig(rebalance_frequency="D", mode="long_only", long_n=1, short_n=1)
+        ),
+    )
+
+    dataset = build_modeling_dataset(panel, config)
+
+    assert not dataset.empty
+    assert set(dataset["signal_date"]).issubset(set(rebalance_signal_dates(panel, "D")))
+    assert dataset["effective_date"].gt(dataset["signal_date"]).all()
+    assert dataset["target_end_date"].eq(dataset["effective_date"]).all()
+    assert dataset["target"].isin({0, 1}).all()

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,56 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.94.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/d7/11a649b986da06aaeb81334632f1843d70e3797f54ca4a9c5d604b7987d0/anthropic-0.94.0.tar.gz", hash = "sha256:dde8c57de73538c5136c1bca9b16da92e75446b53a73562cc911574e4934435c", size = 654236, upload-time = "2026-04-10T22:27:59.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ac/7185750e8688f6ff79b0e3d6a61372c88b81ba81fcda8798c70598e18aca/anthropic-0.94.0-py3-none-any.whl", hash = "sha256:42550b401eed8fcd7f6654234560f99c428306301bca726d32bca4bfb6feb748", size = 627519, upload-time = "2026-04-10T22:27:57.541Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +323,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
 name = "curl-cffi"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +412,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -383,6 +504,52 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -413,12 +580,111 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -518,28 +784,36 @@ wheels = [
 
 [[package]]
 name = "marketlab"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "matplotlib" },
+    { name = "openai" },
     { name = "pandas" },
     { name = "pyyaml" },
     { name = "scikit-learn" },
+    { name = "scipy" },
     { name = "yfinance" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "build" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "tox" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "mcp" },
     { name = "mkdocs" },
     { name = "pytest" },
     { name = "ruff" },
@@ -548,22 +822,28 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.49" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "matplotlib", specifier = ">=3.8" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.27,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27,<2" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6" },
+    { name = "openai", specifier = ">=1.0" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
     { name = "scikit-learn", specifier = ">=1.4" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "yfinance", specifier = ">=0.2" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2" },
+    { name = "mcp", specifier = ">=1.27,<2" },
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.11" },
@@ -688,6 +968,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -799,6 +1104,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
     { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
 ]
 
 [[package]]
@@ -992,12 +1316,126 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1072,12 +1510,46 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1139,6 +1611,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,6 +1637,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -1293,12 +1860,47 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -1341,12 +1943,36 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -1365,6 +1991,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add daily single-ETF timing support plus paper consensus proposal generation
- add autonomous paper-agent approvals with deterministic fallback and MCP inspection tools
- add tracked `QQQ` and alternate `VOO` paper configs, local compose wiring, docs, and the Phase 7.1 issue seed spec

## Roadmap
- Phase 7.1 epic: #65
- #66 six-model paper decision and consensus proposal artifacts
- #69 autonomous paper agent worker and deterministic approval backend
- #67 OpenAI and Claude approval backends with structured fallback
- #68 tracked QQQ and VOO paper configs plus month-run paper reporting

## Commit stack
- `feat: add daily timing support and paper consensus proposals`
- `feat: add autonomous paper agent approvals and MCP tools`
- `docs: add paper configs, compose docs, and issue seed`

## Validation
- `python -m ruff check ...` on each staged slice
- focused unit suite for the paper consensus foundation: `72 passed`
- focused daily timing integration: `1 passed`
- focused agent/report/MCP suite: `6 passed`
- `python -m mkdocs build --strict`
- focused compose and issue-seed tests: `2 passed`

Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
