### PR TITLE
feat: finalize paper MCP setup and Telegram ops feed for unattended QQQ run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ ALPACA_DATA_FEED=iex
 ALPACA_TIMEOUT_SECONDS=30
 OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-telegram-chat-id

--- a/.vscode/mcp.json.example
+++ b/.vscode/mcp.json.example
@@ -32,6 +32,39 @@
         "/app/repo",
         "--allow-network"
       ]
+    },
+    "marketlab-paper-docker-offline": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-paper-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/repo/artifacts",
+        "--repo-root",
+        "/app/repo"
+      ]
+    },
+    "marketlab-paper-docker-online": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-paper-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/repo/artifacts",
+        "--repo-root",
+        "/app/repo",
+        "--allow-network"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ Copy the `mcp_servers` entries into your user-local Codex config, then start `do
 
 Use `marketlab` as the default offline research entry. Use `marketlab_paper` when you want Codex to read the tracked paper proposal and submission state through `marketlab-paper-mcp`. The `_online` variants add `--allow-network` for live data downloads. For the full setup flow and troubleshooting notes, see [docs/codex-mcp.md](docs/codex-mcp.md).
 
-The paper flow now also supports an opt-in Telegram ops feed. Enable `paper.notifications.telegram.enabled: true` in the paper config and set `TELEGRAM_BOT_TOKEN` plus `TELEGRAM_CHAT_ID` in `.env`. Notification audit records are written under `artifacts/paper/state/notifications/`.
+The paper flow now also supports a Telegram ops feed. The tracked `QQQ` paper config enables it by default, while the alternate `VOO` config keeps it explicit but disabled. Keep `TELEGRAM_BOT_TOKEN` plus `TELEGRAM_CHAT_ID` in `.env`. Notification audit records are written under `artifacts/paper/state/notifications/`.
 
 ## Manual Docker Runner Workflow
 

--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ Copy it to `.vscode/mcp.json`, then use the research or paper sidecar as needed:
 
 Start `docker compose -f docker/compose.mcp.yml up -d --build` for the research sidecar or `docker compose --env-file .env -f docker/compose.paper.yml up -d --build` for the paper-review sidecar. The research offline entry is the default review path. The paper offline entry points at `marketlab-paper-mcp` and the tracked paper artifact state under `/app/repo/artifacts`. For the full setup flow and manual verification checklist, see [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md).
 
+If you enable `paper.notifications.telegram.enabled`, keep `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `.env` before starting the paper stack. The paper scheduler, paper agent, and paper MCP sidecar all need those vars because MCP approvals use the same shared approval service.
+
 ## Codex MCP Setup
 
 Codex reads MCP server definitions from user-local `~/.codex/config.toml`.
@@ -529,6 +531,8 @@ The repo includes a checked-in example snippet:
 Copy the `mcp_servers` entries into your user-local Codex config, then start `docker compose -f docker/compose.mcp.yml up -d --build` for the research sidecar or `docker compose --env-file .env -f docker/compose.paper.yml up -d --build` for the paper-review sidecar. After that, start a new Codex session and verify the attachment with `/mcp`, `/debug-config`, and `marketlab_server_info`.
 
 Use `marketlab` as the default offline research entry. Use `marketlab_paper` when you want Codex to read the tracked paper proposal and submission state through `marketlab-paper-mcp`. The `_online` variants add `--allow-network` for live data downloads. For the full setup flow and troubleshooting notes, see [docs/codex-mcp.md](docs/codex-mcp.md).
+
+The paper flow now also supports an opt-in Telegram ops feed. Enable `paper.notifications.telegram.enabled: true` in the paper config and set `TELEGRAM_BOT_TOKEN` plus `TELEGRAM_CHAT_ID` in `.env`. Notification audit records are written under `artifacts/paper/state/notifications/`.
 
 ## Manual Docker Runner Workflow
 

--- a/README.md
+++ b/README.md
@@ -509,12 +509,14 @@ The repo includes a checked-in sample:
 
 - `.vscode/mcp.json.example`
 
-Copy it to `.vscode/mcp.json`, start the MCP sidecar with `docker compose -f docker/compose.mcp.yml up -d --build`, then connect Copilot to either:
+Copy it to `.vscode/mcp.json`, then use the research or paper sidecar as needed:
 
 - `marketlab-docker-offline`
 - `marketlab-docker-online`
+- `marketlab-paper-docker-offline`
+- `marketlab-paper-docker-online`
 
-The offline entry is the default review path. The online entry adds `--allow-network` for live data downloads. For the full setup flow and manual verification checklist, see [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md).
+Start `docker compose -f docker/compose.mcp.yml up -d --build` for the research sidecar or `docker compose --env-file .env -f docker/compose.paper.yml up -d --build` for the paper-review sidecar. The research offline entry is the default review path. The paper offline entry points at `marketlab-paper-mcp` and the tracked paper artifact state under `/app/repo/artifacts`. For the full setup flow and manual verification checklist, see [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md).
 
 ## Codex MCP Setup
 
@@ -524,9 +526,9 @@ The repo includes a checked-in example snippet:
 
 - `docs/codex.config.toml.example`
 
-Copy the `mcp_servers` entries into your user-local Codex config, start the MCP sidecar with `docker compose -f docker/compose.mcp.yml up -d --build`, then start a new Codex session and verify the attachment with `/mcp`, `/debug-config`, and `marketlab_server_info`.
+Copy the `mcp_servers` entries into your user-local Codex config, then start `docker compose -f docker/compose.mcp.yml up -d --build` for the research sidecar or `docker compose --env-file .env -f docker/compose.paper.yml up -d --build` for the paper-review sidecar. After that, start a new Codex session and verify the attachment with `/mcp`, `/debug-config`, and `marketlab_server_info`.
 
-Use `marketlab` as the default offline entry. `marketlab_online` adds `--allow-network` for live data downloads. For the full setup flow and troubleshooting notes, see [docs/codex-mcp.md](docs/codex-mcp.md).
+Use `marketlab` as the default offline research entry. Use `marketlab_paper` when you want Codex to read the tracked paper proposal and submission state through `marketlab-paper-mcp`. The `_online` variants add `--allow-network` for live data downloads. For the full setup flow and troubleshooting notes, see [docs/codex-mcp.md](docs/codex-mcp.md).
 
 ## Manual Docker Runner Workflow
 

--- a/configs/experiment.qqq_paper_daily.yaml
+++ b/configs/experiment.qqq_paper_daily.yaml
@@ -76,7 +76,7 @@ paper:
   poll_interval_seconds: 30
   notifications:
     telegram:
-      enabled: false
+      enabled: true
 
 artifacts:
   output_dir: "artifacts/runs"

--- a/configs/experiment.qqq_paper_daily.yaml
+++ b/configs/experiment.qqq_paper_daily.yaml
@@ -74,6 +74,9 @@ paper:
   approval_inbox_dir: "artifacts/paper/inbox"
   state_dir: "artifacts/paper/state"
   poll_interval_seconds: 30
+  notifications:
+    telegram:
+      enabled: false
 
 artifacts:
   output_dir: "artifacts/runs"

--- a/configs/experiment.voo_paper_daily.yaml
+++ b/configs/experiment.voo_paper_daily.yaml
@@ -74,6 +74,9 @@ paper:
   approval_inbox_dir: "artifacts/paper/inbox"
   state_dir: "artifacts/paper/state"
   poll_interval_seconds: 30
+  notifications:
+    telegram:
+      enabled: false
 
 artifacts:
   output_dir: "artifacts/runs"

--- a/docker/compose.paper.yml
+++ b/docker/compose.paper.yml
@@ -9,6 +9,9 @@ services:
     user: "${MARKETLAB_UID:-1000}:${MARKETLAB_GID:-1000}"
     entrypoint: ["sleep", "infinity"]
     working_dir: /app
+    environment:
+      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
+      TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts
@@ -36,6 +39,8 @@ services:
       ALPACA_TIMEOUT_SECONDS: "${ALPACA_TIMEOUT_SECONDS:-30}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
+      TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts
@@ -63,6 +68,8 @@ services:
       ALPACA_TIMEOUT_SECONDS: "${ALPACA_TIMEOUT_SECONDS:-30}"
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
+      TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -1,6 +1,6 @@
 # Codex MCP Setup
 
-This guide documents the Codex path for attaching the Docker-packaged `marketlab-mcp` server to a new Codex session.
+This guide documents the Codex path for attaching the Docker-packaged `marketlab-mcp` server to a new Codex session for both the research workflow and the paper-review sidecar.
 
 The server contract stays the same as the VS Code Copilot path:
 
@@ -13,19 +13,29 @@ The server contract stays the same as the VS Code Copilot path:
 
 - Codex CLI / Chat session with MCP support enabled
 - one MCP session per `docker exec -i` process
-- writable `/app/workspace` and `/app/artifacts`
+- writable `/app/workspace`
+- writable `/app/artifacts` for the research sidecar
+- writable `/app/repo/artifacts` for the paper sidecar
 - read-only `/app/repo`
 - offline-safe by default, with an explicit network-enabled alternative
 
 ## Start The Container
 
-From the repo root:
+From the repo root, start the sidecar that matches the flow you want:
+
+- research / experiment workflow:
 
 ```bash
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-On Linux, export the host UID/GID before starting the sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container:
+- paper-review workflow:
+
+```bash
+docker compose --env-file .env -f docker/compose.paper.yml up -d --build
+```
+
+On Linux, export the host UID/GID before starting either sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container, then run the matching compose command:
 
 ```bash
 export MARKETLAB_UID="$(id -u)"
@@ -33,7 +43,7 @@ export MARKETLAB_GID="$(id -g)"
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
+This creates a long-lived container named `marketlab-mcp` for the research sidecar or `marketlab-paper-mcp` for the paper-review sidecar. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
 
 If Docker access fails on Windows with a named-pipe permission error, fix Docker Desktop / daemon access first. Codex cannot attach the MCP server until `docker ps` works for the current user.
 
@@ -45,16 +55,18 @@ Codex reads MCP server definitions from `~/.codex/config.toml`. The repo include
 
 Copy the `mcp_servers` entries from that file into your user-level Codex config. Keep this in user-local Codex config rather than committing a repo-local `.codex/config.toml`.
 
-The example defines two servers:
+The example defines four servers:
 
 - `marketlab`: offline default, no `--allow-network`
 - `marketlab_online`: adds `--allow-network` for live data fetches
+- `marketlab_paper`: offline default for the paper-review sidecar
+- `marketlab_paper_online`: paper-review sidecar plus `--allow-network`
 
-The offline entry should be your default for cached-panel or cached-raw workflows. Use the online entry only when you intend to let Codex trigger data downloads.
+Use `marketlab` for normal cached-panel or cached-raw workflows. Use `marketlab_paper` when you want MCP to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
 
 ## Sample Config Contract
 
-The checked-in example uses Codex `config.toml` `mcp_servers` entries with the same Docker foreground stdio rule:
+The checked-in example uses Codex `config.toml` `mcp_servers` entries with the same Docker foreground stdio rule for both container shapes:
 
 ```toml
 [mcp_servers.marketlab]
@@ -71,6 +83,21 @@ args = [
   "--repo-root",
   "/app/repo",
 ]
+
+[mcp_servers.marketlab_paper]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-paper-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/repo/artifacts",
+  "--repo-root",
+  "/app/repo",
+]
 ```
 
 Do not use `docker exec -d`. Codex MCP stdio servers must stay attached to the foreground process.
@@ -79,7 +106,8 @@ Do not use `docker exec -d`. Codex MCP stdio servers must stay attached to the f
 
 - Keep the repo mount read-only.
 - Create and patch configs inside `/app/workspace`.
-- Write all run outputs under `/app/artifacts`.
+- Write research run outputs under `/app/artifacts`.
+- Use `/app/repo/artifacts` only when you intentionally want the paper-review sidecar to read the tracked paper state written by the scheduler and agent.
 - Use `marketlab_copy_repo_config` when you want to start from a tracked repo config.
 - Do not point Codex at a repo-writable container flow by default.
 
@@ -87,28 +115,31 @@ Do not use `docker exec -d`. Codex MCP stdio servers must stay attached to the f
 
 After updating `~/.codex/config.toml`, start a new Codex session in this repo and verify:
 
-1. Type `/mcp` and confirm the `marketlab` server is available.
-2. Type `/debug-config` and verify the active config includes the `mcp_servers.marketlab` entry you added.
-3. Call `marketlab_server_info` and verify the response reports `transport=stdio` and `allow_network=false`.
-4. Call `marketlab_workspace_info` and verify the mounted workspace and artifact roots match `/app/workspace` and `/app/artifacts`.
-5. Create one config from a template with `marketlab_create_config_from_template`.
-6. Validate that config with `marketlab_validate_config`.
-7. Run one offline-safe job from cached data through `marketlab_plan_run` and `marketlab_start_job`.
-8. Inspect the finished run with `marketlab_get_run_summary` and one of the artifact readers.
+1. Type `/mcp` and confirm `marketlab` and `marketlab_paper` are available.
+2. Type `/debug-config` and verify the active config includes the `mcp_servers.marketlab` and `mcp_servers.marketlab_paper` entries you added.
+3. Attach to `marketlab` and call `marketlab_server_info`; verify the response reports `transport=stdio` and `allow_network=false`.
+4. Attach to `marketlab` and call `marketlab_workspace_info`; verify the roots match `/app/workspace` and `/app/artifacts`.
+5. Attach to `marketlab_paper` and call `marketlab_workspace_info`; verify the artifact root is `/app/repo/artifacts`.
+6. Attach to `marketlab_paper` and call `marketlab_get_paper_status` with `config_path="configs/experiment.qqq_paper_daily.yaml"`.
+7. Use `marketlab_create_config_from_template` and `marketlab_validate_config` on the research sidecar when you want a sandboxed experiment config.
+8. Run one offline-safe research job through `marketlab_plan_run` and `marketlab_start_job`, then inspect it with `marketlab_get_run_summary`.
 
 ## Troubleshooting
 
 - If Codex does not show the server in `/mcp`, restart Codex after editing `~/.codex/config.toml`.
 - If `/debug-config` does not show the new server, check for a syntax error in `config.toml`.
 - If Codex cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
+- If the paper entry does not start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp`.
 - If Docker access fails with a Windows named-pipe permission error, fix Docker daemon access for the current user before retrying.
 - If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If job planning says network is required, switch to `marketlab_online` or preload the raw cache / prepared panel.
+- If paper review tools do not show the latest state, confirm the paper sidecar is using `--artifact-root /app/repo/artifacts`.
 - If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
 - If the repo copy tool fails, verify the repo mount is present at `/app/repo`.
 
 ## Operational Defaults
 
 - Use `marketlab` as the default offline Codex attachment.
+- Use `marketlab_paper` when the goal is proposal review and approval against the tracked paper loop state.
 - Keep credentials on the host side; do not bake secrets into the image or into repo-tracked config files.
 - Treat the Docker stdio command as the single source of truth across Codex and VS Code clients.

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -64,6 +64,8 @@ The example defines four servers:
 
 Use `marketlab` for normal cached-panel or cached-raw workflows. Use `marketlab_paper` when you want MCP to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
 
+If the paper config enables `paper.notifications.telegram.enabled`, the paper compose stack also needs `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `.env`. `marketlab-paper-mcp` needs the same env because MCP approvals call the shared paper approval service and should emit the same notification side effects as the CLI and agent worker.
+
 ## Sample Config Contract
 
 The checked-in example uses Codex `config.toml` `mcp_servers` entries with the same Docker foreground stdio rule for both container shapes:

--- a/docs/codex.config.toml.example
+++ b/docs/codex.config.toml.example
@@ -34,3 +34,38 @@ args = [
 ]
 startup_timeout_sec = 20
 tool_timeout_sec = 120
+
+[mcp_servers.marketlab_paper]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-paper-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/repo/artifacts",
+  "--repo-root",
+  "/app/repo",
+]
+startup_timeout_sec = 20
+tool_timeout_sec = 120
+
+[mcp_servers.marketlab_paper_online]
+command = "docker"
+args = [
+  "exec",
+  "-i",
+  "marketlab-paper-mcp",
+  "marketlab-mcp",
+  "--workspace-root",
+  "/app/workspace",
+  "--artifact-root",
+  "/app/repo/artifacts",
+  "--repo-root",
+  "/app/repo",
+  "--allow-network",
+]
+startup_timeout_sec = 20
+tool_timeout_sec = 120

--- a/docs/mcp-vscode-copilot.md
+++ b/docs/mcp-vscode-copilot.md
@@ -1,6 +1,6 @@
 # VS Code Copilot MCP Setup
 
-This guide documents the supported VS Code stable path for connecting GitHub Copilot Chat to the Docker-packaged `marketlab-mcp` server.
+This guide documents the supported VS Code stable path for connecting GitHub Copilot Chat to the Docker-packaged `marketlab-mcp` server for both the research workflow and the paper-review sidecar.
 
 The design stays generic-MCP-first:
 
@@ -13,19 +13,29 @@ The design stays generic-MCP-first:
 
 - VS Code stable with GitHub Copilot Chat
 - one MCP session per `docker exec -i` process
-- writable `/app/workspace` and `/app/artifacts`
+- writable `/app/workspace`
+- writable `/app/artifacts` for the research sidecar
+- writable `/app/repo/artifacts` for the paper sidecar
 - optional read-only `/app/repo`
 - offline-safe by default, with an explicit network-enabled alternative
 
 ## Start The Container
 
-From the repo root:
+From the repo root, start the sidecar that matches the flow you want:
+
+- research / experiment workflow:
 
 ```bash
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-On Linux, export the host UID/GID before starting the sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container:
+- paper-review workflow:
+
+```bash
+docker compose --env-file .env -f docker/compose.paper.yml up -d --build
+```
+
+On Linux, export the host UID/GID before starting either sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container, then run the matching compose command:
 
 ```bash
 export MARKETLAB_UID="$(id -u)"
@@ -33,7 +43,7 @@ export MARKETLAB_GID="$(id -g)"
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-This creates a long-lived container named `marketlab-mcp`. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
+This creates a long-lived container named `marketlab-mcp` for the research sidecar or `marketlab-paper-mcp` for the paper-review sidecar. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
 
 ## Add The VS Code MCP Config
 
@@ -49,16 +59,18 @@ On Windows PowerShell:
 Copy-Item .vscode\mcp.json.example .vscode\mcp.json
 ```
 
-The sample defines two servers:
+The sample defines four servers:
 
 - `marketlab-docker-offline`: no `--allow-network` flag
 - `marketlab-docker-online`: adds `--allow-network` for live data fetches
+- `marketlab-paper-docker-offline`: paper-review sidecar, no `--allow-network`
+- `marketlab-paper-docker-online`: paper-review sidecar plus `--allow-network`
 
-The offline entry should be your default for cached-panel or cached-raw workflows. Use the online entry only when you intend to let Copilot trigger data downloads.
+Use `marketlab-docker-offline` for normal cached-panel or cached-raw workflows. Use `marketlab-paper-docker-offline` when you want Copilot to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
 
 ## Sample Config Contract
 
-The checked-in sample uses the current VS Code `mcp.json` workspace format and the Docker foreground stdio rule:
+The checked-in sample uses the current VS Code `mcp.json` workspace format and the Docker foreground stdio rule for both container shapes:
 
 ```json
 {
@@ -78,6 +90,22 @@ The checked-in sample uses the current VS Code `mcp.json` workspace format and t
         "--repo-root",
         "/app/repo"
       ]
+    },
+    "marketlab-paper-docker-offline": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "exec",
+        "-i",
+        "marketlab-paper-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/repo/artifacts",
+        "--repo-root",
+        "/app/repo"
+      ]
     }
   }
 }
@@ -89,7 +117,8 @@ Do not use `docker exec -d`. VS Code MCP stdio servers must stay attached to the
 
 - Keep the repo mount read-only.
 - Create and patch configs inside `/app/workspace`.
-- Write all run outputs under `/app/artifacts`.
+- Write research run outputs under `/app/artifacts`.
+- Use `/app/repo/artifacts` only when you intentionally want the paper-review sidecar to read the tracked paper state written by the scheduler and agent.
 - Use `marketlab_copy_repo_config` when you want to start from a tracked repo config.
 - Do not point Copilot at a repo-writable container flow by default.
 
@@ -97,24 +126,27 @@ Do not use `docker exec -d`. VS Code MCP stdio servers must stay attached to the
 
 After copying `.vscode/mcp.json` and reloading VS Code:
 
-1. Open Copilot Chat in agent mode and confirm the `marketlab-docker-offline` server is available.
-2. Call `marketlab_server_info` and verify the response reports `transport=stdio`.
-3. Call `marketlab_workspace_info` and verify the mounted workspace and artifact roots match `/app/workspace` and `/app/artifacts`.
-4. Create one config from a template with `marketlab_create_config_from_template`.
-5. Validate that config with `marketlab_validate_config`.
-6. Run one offline-safe job from cached data through `marketlab_plan_run` and `marketlab_start_job`.
-7. Inspect the finished run with `marketlab_get_run_summary` and one of the artifact readers.
+1. Open Copilot Chat in agent mode and confirm `marketlab-docker-offline` and `marketlab-paper-docker-offline` are available.
+2. Attach to `marketlab-docker-offline`, call `marketlab_server_info`, and verify the response reports `transport=stdio`.
+3. Attach to `marketlab-docker-offline`, call `marketlab_workspace_info`, and verify the roots match `/app/workspace` and `/app/artifacts`.
+4. Attach to `marketlab-paper-docker-offline`, call `marketlab_workspace_info`, and verify the artifact root is `/app/repo/artifacts`.
+5. Attach to `marketlab-paper-docker-offline`, call `marketlab_get_paper_status` with `config_path="configs/experiment.qqq_paper_daily.yaml"`.
+6. Use the research sidecar for `marketlab_create_config_from_template` and `marketlab_validate_config`.
+7. Run one offline-safe research job through `marketlab_plan_run` and `marketlab_start_job`, then inspect it with `marketlab_get_run_summary`.
 
 ## Troubleshooting
 
 - If VS Code cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
+- If the paper entry cannot start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp`.
 - If Copilot connects but job planning says network is required, switch to the online server or preload the raw cache / prepared panel.
 - If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.
+- If paper review tools do not show the latest state, confirm the paper sidecar is using `--artifact-root /app/repo/artifacts`.
 - If the repo copy tool fails, verify the repo mount is present at `/app/repo`.
 
 ## Operational Defaults
 
 - Use `marketlab-docker-offline` for normal review and cached-run flows.
+- Use `marketlab-paper-docker-offline` for proposal review and approval against the tracked paper loop state.
 - Keep credentials on the host side; do not bake secrets into the image or commit them into `.vscode/mcp.json`.
 - Treat this as the supported VS Code stable path. Other MCP clients can still reuse the same `docker exec -i marketlab-mcp ...` contract.

--- a/docs/mcp-vscode-copilot.md
+++ b/docs/mcp-vscode-copilot.md
@@ -68,6 +68,8 @@ The sample defines four servers:
 
 Use `marketlab-docker-offline` for normal cached-panel or cached-raw workflows. Use `marketlab-paper-docker-offline` when you want Copilot to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
 
+If the paper config enables `paper.notifications.telegram.enabled`, the paper compose stack also needs `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `.env`. `marketlab-paper-mcp` needs the same env because MCP approvals use the shared paper approval service and should emit the same notification side effects as the CLI and agent worker.
+
 ## Sample Config Contract
 
 The checked-in sample uses the current VS Code `mcp.json` workspace format and the Docker foreground stdio rule for both container shapes:

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -176,6 +176,11 @@ docker exec -i marketlab-paper-mcp \
   --repo-root /app/repo
 ```
 
+The checked-in client samples now include paper-specific entries for this sidecar:
+
+- `docs/codex.config.toml.example`: `marketlab_paper`, `marketlab_paper_online`
+- `.vscode/mcp.json.example`: `marketlab-paper-docker-offline`, `marketlab-paper-docker-online`
+
 ## MCP Paper Tools
 
 The MCP server now also exposes a narrow paper-review surface:

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -11,6 +11,8 @@ Phase 7 adds a local, paper-only execution loop around a configurable single-ETF
 
 This is still a paper-trading MVP. It is not a live-money workflow. The tracked unattended-month config uses `QQQ`, and `VOO` ships as the first alternate comparison config.
 
+The tracked `QQQ` config is launch-ready for the unattended local month run, including Telegram notifications. The alternate `VOO` config keeps the same paper shape but leaves Telegram explicit and disabled.
+
 ## Tracked Config
 
 The tracked Phase 7 config is:
@@ -38,7 +40,8 @@ It pins the current paper path to:
 - default execution mode: `agent_approval`
 - default provider backend in the tracked config: `openai`
 - required fallback backend: `deterministic_consensus`
-- optional Telegram ops feed: `paper.notifications.telegram.enabled`
+- tracked `QQQ` config default: `paper.notifications.telegram.enabled: true`
+- alternate `VOO` config default: `paper.notifications.telegram.enabled: false`
 
 The paper path intentionally does not auto-pick the latest research winner at runtime. If the model set, threshold, or provider backend changes, do that by changing the tracked config and reviewing the research outcome first.
 
@@ -141,7 +144,7 @@ The paper broker path rejects non-paper trading endpoints at runtime unless the 
 
 ## Telegram Ops Feed
 
-Telegram notifications are opt-in and stay out of YAML credentials. Enable them in the paper config:
+Telegram credentials stay out of YAML. The tracked `QQQ` config already enables the ops feed, and the alternate `VOO` config leaves it explicit but disabled. To enable it in another paper config:
 
 ```yaml
 paper:

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -38,6 +38,7 @@ It pins the current paper path to:
 - default execution mode: `agent_approval`
 - default provider backend in the tracked config: `openai`
 - required fallback backend: `deterministic_consensus`
+- optional Telegram ops feed: `paper.notifications.telegram.enabled`
 
 The paper path intentionally does not auto-pick the latest research winner at runtime. If the model set, threshold, or provider backend changes, do that by changing the tracked config and reviewing the research outcome first.
 
@@ -132,9 +133,37 @@ ALPACA_DATA_FEED="iex"
 ALPACA_TIMEOUT_SECONDS="30"
 OPENAI_API_KEY="..."
 ANTHROPIC_API_KEY="..."
+TELEGRAM_BOT_TOKEN="..."
+TELEGRAM_CHAT_ID="..."
 ```
 
 The paper broker path rejects non-paper trading endpoints at runtime unless the base URL is a local test server.
+
+## Telegram Ops Feed
+
+Telegram notifications are opt-in and stay out of YAML credentials. Enable them in the paper config:
+
+```yaml
+paper:
+  notifications:
+    telegram:
+      enabled: true
+```
+
+When enabled, the shared paper service layer sends one plain-text Telegram message per event for:
+
+- `paper-decision`: `proposal_created`, `existing_proposal`, `non_trading_day`, `stale_signal_date`
+- `paper-approve`: `approved`, `rejected`
+- `paper-submit`: `submitted`, `no_trade_required`, `skipped`, `existing_submission`
+- `paper-error`: uncaught scheduler or agent-loop failures, deduplicated until the next successful iteration
+
+Notifications are advisory only. Paper decision, approval, and submit still complete even if Telegram delivery fails or credentials are missing.
+
+Every notification attempt is also persisted under:
+
+- `artifacts/paper/state/notifications/*.json`
+
+These audit records include the stage, outcome, message body, delivery result, and any delivery error. They do not replace the proposal, approval, or submission state files.
 
 ## Docker Compose Loop
 
@@ -166,6 +195,8 @@ The scheduler uses the tracked repo config at `/app/repo/configs/experiment.qqq_
 
 The agent worker uses the same tracked config and artifact mount, so the approval loop and the scheduler see the same proposal, approval, and submission state.
 
+If `paper.notifications.telegram.enabled` is true, all three paper containers need the Telegram env vars because notifications can be emitted from the scheduler, the agent worker, and MCP-driven approvals.
+
 The matching MCP sidecar should be launched with the same artifact root so it sees the same proposal and submission files:
 
 ```bash
@@ -191,6 +222,8 @@ The MCP server now also exposes a narrow paper-review surface:
 - `marketlab_decide_paper_proposal`
 
 These tools intentionally stop at review and approval. Order submission still happens through the CLI-backed scheduler path.
+
+There is no separate Telegram MCP tool. `marketlab_decide_paper_proposal` uses the same shared paper approval service, so MCP approvals trigger the same Telegram notification and audit artifact behavior as CLI or agent approvals.
 
 ## Fixed Defaults
 

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -161,6 +161,16 @@ class ArtifactsConfig:
 
 
 @dataclass(slots=True)
+class TelegramNotificationsConfig:
+    enabled: bool = False
+
+
+@dataclass(slots=True)
+class PaperNotificationsConfig:
+    telegram: TelegramNotificationsConfig = field(default_factory=TelegramNotificationsConfig)
+
+
+@dataclass(slots=True)
 class PaperConfig:
     enabled: bool = False
     data_provider: str = "alpaca"
@@ -179,6 +189,7 @@ class PaperConfig:
     approval_inbox_dir: str = "artifacts/paper/inbox"
     state_dir: str = "artifacts/paper/state"
     poll_interval_seconds: int = 30
+    notifications: PaperNotificationsConfig = field(default_factory=PaperNotificationsConfig)
 
 
 @dataclass(slots=True)
@@ -575,6 +586,9 @@ def _validate_config(config: ExperimentConfig) -> None:
 def load_config(path: str | Path) -> ExperimentConfig:
     config_path = Path(path).resolve()
     payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    paper_payload = payload.get("paper") or {}
+    paper_notifications_payload = paper_payload.get("notifications") or {}
+    paper_defaults = PaperConfig()
 
     config = ExperimentConfig(
         experiment_name=payload.get("experiment_name", "weekly_rank_v1"),
@@ -621,7 +635,52 @@ def load_config(path: str | Path) -> ExperimentConfig:
             factor_model_path=(payload.get("evaluation") or {}).get("factor_model_path", ""),
         ),
         artifacts=_section(ArtifactsConfig, payload.get("artifacts")),
-        paper=_section(PaperConfig, payload.get("paper")),
+        paper=PaperConfig(
+            enabled=paper_payload.get("enabled", paper_defaults.enabled),
+            data_provider=paper_payload.get("data_provider", paper_defaults.data_provider),
+            broker=paper_payload.get("broker", paper_defaults.broker),
+            execution_mode=paper_payload.get("execution_mode", paper_defaults.execution_mode),
+            agent_backend=paper_payload.get("agent_backend", paper_defaults.agent_backend),
+            agent_model=paper_payload.get("agent_model", paper_defaults.agent_model),
+            agent_timeout_seconds=paper_payload.get(
+                "agent_timeout_seconds",
+                paper_defaults.agent_timeout_seconds,
+            ),
+            agent_fallback_backend=paper_payload.get(
+                "agent_fallback_backend",
+                paper_defaults.agent_fallback_backend,
+            ),
+            consensus_min_long_votes=paper_payload.get(
+                "consensus_min_long_votes",
+                paper_defaults.consensus_min_long_votes,
+            ),
+            schedule_timezone=paper_payload.get(
+                "schedule_timezone",
+                paper_defaults.schedule_timezone,
+            ),
+            decision_time=paper_payload.get("decision_time", paper_defaults.decision_time),
+            submission_time=paper_payload.get("submission_time", paper_defaults.submission_time),
+            order_type=paper_payload.get("order_type", paper_defaults.order_type),
+            position_sizing=paper_payload.get(
+                "position_sizing",
+                paper_defaults.position_sizing,
+            ),
+            approval_inbox_dir=paper_payload.get(
+                "approval_inbox_dir",
+                paper_defaults.approval_inbox_dir,
+            ),
+            state_dir=paper_payload.get("state_dir", paper_defaults.state_dir),
+            poll_interval_seconds=paper_payload.get(
+                "poll_interval_seconds",
+                paper_defaults.poll_interval_seconds,
+            ),
+            notifications=PaperNotificationsConfig(
+                telegram=_section(
+                    TelegramNotificationsConfig,
+                    paper_notifications_payload.get("telegram"),
+                )
+            ),
+        ),
         base_dir=_config_base_dir(config_path),
     )
     _normalize_mapping_sections(config)

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -11,10 +11,17 @@ from typing import Any
 from marketlab.config import ExperimentConfig
 from marketlab.env import load_env_file
 from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+from marketlab.paper.notifications import (
+    PaperLoopStageError,
+    TelegramTransport,
+    build_error_fingerprint,
+    build_error_message,
+)
 from marketlab.paper.service import (
     APPROVAL_PENDING,
     PaperStateStore,
     _now_utc,
+    _write_notification_record,
     decide_paper_proposal,
     read_paper_evidence,
     validate_paper_trading_config,
@@ -69,6 +76,87 @@ def _load_worker_state(config: ExperimentConfig) -> dict[str, Any]:
 
 def _save_worker_state(config: ExperimentConfig, payload: dict[str, Any]) -> Path:
     return _json_dump(_worker_state_path(config), payload)
+
+
+def _clear_worker_error_state(state: dict[str, Any]) -> None:
+    for key in (
+        "last_error_fingerprint",
+        "last_error_stage",
+        "last_error_type",
+        "last_error_message",
+        "last_error_proposal_id",
+        "last_error_trade_date",
+        "last_error_alert_at",
+    ):
+        state.pop(key, None)
+
+
+def _notify_worker_error(
+    config: ExperimentConfig,
+    *,
+    state: dict[str, Any],
+    exc: Exception,
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path | None:
+    if isinstance(exc, PaperLoopStageError):
+        stage = exc.stage
+        root_error = exc.cause
+        proposal_id = exc.proposal_id
+        trade_date = exc.trade_date
+    else:
+        stage = "paper-approve"
+        root_error = exc
+        proposal_id = ""
+        trade_date = ""
+
+    fingerprint = build_error_fingerprint(
+        loop_name="agent",
+        stage=stage,
+        exc=root_error,
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+    )
+    state["last_checked_at"] = _now_utc(now).isoformat()
+    state["last_result"] = "error"
+    if state.get("last_error_fingerprint") == fingerprint:
+        return None
+
+    state["last_error_fingerprint"] = fingerprint
+    state["last_error_stage"] = stage
+    state["last_error_type"] = type(root_error).__name__
+    state["last_error_message"] = str(root_error)
+    state["last_error_proposal_id"] = proposal_id
+    state["last_error_trade_date"] = trade_date
+    state["last_error_alert_at"] = _now_utc(now).isoformat()
+    store = PaperStateStore(config)
+    return _write_notification_record(
+        config,
+        store,
+        stage="paper-error",
+        outcome="error",
+        message=build_error_message(
+            config,
+            loop_name="agent",
+            stage=stage,
+            exc=root_error,
+            proposal_id=proposal_id,
+            trade_date=trade_date,
+        ),
+        details={
+            "experiment_name": config.experiment_name,
+            "loop": "agent",
+            "failed_stage": stage,
+            "proposal_id": proposal_id,
+            "trade_date": trade_date,
+            "exception_type": type(root_error).__name__,
+            "exception_message": str(root_error),
+        },
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+        now=now,
+        transport=transport,
+    )
 
 
 def _decision_schema() -> dict[str, Any]:
@@ -387,12 +475,14 @@ def run_agent_approval_iteration(
     *,
     now: datetime | None = None,
     broker: AlpacaPaperBrokerClient | None = None,
+    notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     state = _load_worker_state(config)
     events: list[dict[str, Any]] = []
 
     if config.paper.execution_mode != "agent_approval":
+        _clear_worker_error_state(state)
         state["last_checked_at"] = _now_utc(now).isoformat()
         state["last_result"] = "execution_mode_not_agent_approval"
         state_path = _save_worker_state(config, state)
@@ -423,26 +513,63 @@ def run_agent_approval_iteration(
     )
 
     for proposal in proposals:
-        evidence = read_paper_evidence(config, proposal_id=proposal["proposal_id"])
-        decision = _evaluate_with_fallback(
-            config,
-            proposal=proposal,
-            evidence=evidence,
-            status=current_status,
-            account_context=account_context,
-        )
-        result = decide_paper_proposal(
-            config,
-            proposal_id=proposal["proposal_id"],
-            decision=decision.decision,
-            actor="agent",
-            rationale=decision.rationale,
-            provider=decision.provider,
-            model=decision.model,
-            fallback_used=decision.fallback_used,
-            fallback_reason=decision.fallback_reason,
-            now=now,
-        )
+        try:
+            evidence = read_paper_evidence(config, proposal_id=proposal["proposal_id"])
+        except FileNotFoundError as exc:
+            result = decide_paper_proposal(
+                config,
+                proposal_id=proposal["proposal_id"],
+                decision="reject",
+                actor="agent",
+                rationale=(
+                    "Rejected because the approval worker could not read the persisted "
+                    f"proposal evidence: {exc}."
+                ),
+                fallback_reason=str(exc),
+                now=now,
+                notification_transport=notification_transport,
+            )
+            events.append(
+                {
+                    "proposal_id": proposal["proposal_id"],
+                    "decision": "reject",
+                    "provider": "",
+                    "model": "",
+                    "fallback_used": False,
+                    "fallback_reason": str(exc),
+                    "approval_path": result["approval_path"],
+                }
+            )
+            continue
+        try:
+            decision = _evaluate_with_fallback(
+                config,
+                proposal=proposal,
+                evidence=evidence,
+                status=current_status,
+                account_context=account_context,
+            )
+            result = decide_paper_proposal(
+                config,
+                proposal_id=proposal["proposal_id"],
+                decision=decision.decision,
+                actor="agent",
+                rationale=decision.rationale,
+                provider=decision.provider,
+                model=decision.model,
+                fallback_used=decision.fallback_used,
+                fallback_reason=decision.fallback_reason,
+                now=now,
+                notification_transport=notification_transport,
+            )
+        except Exception as exc:
+            raise PaperLoopStageError(
+                loop_name="agent",
+                stage="paper-approve",
+                cause=exc,
+                proposal_id=str(proposal["proposal_id"]),
+                trade_date=str(proposal["effective_date"]),
+            ) from exc
         events.append(
             {
                 "proposal_id": proposal["proposal_id"],
@@ -455,6 +582,7 @@ def run_agent_approval_iteration(
             }
         )
 
+    _clear_worker_error_state(state)
     state["last_checked_at"] = _now_utc(now).isoformat()
     state["last_processed_count"] = len(events)
     state["last_result"] = "processed" if events else "no_pending_proposals"
@@ -466,9 +594,38 @@ def run_agent_approval_iteration(
     }
 
 
-def run_agent_approval_loop(config: ExperimentConfig, *, once: bool = False) -> None:
+def run_agent_approval_loop(
+    config: ExperimentConfig,
+    *,
+    once: bool = False,
+    notification_transport: TelegramTransport | None = None,
+) -> None:
     while True:
-        summary = run_agent_approval_iteration(config)
+        try:
+            summary = run_agent_approval_iteration(
+                config,
+                notification_transport=notification_transport,
+            )
+        except Exception as exc:
+            state = _load_worker_state(config)
+            notification_path = _notify_worker_error(
+                config,
+                state=state,
+                exc=exc,
+                transport=notification_transport,
+            )
+            state_path = _save_worker_state(config, state)
+            summary = {
+                "agent_state_path": str(state_path),
+                "events": [],
+                "processed_count": 0,
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                    "notification_path": str(notification_path) if notification_path else "",
+                    "duplicate_suppressed": notification_path is None,
+                },
+            }
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
             return

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -601,12 +601,14 @@ def run_agent_approval_loop(
     notification_transport: TelegramTransport | None = None,
 ) -> None:
     while True:
+        loop_error: Exception | None = None
         try:
             summary = run_agent_approval_iteration(
                 config,
                 notification_transport=notification_transport,
             )
         except Exception as exc:
+            loop_error = exc
             state = _load_worker_state(config)
             notification_path = _notify_worker_error(
                 config,
@@ -628,5 +630,7 @@ def run_agent_approval_loop(
             }
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
+            if loop_error is not None:
+                raise loop_error
             return
         time.sleep(config.paper.poll_interval_seconds)

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+from urllib import error, request
+
+from marketlab.config import ExperimentConfig
+from marketlab.env import load_env_file
+
+TELEGRAM_API_BASE_URL_ENV = "MARKETLAB_TELEGRAM_API_BASE_URL"
+TELEGRAM_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
+TELEGRAM_CHAT_ID_ENV = "TELEGRAM_CHAT_ID"
+DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org"
+DEFAULT_TELEGRAM_TIMEOUT_SECONDS = 10
+DELIVERY_DELIVERED = "delivered"
+DELIVERY_SKIPPED_DISABLED = "skipped_disabled"
+DELIVERY_SKIPPED_MISSING_CREDENTIALS = "skipped_missing_credentials"
+DELIVERY_FAILED = "failed_delivery"
+
+TelegramTransport = Callable[[str, dict[str, Any], int], tuple[int, str]]
+
+
+class PaperLoopStageError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        loop_name: str,
+        stage: str,
+        cause: Exception,
+        proposal_id: str = "",
+        trade_date: str = "",
+    ) -> None:
+        super().__init__(str(cause))
+        self.loop_name = loop_name
+        self.stage = stage
+        self.cause = cause
+        self.proposal_id = proposal_id
+        self.trade_date = trade_date
+
+
+def _now_utc(now: datetime | None = None) -> datetime:
+    if now is None:
+        return datetime.now(UTC)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
+
+
+def _default_transport(url: str, payload: dict[str, Any], timeout_seconds: int) -> tuple[int, str]:
+    encoded = json.dumps(payload).encode("utf-8")
+    telegram_request = request.Request(
+        url,
+        data=encoded,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(telegram_request, timeout=timeout_seconds) as response:
+        return response.status, response.read().decode("utf-8")
+
+
+def _notification_symbol(
+    config: ExperimentConfig,
+    proposal: Mapping[str, Any] | None = None,
+) -> str:
+    if proposal is not None and str(proposal.get("symbol", "")).strip() != "":
+        return str(proposal["symbol"])
+    symbols = [str(symbol).strip() for symbol in config.data.symbols if str(symbol).strip() != ""]
+    if len(symbols) == 1:
+        return symbols[0]
+    return ""
+
+
+def _format_number(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        text = f"{value:.6f}"
+        return text.rstrip("0").rstrip(".") or "0"
+    return str(value)
+
+
+def _append_line(lines: list[str], label: str, value: Any) -> None:
+    if value is None:
+        return
+    text = str(value).strip()
+    if text == "":
+        return
+    lines.append(f"{label}: {text}")
+
+
+def _message_lines(stage: str, *, config: ExperimentConfig, proposal: Mapping[str, Any] | None) -> list[str]:
+    lines = [stage]
+    _append_line(lines, "experiment", config.experiment_name)
+    _append_line(lines, "symbol", _notification_symbol(config, proposal))
+    return lines
+
+
+def build_decision_message(
+    config: ExperimentConfig,
+    *,
+    outcome: str,
+    status: Mapping[str, Any],
+    proposal: Mapping[str, Any] | None = None,
+) -> str:
+    lines = _message_lines("paper-decision", config=config, proposal=proposal)
+    _append_line(lines, "outcome", outcome)
+    _append_line(lines, "market_date", status.get("market_date"))
+    _append_line(lines, "signal_date", (proposal or {}).get("signal_date"))
+    _append_line(lines, "effective_date", (proposal or {}).get("effective_date"))
+    _append_line(lines, "latest_signal_date", status.get("latest_signal_date"))
+    _append_line(lines, "proposal_id", (proposal or {}).get("proposal_id"))
+    _append_line(lines, "decision", (proposal or {}).get("decision"))
+    target_weight = (proposal or {}).get("target_weight")
+    if target_weight is not None:
+        _append_line(lines, "target_weight", _format_number(target_weight))
+    long_vote_count = (proposal or {}).get("long_vote_count")
+    cash_vote_count = (proposal or {}).get("cash_vote_count")
+    threshold = config.paper.consensus_min_long_votes
+    if long_vote_count is not None or cash_vote_count is not None:
+        votes = (
+            f"long={_format_number(long_vote_count or 0)} "
+            f"cash={_format_number(cash_vote_count or 0)} "
+            f"threshold={threshold}"
+        )
+        _append_line(lines, "votes", votes)
+    reference_price = (proposal or {}).get("reference_price")
+    if reference_price is not None:
+        _append_line(lines, "reference_price", _format_number(reference_price))
+    _append_line(lines, "reason", status.get("reason"))
+    return "\n".join(lines)
+
+
+def build_approval_message(
+    config: ExperimentConfig,
+    *,
+    proposal: Mapping[str, Any],
+    approval: Mapping[str, Any],
+) -> str:
+    lines = _message_lines("paper-approve", config=config, proposal=proposal)
+    _append_line(lines, "outcome", approval.get("approval_status"))
+    _append_line(lines, "signal_date", proposal.get("signal_date"))
+    _append_line(lines, "effective_date", proposal.get("effective_date"))
+    _append_line(lines, "proposal_id", proposal.get("proposal_id"))
+    _append_line(lines, "actor", approval.get("actor"))
+    _append_line(lines, "provider", approval.get("provider"))
+    _append_line(lines, "model", approval.get("model"))
+    _append_line(lines, "fallback_used", _format_number(approval.get("fallback_used", False)))
+    _append_line(lines, "fallback_reason", approval.get("fallback_reason"))
+    _append_line(lines, "rationale", approval.get("rationale"))
+    return "\n".join(lines)
+
+
+def build_submission_message(
+    config: ExperimentConfig,
+    *,
+    outcome: str,
+    status: Mapping[str, Any],
+    proposal: Mapping[str, Any] | None = None,
+    submission: Mapping[str, Any] | None = None,
+) -> str:
+    lines = _message_lines("paper-submit", config=config, proposal=proposal)
+    _append_line(lines, "outcome", outcome)
+    _append_line(lines, "signal_date", (proposal or {}).get("signal_date"))
+    _append_line(lines, "effective_date", (proposal or {}).get("effective_date"))
+    _append_line(lines, "trade_date", (submission or {}).get("trade_date"))
+    _append_line(lines, "proposal_id", (proposal or {}).get("proposal_id") or (submission or {}).get("proposal_id"))
+    _append_line(lines, "reason", (submission or {}).get("reason") or status.get("reason"))
+    _append_line(lines, "side", (submission or {}).get("side"))
+    qty = (submission or {}).get("qty")
+    if qty is not None:
+        _append_line(lines, "qty", _format_number(qty))
+    _append_line(lines, "order_id", (submission or {}).get("order_id"))
+    _append_line(lines, "order_status", (submission or {}).get("order_status"))
+    return "\n".join(lines)
+
+
+def build_error_message(
+    config: ExperimentConfig,
+    *,
+    loop_name: str,
+    stage: str,
+    exc: Exception,
+    proposal_id: str = "",
+    trade_date: str = "",
+) -> str:
+    lines = _message_lines("paper-error", config=config, proposal=None)
+    _append_line(lines, "loop", loop_name)
+    _append_line(lines, "failed_stage", stage)
+    _append_line(lines, "proposal_id", proposal_id)
+    _append_line(lines, "trade_date", trade_date)
+    _append_line(lines, "exception_type", type(exc).__name__)
+    _append_line(lines, "exception_message", str(exc))
+    return "\n".join(lines)
+
+
+def build_error_fingerprint(
+    *,
+    loop_name: str,
+    stage: str,
+    exc: Exception,
+    proposal_id: str = "",
+    trade_date: str = "",
+) -> str:
+    raw = "|".join(
+        [
+            loop_name,
+            stage,
+            type(exc).__name__,
+            str(exc),
+            proposal_id,
+            trade_date,
+        ]
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _telegram_api_base_url() -> str:
+    configured = os.environ.get(TELEGRAM_API_BASE_URL_ENV, "").strip()
+    if configured != "":
+        return configured.rstrip("/")
+    return DEFAULT_TELEGRAM_API_BASE_URL
+
+
+def _safe_json(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def deliver_telegram_notification(
+    config: ExperimentConfig,
+    *,
+    stage: str,
+    outcome: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+    proposal_id: str = "",
+    trade_date: str = "",
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> dict[str, Any]:
+    timestamp = _now_utc(now).isoformat()
+    record: dict[str, Any] = {
+        "channel": "telegram",
+        "stage": stage,
+        "outcome": outcome,
+        "proposal_id": proposal_id,
+        "trade_date": trade_date,
+        "message": message,
+        "details": dict(details or {}),
+        "requested_at": timestamp,
+    }
+    if not config.paper.notifications.telegram.enabled:
+        record["delivery_status"] = DELIVERY_SKIPPED_DISABLED
+        return record
+
+    load_env_file()
+    bot_token = os.environ.get(TELEGRAM_BOT_TOKEN_ENV, "").strip()
+    chat_id = os.environ.get(TELEGRAM_CHAT_ID_ENV, "").strip()
+    api_base_url = _telegram_api_base_url()
+    record["api_base_url"] = api_base_url
+    if bot_token == "" or chat_id == "":
+        record["delivery_status"] = DELIVERY_SKIPPED_MISSING_CREDENTIALS
+        record["missing_credentials"] = {
+            TELEGRAM_BOT_TOKEN_ENV: bot_token == "",
+            TELEGRAM_CHAT_ID_ENV: chat_id == "",
+        }
+        return record
+
+    payload = {
+        "chat_id": chat_id,
+        "text": message,
+        "disable_web_page_preview": True,
+    }
+    record["request"] = payload
+    sender = transport or _default_transport
+    url = f"{api_base_url}/bot{bot_token}/sendMessage"
+
+    try:
+        response_status, response_body = sender(url, payload, DEFAULT_TELEGRAM_TIMEOUT_SECONDS)
+        response_payload = _safe_json(response_body)
+        record["response_status"] = response_status
+        record["response_body"] = response_payload
+        if not 200 <= response_status < 300:
+            raise RuntimeError(f"Telegram API responded with HTTP {response_status}.")
+        if isinstance(response_payload, dict) and response_payload.get("ok") is False:
+            raise RuntimeError(
+                f"Telegram API rejected the message: {response_payload.get('description', 'unknown error')}"
+            )
+        record["delivery_status"] = DELIVERY_DELIVERED
+    except (RuntimeError, error.URLError, error.HTTPError, OSError, ValueError) as exc:
+        record["delivery_status"] = DELIVERY_FAILED
+        record["error"] = f"{type(exc).__name__}: {exc}"
+
+    return record

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -7,10 +7,18 @@ from pathlib import Path
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.paper.notifications import (
+    PaperLoopStageError,
+    TelegramTransport,
+    build_error_fingerprint,
+    build_error_message,
+)
 from marketlab.paper.service import (
+    PaperStateStore,
     _clock_value,
     _local_now,
     _now_utc,
+    _write_notification_record,
     run_paper_decision,
     run_paper_submit,
 )
@@ -34,10 +42,91 @@ def _save_scheduler_state(config: ExperimentConfig, payload: dict[str, Any]) -> 
     return path
 
 
+def _clear_scheduler_error_state(state: dict[str, Any]) -> None:
+    for key in (
+        "last_error_fingerprint",
+        "last_error_stage",
+        "last_error_type",
+        "last_error_message",
+        "last_error_proposal_id",
+        "last_error_trade_date",
+        "last_error_alert_at",
+    ):
+        state.pop(key, None)
+
+
+def _notify_scheduler_error(
+    config: ExperimentConfig,
+    *,
+    state: dict[str, Any],
+    exc: Exception,
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path | None:
+    if isinstance(exc, PaperLoopStageError):
+        stage = exc.stage
+        root_error = exc.cause
+        proposal_id = exc.proposal_id
+        trade_date = exc.trade_date
+    else:
+        stage = "paper-scheduler"
+        root_error = exc
+        proposal_id = ""
+        trade_date = ""
+
+    fingerprint = build_error_fingerprint(
+        loop_name="scheduler",
+        stage=stage,
+        exc=root_error,
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+    )
+    state["last_checked_at"] = _now_utc(now).isoformat()
+    if state.get("last_error_fingerprint") == fingerprint:
+        return None
+
+    state["last_error_fingerprint"] = fingerprint
+    state["last_error_stage"] = stage
+    state["last_error_type"] = type(root_error).__name__
+    state["last_error_message"] = str(root_error)
+    state["last_error_proposal_id"] = proposal_id
+    state["last_error_trade_date"] = trade_date
+    state["last_error_alert_at"] = _now_utc(now).isoformat()
+    store = PaperStateStore(config)
+    return _write_notification_record(
+        config,
+        store,
+        stage="paper-error",
+        outcome="error",
+        message=build_error_message(
+            config,
+            loop_name="scheduler",
+            stage=stage,
+            exc=root_error,
+            proposal_id=proposal_id,
+            trade_date=trade_date,
+        ),
+        details={
+            "experiment_name": config.experiment_name,
+            "loop": "scheduler",
+            "failed_stage": stage,
+            "proposal_id": proposal_id,
+            "trade_date": trade_date,
+            "exception_type": type(root_error).__name__,
+            "exception_message": str(root_error),
+        },
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+        now=now,
+        transport=transport,
+    )
+
+
 def run_scheduler_iteration(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
+    notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     local_now = _local_now(config, now)
     market_date = local_now.date().isoformat()
@@ -47,17 +136,43 @@ def run_scheduler_iteration(
     events: list[dict[str, Any]] = []
 
     if local_now.time() >= decision_clock and state.get("last_decision_market_date") != market_date:
-        result = run_paper_decision(config, now=now)
+        try:
+            result = run_paper_decision(
+                config,
+                now=now,
+                notification_transport=notification_transport,
+            )
+        except Exception as exc:
+            raise PaperLoopStageError(
+                loop_name="scheduler",
+                stage="paper-decision",
+                cause=exc,
+            ) from exc
         events.append({"phase": "decision", **result})
         state["last_decision_market_date"] = market_date
         state["last_decision_at"] = _now_utc(now).isoformat()
 
     if local_now.time() >= submission_clock and state.get("last_submission_market_date") != market_date:
-        result = run_paper_submit(config, now=now)
+        try:
+            result = run_paper_submit(
+                config,
+                now=now,
+                notification_transport=notification_transport,
+            )
+        except Exception as exc:
+            proposal = PaperStateStore(config).latest_proposal()
+            raise PaperLoopStageError(
+                loop_name="scheduler",
+                stage="paper-submit",
+                cause=exc,
+                proposal_id=str((proposal or {}).get("proposal_id", "")),
+                trade_date=str((proposal or {}).get("effective_date", "")),
+            ) from exc
         events.append({"phase": "submission", **result})
         state["last_submission_market_date"] = market_date
         state["last_submission_at"] = _now_utc(now).isoformat()
 
+    _clear_scheduler_error_state(state)
     state["last_checked_at"] = _now_utc(now).isoformat()
     state["last_checked_market_date"] = market_date
     state_path = _save_scheduler_state(config, state)
@@ -68,9 +183,37 @@ def run_scheduler_iteration(
     }
 
 
-def run_scheduler_loop(config: ExperimentConfig, *, once: bool = False) -> None:
+def run_scheduler_loop(
+    config: ExperimentConfig,
+    *,
+    once: bool = False,
+    notification_transport: TelegramTransport | None = None,
+) -> None:
     while True:
-        summary = run_scheduler_iteration(config)
+        try:
+            summary = run_scheduler_iteration(
+                config,
+                notification_transport=notification_transport,
+            )
+        except Exception as exc:
+            state = _load_scheduler_state(config)
+            notification_path = _notify_scheduler_error(
+                config,
+                state=state,
+                exc=exc,
+                transport=notification_transport,
+            )
+            state_path = _save_scheduler_state(config, state)
+            summary = {
+                "scheduler_state_path": str(state_path),
+                "events": [],
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                    "notification_path": str(notification_path) if notification_path else "",
+                    "duplicate_suppressed": notification_path is None,
+                },
+            }
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
             return

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -190,12 +190,14 @@ def run_scheduler_loop(
     notification_transport: TelegramTransport | None = None,
 ) -> None:
     while True:
+        loop_error: Exception | None = None
         try:
             summary = run_scheduler_iteration(
                 config,
                 notification_transport=notification_transport,
             )
         except Exception as exc:
+            loop_error = exc
             state = _load_scheduler_state(config)
             notification_path = _notify_scheduler_error(
                 config,
@@ -216,5 +218,7 @@ def run_scheduler_loop(
             }
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
+            if loop_error is not None:
+                raise loop_error
             return
         time.sleep(config.paper.poll_interval_seconds)

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -25,6 +25,13 @@ from marketlab.paper.alpaca import (
     AlpacaMarketDataProvider,
     AlpacaPaperBrokerClient,
 )
+from marketlab.paper.notifications import (
+    TelegramTransport,
+    build_approval_message,
+    build_decision_message,
+    build_submission_message,
+    deliver_telegram_notification,
+)
 from marketlab.targets import add_forward_targets, build_rebalance_snapshots
 
 APPROVAL_PENDING = "pending"
@@ -131,10 +138,17 @@ class PaperStateStore:
         self._config = config
         self.inbox_root = config.paper_approval_inbox_dir
         self.state_root = config.paper_state_dir
+        self.notifications_root = self.state_root / "notifications"
         self.trades_root = self.state_root / "trades"
         self.reports_root = self.state_root.parent / "reports"
         self.status_path = self.state_root / "status.json"
-        for root in (self.inbox_root, self.state_root, self.trades_root, self.reports_root):
+        for root in (
+            self.inbox_root,
+            self.state_root,
+            self.notifications_root,
+            self.trades_root,
+            self.reports_root,
+        ):
             root.mkdir(parents=True, exist_ok=True)
 
     def trade_dir(self, trade_date: str) -> Path:
@@ -170,6 +184,35 @@ class PaperStateStore:
         path = self.reports_root / f"{start_date}_{end_date}"
         path.mkdir(parents=True, exist_ok=True)
         return path
+
+    def notification_record_path(
+        self,
+        *,
+        stage: str,
+        outcome: str,
+        now: datetime | None = None,
+    ) -> Path:
+        timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
+        stem = f"{timestamp}_{stage}_{outcome}".replace(" ", "_")
+        path = self.notifications_root / f"{stem}.json"
+        suffix = 1
+        while path.exists():
+            path = self.notifications_root / f"{stem}_{suffix}.json"
+            suffix += 1
+        return path
+
+    def write_notification_record(
+        self,
+        *,
+        stage: str,
+        outcome: str,
+        payload: dict[str, Any],
+        now: datetime | None = None,
+    ) -> Path:
+        return _json_dump(
+            self.notification_record_path(stage=stage, outcome=outcome, now=now),
+            payload,
+        )
 
     def write_status(self, payload: dict[str, Any]) -> Path:
         return _json_dump(self.status_path, payload)
@@ -219,6 +262,169 @@ class PaperStateStore:
         if not proposals:
             return None
         return proposals[0]
+
+
+def _write_notification_record(
+    config: ExperimentConfig,
+    store: PaperStateStore,
+    *,
+    stage: str,
+    outcome: str,
+    message: str,
+    details: dict[str, Any],
+    proposal_id: str = "",
+    trade_date: str = "",
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path:
+    record = deliver_telegram_notification(
+        config,
+        stage=stage,
+        outcome=outcome,
+        message=message,
+        details=details,
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+        now=now,
+        transport=transport,
+    )
+    return store.write_notification_record(
+        stage=stage,
+        outcome=outcome,
+        payload=record,
+        now=now,
+    )
+
+
+def _notify_paper_decision(
+    config: ExperimentConfig,
+    store: PaperStateStore,
+    *,
+    outcome: str,
+    status: dict[str, Any],
+    proposal: dict[str, Any] | None = None,
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path:
+    details: dict[str, Any] = {
+        "experiment_name": config.experiment_name,
+        "market_date": status.get("market_date"),
+        "latest_signal_date": status.get("latest_signal_date"),
+        "reason": status.get("reason"),
+    }
+    if proposal is not None:
+        details.update(
+            {
+                "symbol": proposal.get("symbol"),
+                "signal_date": proposal.get("signal_date"),
+                "effective_date": proposal.get("effective_date"),
+                "decision": proposal.get("decision"),
+                "target_weight": proposal.get("target_weight"),
+                "long_vote_count": proposal.get("long_vote_count"),
+                "cash_vote_count": proposal.get("cash_vote_count"),
+                "threshold": config.paper.consensus_min_long_votes,
+                "reference_price": proposal.get("reference_price"),
+            }
+        )
+    return _write_notification_record(
+        config,
+        store,
+        stage="paper-decision",
+        outcome=outcome,
+        message=build_decision_message(
+            config,
+            outcome=outcome,
+            status=status,
+            proposal=proposal,
+        ),
+        details=details,
+        proposal_id=(proposal or {}).get("proposal_id", ""),
+        trade_date=(proposal or {}).get("effective_date", ""),
+        now=now,
+        transport=transport,
+    )
+
+
+def _notify_paper_approval(
+    config: ExperimentConfig,
+    store: PaperStateStore,
+    *,
+    proposal: dict[str, Any],
+    approval_record: dict[str, Any],
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path:
+    outcome = str(approval_record["approval_status"])
+    details = {
+        "experiment_name": config.experiment_name,
+        "symbol": proposal.get("symbol"),
+        "signal_date": proposal.get("signal_date"),
+        "effective_date": proposal.get("effective_date"),
+        "actor": approval_record.get("actor"),
+        "provider": approval_record.get("provider"),
+        "model": approval_record.get("model"),
+        "fallback_used": approval_record.get("fallback_used", False),
+        "fallback_reason": approval_record.get("fallback_reason"),
+        "rationale": approval_record.get("rationale"),
+    }
+    return _write_notification_record(
+        config,
+        store,
+        stage="paper-approve",
+        outcome=outcome,
+        message=build_approval_message(
+            config,
+            proposal=proposal,
+            approval=approval_record,
+        ),
+        details=details,
+        proposal_id=str(proposal["proposal_id"]),
+        trade_date=str(proposal["effective_date"]),
+        now=now,
+        transport=transport,
+    )
+
+
+def _notify_paper_submission(
+    config: ExperimentConfig,
+    store: PaperStateStore,
+    *,
+    outcome: str,
+    status: dict[str, Any],
+    proposal: dict[str, Any] | None = None,
+    submission: dict[str, Any] | None = None,
+    now: datetime | None = None,
+    transport: TelegramTransport | None = None,
+) -> Path:
+    details = {
+        "experiment_name": config.experiment_name,
+        "symbol": (proposal or {}).get("symbol"),
+        "signal_date": (proposal or {}).get("signal_date"),
+        "effective_date": (proposal or {}).get("effective_date"),
+        "reason": (submission or {}).get("reason") or status.get("reason"),
+        "side": (submission or {}).get("side"),
+        "qty": (submission or {}).get("qty"),
+        "order_id": (submission or {}).get("order_id"),
+        "order_status": (submission or {}).get("order_status"),
+    }
+    return _write_notification_record(
+        config,
+        store,
+        stage="paper-submit",
+        outcome=outcome,
+        message=build_submission_message(
+            config,
+            outcome=outcome,
+            status=status,
+            proposal=proposal,
+            submission=submission,
+        ),
+        details=details,
+        proposal_id=str((proposal or {}).get("proposal_id") or (submission or {}).get("proposal_id") or ""),
+        trade_date=str((submission or {}).get("trade_date") or (proposal or {}).get("effective_date") or ""),
+        now=now,
+        transport=transport,
+    )
 
 
 def _build_alpaca_panel(
@@ -382,6 +588,7 @@ def run_paper_decision(
     now: datetime | None = None,
     provider: AlpacaMarketDataProvider | None = None,
     broker: AlpacaPaperBrokerClient | None = None,
+    notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     paper_symbol = _paper_symbol(config)
@@ -399,6 +606,14 @@ def run_paper_decision(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_decision(
+            config,
+            store,
+            outcome="non_trading_day",
+            status=status,
+            now=now,
+            transport=notification_transport,
+        )
         return {"status_path": str(status_path), "status": status}
 
     panel = _build_alpaca_panel(config, provider=provider)
@@ -421,6 +636,14 @@ def run_paper_decision(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_decision(
+            config,
+            store,
+            outcome="stale_signal_date",
+            status=status,
+            now=now,
+            transport=notification_transport,
+        )
         return {"status_path": str(status_path), "status": status}
 
     labeled_dataset = add_forward_targets(
@@ -463,6 +686,15 @@ def run_paper_decision(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_decision(
+            config,
+            store,
+            outcome="existing_proposal",
+            status=status,
+            proposal=existing,
+            now=now,
+            transport=notification_transport,
+        )
         return {
             "proposal_id": proposal_id,
             "proposal_path": str(store.inbox_proposal_path(proposal_id)),
@@ -553,6 +785,15 @@ def run_paper_decision(
         "updated_at": _now_utc(now).isoformat(),
     }
     status_path = store.write_status(status)
+    _notify_paper_decision(
+        config,
+        store,
+        outcome="proposal_created",
+        status=status,
+        proposal=proposal,
+        now=now,
+        transport=notification_transport,
+    )
     return {
         "proposal_id": proposal_id,
         "proposal_path": str(proposal_path),
@@ -599,6 +840,7 @@ def decide_paper_proposal(
     fallback_used: bool = False,
     fallback_reason: str | None = None,
     now: datetime | None = None,
+    notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     if decision not in {"approve", "reject"}:
@@ -665,6 +907,14 @@ def decide_paper_proposal(
         "updated_at": approval_timestamp,
     }
     status_path = store.write_status(status)
+    _notify_paper_approval(
+        config,
+        store,
+        proposal=proposal,
+        approval_record=approval_record,
+        now=now,
+        transport=notification_transport,
+    )
     return {
         "proposal_id": proposal_id,
         "proposal_path": str(proposal_path),
@@ -698,6 +948,7 @@ def run_paper_submit(
     *,
     now: datetime | None = None,
     broker: AlpacaPaperBrokerClient | None = None,
+    notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     paper_symbol = _paper_symbol(config)
@@ -711,6 +962,14 @@ def run_paper_submit(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_submission(
+            config,
+            store,
+            outcome=SUBMISSION_SKIPPED,
+            status=status,
+            now=now,
+            transport=notification_transport,
+        )
         return {"status_path": str(status_path), "status": status}
 
     local_now = _local_now(config, now)
@@ -733,6 +992,16 @@ def run_paper_submit(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_submission(
+            config,
+            store,
+            outcome="existing_submission",
+            status=status,
+            proposal=proposal,
+            submission=submission,
+            now=now,
+            transport=notification_transport,
+        )
         return {
             "submission_path": str(submission_path),
             "status_path": str(status_path),
@@ -760,6 +1029,16 @@ def run_paper_submit(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_submission(
+            config,
+            store,
+            outcome=gate_status,
+            status=status,
+            proposal=proposal,
+            submission=submission,
+            now=now,
+            transport=notification_transport,
+        )
         return {
             "submission_path": str(submission_path),
             "status_path": str(status_path),
@@ -811,6 +1090,16 @@ def run_paper_submit(
             "updated_at": _now_utc(now).isoformat(),
         }
         status_path = store.write_status(status)
+        _notify_paper_submission(
+            config,
+            store,
+            outcome=SUBMISSION_NOOP,
+            status=status,
+            proposal=proposal,
+            submission=submission,
+            now=now,
+            transport=notification_transport,
+        )
         return {
             "submission_path": str(submission_path),
             "status_path": str(status_path),
@@ -842,6 +1131,8 @@ def run_paper_submit(
         "proposal_id": proposal["proposal_id"],
         "trade_date": trade_date,
         "status": SUBMISSION_SUBMITTED,
+        "side": side,
+        "qty": abs(delta_qty),
         "order_id": order["id"],
         "client_order_id": order.get("client_order_id", client_order_id),
         "order_status": order_status.get("status", order.get("status", "unknown")),
@@ -860,6 +1151,16 @@ def run_paper_submit(
         "updated_at": _now_utc(now).isoformat(),
     }
     status_path = store.write_status(status)
+    _notify_paper_submission(
+        config,
+        store,
+        outcome=SUBMISSION_SUBMITTED,
+        status=status,
+        proposal=proposal,
+        submission=submission,
+        now=now,
+        transport=notification_transport,
+    )
     return {
         "submission_path": str(submission_path),
         "status_path": str(status_path),

--- a/tests/_paper_fakes.py
+++ b/tests/_paper_fakes.py
@@ -14,9 +14,11 @@ from marketlab.config import (
     FeaturesConfig,
     ModelSpec,
     PaperConfig,
+    PaperNotificationsConfig,
     PortfolioConfig,
     RankingConfig,
     TargetConfig,
+    TelegramNotificationsConfig,
     WalkForwardConfig,
 )
 
@@ -59,6 +61,7 @@ def build_phase7_paper_config(
     symbol: str = "VOO",
     agent_backend: str = "deterministic_consensus",
     agent_model: str = "",
+    telegram_enabled: bool = False,
 ) -> ExperimentConfig:
     return ExperimentConfig(
         experiment_name="phase7_paper_fixture",
@@ -117,6 +120,9 @@ def build_phase7_paper_config(
             poll_interval_seconds=1,
             approval_inbox_dir="artifacts/paper/inbox",
             state_dir="artifacts/paper/state",
+            notifications=PaperNotificationsConfig(
+                telegram=TelegramNotificationsConfig(enabled=telegram_enabled)
+            ),
         ),
     )
 
@@ -218,6 +224,7 @@ def write_phase7_paper_config(
     symbol: str = "VOO",
     agent_backend: str = "deterministic_consensus",
     agent_model: str = "",
+    telegram_enabled: bool = False,
 ) -> Path:
     payload = {
         "experiment_name": "phase7_paper_fixture",
@@ -288,6 +295,11 @@ def write_phase7_paper_config(
             "approval_inbox_dir": "artifacts/paper/inbox",
             "state_dir": "artifacts/paper/state",
             "poll_interval_seconds": 1,
+            "notifications": {
+                "telegram": {
+                    "enabled": telegram_enabled,
+                }
+            },
         },
         "artifacts": {
             "output_dir": "artifacts/runs",

--- a/tests/_telegram_fakes.py
+++ b/tests/_telegram_fakes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Any
+
+
+@dataclass(slots=True)
+class TelegramRequest:
+    path: str
+    headers: dict[str, str]
+    payload: dict[str, Any]
+
+
+class FakeTelegramServer:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        response_payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.response_payload = response_payload or {"ok": True, "result": {"message_id": 1}}
+        self.requests: list[TelegramRequest] = []
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._build_handler())
+        self._thread = Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+    def __enter__(self) -> "FakeTelegramServer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def _build_handler(self) -> type[BaseHTTPRequestHandler]:
+        owner = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                content_length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(content_length).decode("utf-8")
+                payload = json.loads(body)
+                owner.requests.append(
+                    TelegramRequest(
+                        path=self.path,
+                        headers={key: value for key, value in self.headers.items()},
+                        payload=payload,
+                    )
+                )
+                encoded = json.dumps(owner.response_payload).encode("utf-8")
+                self.send_response(owner.status_code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+                return
+
+        return _Handler

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from datetime import UTC, datetime
@@ -14,6 +15,7 @@ from tests._paper_fakes import (
     FakeAlpacaProvider,
     write_phase7_paper_config,
 )
+from tests._telegram_fakes import FakeTelegramServer
 from tests.integration._cli_harness import build_synthetic_panel, write_raw_symbol_cache
 
 from marketlab.config import load_config
@@ -203,6 +205,7 @@ async def test_mcp_server_supports_config_generation_run_execution_and_artifact_
 
 @pytest.mark.anyio
 async def test_mcp_server_supports_paper_proposal_listing_reading_and_agent_approval(
+    monkeypatch,
     tmp_path: Path,
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -210,92 +213,104 @@ async def test_mcp_server_supports_paper_proposal_listing_reading_and_agent_appr
     workspace.mkdir(parents=True)
     artifact_root.mkdir(parents=True)
 
-    config_path = write_phase7_paper_config(
-        workspace / "configs" / "phase7_paper.yaml",
-        execution_mode="agent_approval",
-    )
-    config = load_config(config_path)
-    decision = run_paper_decision(
-        config,
-        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
-        provider=FakeAlpacaProvider(),
-        broker=FakeAlpacaBroker(),
-    )
-    proposal_id = decision["proposal_id"]
+    with FakeTelegramServer() as telegram_server:
+        config_path = write_phase7_paper_config(
+            workspace / "configs" / "phase7_paper.yaml",
+            execution_mode="agent_approval",
+            telegram_enabled=True,
+        )
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+        monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", telegram_server.base_url)
+        config = load_config(config_path)
+        decision = run_paper_decision(
+            config,
+            now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+            provider=FakeAlpacaProvider(),
+            broker=FakeAlpacaBroker(),
+        )
+        proposal_id = decision["proposal_id"]
 
-    env = os.environ.copy()
-    existing_pythonpath = env.get("PYTHONPATH")
-    repo_src = str(REPO_ROOT / "src")
-    env["PYTHONPATH"] = repo_src if not existing_pythonpath else os.pathsep.join(
-        [repo_src, existing_pythonpath]
-    )
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH")
+        repo_src = str(REPO_ROOT / "src")
+        env["PYTHONPATH"] = repo_src if not existing_pythonpath else os.pathsep.join(
+            [repo_src, existing_pythonpath]
+        )
 
-    server = StdioServerParameters(
-        command=sys.executable,
-        args=[
-            str(MCP_LAUNCHER),
-            "--workspace-root",
-            str(workspace),
-            "--artifact-root",
-            str(artifact_root),
-            "--repo-root",
-            str(REPO_ROOT),
-        ],
-        cwd=REPO_ROOT,
-        env=env,
-    )
+        server = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                str(MCP_LAUNCHER),
+                "--workspace-root",
+                str(workspace),
+                "--artifact-root",
+                str(artifact_root),
+                "--repo-root",
+                str(REPO_ROOT),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+        )
 
-    async with stdio_client(server) as (read_stream, write_stream):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            tools = await session.list_tools()
-            tool_names = sorted(tool.name for tool in tools.tools)
-            assert "marketlab_list_paper_proposals" in tool_names
-            assert "marketlab_decide_paper_proposal" in tool_names
+        async with stdio_client(server) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                tool_names = sorted(tool.name for tool in tools.tools)
+                assert "marketlab_list_paper_proposals" in tool_names
+                assert "marketlab_decide_paper_proposal" in tool_names
 
-            listed = await _call_tool(
-                session,
-                "marketlab_list_paper_proposals",
-                {"config_path": "configs/phase7_paper.yaml"},
-            )
-            assert len(listed["proposals"]) == 1
-            assert listed["proposals"][0]["proposal_id"] == proposal_id
+                listed = await _call_tool(
+                    session,
+                    "marketlab_list_paper_proposals",
+                    {"config_path": "configs/phase7_paper.yaml"},
+                )
+                assert len(listed["proposals"]) == 1
+                assert listed["proposals"][0]["proposal_id"] == proposal_id
 
-            proposal = await _call_tool(
-                session,
-                "marketlab_read_paper_proposal",
-                {
-                    "config_path": "configs/phase7_paper.yaml",
-                    "proposal_id": proposal_id,
-                },
-            )
-            assert proposal["proposal"]["approval_status"] == "pending"
+                proposal = await _call_tool(
+                    session,
+                    "marketlab_read_paper_proposal",
+                    {
+                        "config_path": "configs/phase7_paper.yaml",
+                        "proposal_id": proposal_id,
+                    },
+                )
+                assert proposal["proposal"]["approval_status"] == "pending"
 
-            status = await _call_tool(
-                session,
-                "marketlab_get_paper_status",
-                {"config_path": "configs/phase7_paper.yaml"},
-            )
-            assert status["latest_proposal"]["proposal_id"] == proposal_id
+                status = await _call_tool(
+                    session,
+                    "marketlab_get_paper_status",
+                    {"config_path": "configs/phase7_paper.yaml"},
+                )
+                assert status["latest_proposal"]["proposal_id"] == proposal_id
 
-            approved = await _call_tool(
-                session,
-                "marketlab_decide_paper_proposal",
-                {
-                    "config_path": "configs/phase7_paper.yaml",
-                    "proposal_id": proposal_id,
-                    "decision": "approve",
-                    "actor": "agent",
-                },
-            )
-            assert approved["status"]["status"] == "approved"
+                approved = await _call_tool(
+                    session,
+                    "marketlab_decide_paper_proposal",
+                    {
+                        "config_path": "configs/phase7_paper.yaml",
+                        "proposal_id": proposal_id,
+                        "decision": "approve",
+                        "actor": "agent",
+                    },
+                )
+                assert approved["status"]["status"] == "approved"
 
-            reread = await _call_tool(
-                session,
-                "marketlab_read_paper_proposal",
-                {
-                    "config_path": "configs/phase7_paper.yaml",
-                    "proposal_id": proposal_id,
-                },
-            )
-            assert reread["proposal"]["approval_status"] == "approved"
+                reread = await _call_tool(
+                    session,
+                    "marketlab_read_paper_proposal",
+                    {
+                        "config_path": "configs/phase7_paper.yaml",
+                        "proposal_id": proposal_id,
+                    },
+                )
+                assert reread["proposal"]["approval_status"] == "approved"
+
+        records = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted((workspace / "artifacts" / "paper" / "state" / "notifications").glob("*.json"))
+        ]
+        assert any(record["stage"] == "paper-approve" for record in records)
+        assert any(request.payload["text"].startswith("paper-approve") for request in telegram_server.requests)

--- a/tests/integration/test_paper_notification_flow.py
+++ b/tests/integration/test_paper_notification_flow.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    build_phase7_paper_config,
+)
+from tests._telegram_fakes import FakeTelegramServer
+
+from marketlab.paper.agent import run_agent_approval_iteration
+from marketlab.paper.service import (
+    PaperStateStore,
+    run_paper_decision,
+    run_paper_submit,
+)
+
+
+def test_local_paper_flow_sends_decision_approval_and_submit_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
+    provider = FakeAlpacaProvider(symbol="VOO")
+    broker = FakeAlpacaBroker(symbol="VOO")
+
+    with FakeTelegramServer() as telegram_server:
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+        monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", telegram_server.base_url)
+
+        decision = run_paper_decision(
+            config,
+            now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+            provider=provider,
+            broker=broker,
+        )
+        approval = run_agent_approval_iteration(
+            config,
+            now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+            broker=broker,
+        )
+        submission = run_paper_submit(
+            config,
+            now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+            broker=broker,
+        )
+
+    records = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(PaperStateStore(config).notifications_root.glob("*.json"))
+    ]
+    messages = [request.payload["text"] for request in telegram_server.requests]
+
+    assert decision["status"]["status"] == "proposal_created"
+    assert approval["processed_count"] == 1
+    assert submission["submission"]["status"] in {"submitted", "no_trade_required"}
+    assert len(telegram_server.requests) == 3
+    assert messages[0].startswith("paper-decision")
+    assert messages[1].startswith("paper-approve")
+    assert messages[2].startswith("paper-submit")
+    assert [record["stage"] for record in records] == [
+        "paper-decision",
+        "paper-approve",
+        "paper-submit",
+    ]

--- a/tests/integration/test_real_telegram_smoke.py
+++ b/tests/integration/test_real_telegram_smoke.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests._paper_fakes import build_phase7_paper_config
+
+from marketlab.env import load_env_file
+from marketlab.paper.notifications import (
+    DELIVERY_DELIVERED,
+    deliver_telegram_notification,
+)
+from marketlab.paper.service import PaperStateStore
+
+pytestmark = [pytest.mark.network]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _require_real_telegram_env() -> None:
+    if os.getenv("MARKETLAB_RUN_REAL_TELEGRAM") != "1":
+        pytest.skip("Set MARKETLAB_RUN_REAL_TELEGRAM=1 to run the real Telegram smoke test.")
+
+    load_env_file()
+    missing = [
+        name
+        for name in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID")
+        if os.getenv(name, "").strip() == ""
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        pytest.skip(f"Real Telegram smoke test requires configured env vars: {joined}.")
+
+
+def test_real_telegram_smoke_sends_one_message_and_persists_audit_record(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.delenv("MARKETLAB_TELEGRAM_API_BASE_URL", raising=False)
+    _require_real_telegram_env()
+
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
+    store = PaperStateStore(config)
+    now = datetime.now(UTC)
+    timestamp = now.strftime("%Y-%m-%d %H:%M:%S UTC")
+    message = "\n".join(
+        [
+            "paper-submit",
+            "experiment: telegram_smoke_test",
+            "symbol: TEST",
+            "outcome: smoke_test",
+            f"note: MarketLab real Telegram smoke test at {timestamp}",
+        ]
+    )
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-submit",
+        outcome="smoke_test",
+        message=message,
+        details={
+            "experiment_name": "telegram_smoke_test",
+            "symbol": "TEST",
+            "note": f"MarketLab real Telegram smoke test at {timestamp}",
+        },
+        proposal_id="telegram-smoke-test",
+        trade_date=now.date().isoformat(),
+        now=now,
+    )
+    record_path = store.write_notification_record(
+        stage="paper-submit",
+        outcome="smoke_test",
+        payload=record,
+        now=now,
+    )
+
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["delivery_status"] == DELIVERY_DELIVERED, record
+    assert persisted["delivery_status"] == DELIVERY_DELIVERED
+    assert persisted["response_body"]["ok"] is True
+    assert persisted["request"]["text"] == message

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -587,6 +587,11 @@ def test_load_config_accepts_phase7_paper_settings(tmp_path: Path) -> None:
         "approval_inbox_dir": "artifacts/paper/inbox",
         "state_dir": "artifacts/paper/state",
         "poll_interval_seconds": 15,
+        "notifications": {
+            "telegram": {
+                "enabled": True,
+            }
+        },
     }
     config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
 
@@ -598,8 +603,43 @@ def test_load_config_accepts_phase7_paper_settings(tmp_path: Path) -> None:
     assert config.paper.agent_model == "gpt-4o-mini"
     assert config.paper.agent_timeout_seconds == 45
     assert config.paper.consensus_min_long_votes == 4
+    assert config.paper.notifications.telegram.enabled is True
     assert config.paper_approval_inbox_dir == (tmp_path / "artifacts" / "paper" / "inbox").resolve()
     assert config.paper_state_dir == (tmp_path / "artifacts" / "paper" / "state").resolve()
+
+
+def test_load_config_defaults_paper_telegram_notifications_to_disabled(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        data={"symbols": ["VOO"], "interval": "1d"},
+    )
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["target"] = {"horizon_days": 1, "type": "direction"}
+    payload["portfolio"] = {
+        "ranking": {
+            "long_n": 1,
+            "short_n": 1,
+            "rebalance_frequency": "D",
+            "mode": "long_only",
+        }
+    }
+    payload["models"] = [
+        {"name": "logistic_regression"},
+        {"name": "logistic_l1"},
+        {"name": "random_forest"},
+        {"name": "extra_trees"},
+        {"name": "gradient_boosting"},
+        {"name": "hist_gradient_boosting"},
+    ]
+    payload["paper"] = {
+        "enabled": True,
+        "execution_mode": "agent_approval",
+    }
+    config_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    config = load_config(config_path)
+
+    assert config.paper.notifications.telegram.enabled is False
 
 
 def test_load_config_rejects_unknown_paper_agent_backend(tmp_path: Path) -> None:

--- a/tests/unit/test_mcp_codex_config.py
+++ b/tests/unit/test_mcp_codex_config.py
@@ -4,19 +4,23 @@ import tomllib
 from pathlib import Path
 
 
-def test_codex_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
+def test_codex_mcp_sample_exposes_research_and_paper_docker_servers() -> None:
     document = tomllib.loads(Path("docs/codex.config.toml.example").read_text(encoding="utf-8"))
 
     assert set(document["mcp_servers"]) == {
         "marketlab",
         "marketlab_online",
+        "marketlab_paper",
+        "marketlab_paper_online",
     }
 
-    offline = document["mcp_servers"]["marketlab"]
-    online = document["mcp_servers"]["marketlab_online"]
+    research_offline = document["mcp_servers"]["marketlab"]
+    research_online = document["mcp_servers"]["marketlab_online"]
+    paper_offline = document["mcp_servers"]["marketlab_paper"]
+    paper_online = document["mcp_servers"]["marketlab_paper_online"]
 
-    assert offline["command"] == "docker"
-    assert offline["args"] == [
+    assert research_offline["command"] == "docker"
+    assert research_offline["args"] == [
         "exec",
         "-i",
         "marketlab-mcp",
@@ -28,11 +32,29 @@ def test_codex_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
         "--repo-root",
         "/app/repo",
     ]
-    assert offline["startup_timeout_sec"] == 20
-    assert offline["tool_timeout_sec"] == 120
-    assert online["args"] == [*offline["args"], "--allow-network"]
-    assert online["startup_timeout_sec"] == offline["startup_timeout_sec"]
-    assert online["tool_timeout_sec"] == offline["tool_timeout_sec"]
+    assert paper_offline["command"] == "docker"
+    assert paper_offline["args"] == [
+        "exec",
+        "-i",
+        "marketlab-paper-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/repo/artifacts",
+        "--repo-root",
+        "/app/repo",
+    ]
+    assert research_offline["startup_timeout_sec"] == 20
+    assert research_offline["tool_timeout_sec"] == 120
+    assert research_online["args"] == [*research_offline["args"], "--allow-network"]
+    assert research_online["startup_timeout_sec"] == research_offline["startup_timeout_sec"]
+    assert research_online["tool_timeout_sec"] == research_offline["tool_timeout_sec"]
+    assert paper_offline["startup_timeout_sec"] == 20
+    assert paper_offline["tool_timeout_sec"] == 120
+    assert paper_online["args"] == [*paper_offline["args"], "--allow-network"]
+    assert paper_online["startup_timeout_sec"] == paper_offline["startup_timeout_sec"]
+    assert paper_online["tool_timeout_sec"] == paper_offline["tool_timeout_sec"]
 
 
 def test_codex_mcp_sample_matches_compose_container_contract() -> None:
@@ -46,4 +68,18 @@ def test_codex_mcp_sample_matches_compose_container_contract() -> None:
     assert '"marketlab-mcp"' in sample_text
     assert '"/app/workspace"' in sample_text
     assert '"/app/artifacts"' in sample_text
+    assert '"/app/repo"' in sample_text
+
+
+def test_codex_paper_mcp_sample_matches_compose_paper_container_contract() -> None:
+    compose_text = Path("docker/compose.paper.yml").read_text(encoding="utf-8")
+    sample_text = Path("docs/codex.config.toml.example").read_text(encoding="utf-8")
+
+    assert 'container_name: marketlab-paper-mcp' in compose_text
+    assert '../artifacts:/app/repo/artifacts' in compose_text
+    assert '/app/workspace' in compose_text
+    assert '/app/repo:ro' in compose_text
+    assert '"marketlab-paper-mcp"' in sample_text
+    assert '"/app/workspace"' in sample_text
+    assert '"/app/repo/artifacts"' in sample_text
     assert '"/app/repo"' in sample_text

--- a/tests/unit/test_mcp_vscode_config.py
+++ b/tests/unit/test_mcp_vscode_config.py
@@ -4,20 +4,24 @@ import json
 from pathlib import Path
 
 
-def test_vscode_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
+def test_vscode_mcp_sample_exposes_research_and_paper_docker_servers() -> None:
     document = json.loads(Path(".vscode/mcp.json.example").read_text(encoding="utf-8"))
 
     assert set(document["servers"]) == {
         "marketlab-docker-offline",
         "marketlab-docker-online",
+        "marketlab-paper-docker-offline",
+        "marketlab-paper-docker-online",
     }
 
-    offline = document["servers"]["marketlab-docker-offline"]
-    online = document["servers"]["marketlab-docker-online"]
+    research_offline = document["servers"]["marketlab-docker-offline"]
+    research_online = document["servers"]["marketlab-docker-online"]
+    paper_offline = document["servers"]["marketlab-paper-docker-offline"]
+    paper_online = document["servers"]["marketlab-paper-docker-online"]
 
-    assert offline["type"] == "stdio"
-    assert offline["command"] == "docker"
-    assert offline["args"] == [
+    assert research_offline["type"] == "stdio"
+    assert research_offline["command"] == "docker"
+    assert research_offline["args"] == [
         "exec",
         "-i",
         "marketlab-mcp",
@@ -29,7 +33,22 @@ def test_vscode_mcp_sample_exposes_offline_and_online_docker_servers() -> None:
         "--repo-root",
         "/app/repo",
     ]
-    assert online["args"] == [*offline["args"], "--allow-network"]
+    assert paper_offline["type"] == "stdio"
+    assert paper_offline["command"] == "docker"
+    assert paper_offline["args"] == [
+        "exec",
+        "-i",
+        "marketlab-paper-mcp",
+        "marketlab-mcp",
+        "--workspace-root",
+        "/app/workspace",
+        "--artifact-root",
+        "/app/repo/artifacts",
+        "--repo-root",
+        "/app/repo",
+    ]
+    assert research_online["args"] == [*research_offline["args"], "--allow-network"]
+    assert paper_online["args"] == [*paper_offline["args"], "--allow-network"]
 
 
 def test_vscode_mcp_sample_matches_compose_container_contract() -> None:
@@ -43,4 +62,18 @@ def test_vscode_mcp_sample_matches_compose_container_contract() -> None:
     assert '"marketlab-mcp"' in sample_text
     assert '"/app/workspace"' in sample_text
     assert '"/app/artifacts"' in sample_text
+    assert '"/app/repo"' in sample_text
+
+
+def test_vscode_paper_mcp_sample_matches_compose_paper_container_contract() -> None:
+    compose_text = Path("docker/compose.paper.yml").read_text(encoding="utf-8")
+    sample_text = Path(".vscode/mcp.json.example").read_text(encoding="utf-8")
+
+    assert 'container_name: marketlab-paper-mcp' in compose_text
+    assert '../artifacts:/app/repo/artifacts' in compose_text
+    assert '/app/workspace' in compose_text
+    assert '/app/repo:ro' in compose_text
+    assert '"marketlab-paper-mcp"' in sample_text
+    assert '"/app/workspace"' in sample_text
+    assert '"/app/repo/artifacts"' in sample_text
     assert '"/app/repo"' in sample_text

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import types
 from datetime import UTC, datetime
@@ -11,8 +12,28 @@ from tests._paper_fakes import (
     build_phase7_paper_config,
 )
 
-from marketlab.paper.agent import run_agent_approval_iteration
+import marketlab.paper.agent as agent_module
+from marketlab.paper.agent import run_agent_approval_iteration, run_agent_approval_loop
 from marketlab.paper.service import PaperStateStore, run_paper_decision
+
+
+def _capture_transport(calls: list[dict[str, object]]):
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        calls.append(
+            {
+                "url": url,
+                "payload": payload,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return 200, '{"ok": true, "result": {"message_id": 1}}'
+
+    return _transport
+
+
+def _configure_notification_env(monkeypatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
 
 
 def test_agent_worker_approves_with_openai_backend(monkeypatch, tmp_path: Path) -> None:
@@ -113,6 +134,7 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
         execution_mode="agent_approval",
         agent_backend="openai",
         agent_model="gpt-4o-mini",
+        telegram_enabled=True,
     )
     run_paper_decision(
         config,
@@ -131,11 +153,14 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAIClient))
+    _configure_notification_env(monkeypatch)
+    calls: list[dict[str, object]] = []
 
     run_agent_approval_iteration(
         config,
         now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
         broker=FakeAlpacaBroker(symbol="VOO"),
+        notification_transport=_capture_transport(calls),
     )
 
     proposal = PaperStateStore(config).latest_proposal()
@@ -144,6 +169,10 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
     assert proposal["approval_backend"] == "deterministic_consensus"
     assert proposal["approval_fallback_used"] is True
     assert "openai backend failed" in proposal["approval_fallback_reason"]
+    assert len(calls) == 1
+    assert "provider: deterministic_consensus" in calls[0]["payload"]["text"]
+    assert "fallback_used: true" in calls[0]["payload"]["text"]
+    assert "fallback_reason: openai backend failed" in calls[0]["payload"]["text"]
 
 
 def test_agent_worker_is_idempotent_after_first_approval(monkeypatch, tmp_path: Path) -> None:
@@ -168,3 +197,92 @@ def test_agent_worker_is_idempotent_after_first_approval(monkeypatch, tmp_path: 
 
     assert first["processed_count"] == 1
     assert second["processed_count"] == 0
+
+
+def test_agent_worker_rejects_proposal_when_evidence_is_missing(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+    store = PaperStateStore(config)
+    proposal_id = "2026-04-13-VOO-2026-04-10"
+    store.save_proposal(
+        {
+            "proposal_id": proposal_id,
+            "experiment_name": config.experiment_name,
+            "symbol": "VOO",
+            "signal_date": "2026-04-10",
+            "effective_date": "2026-04-13",
+            "execution_mode": config.paper.execution_mode,
+            "approval_status": "pending",
+            "submission_status": "pending",
+            "created_at": datetime(2026, 4, 10, 20, 10, tzinfo=UTC).isoformat(),
+        }
+    )
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "rejected"
+    assert "could not read the persisted proposal evidence" in proposal["approval_rationale"]
+
+
+def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    def _failing_iteration(*args, **kwargs):
+        raise RuntimeError("approval backend exploded")
+
+    def _successful_iteration(*args, **kwargs):
+        state = agent_module._load_worker_state(config)
+        agent_module._clear_worker_error_state(state)
+        state["last_checked_at"] = datetime(2026, 4, 10, 20, 40, tzinfo=UTC).isoformat()
+        state["last_result"] = "no_pending_proposals"
+        state_path = agent_module._save_worker_state(config, state)
+        return {
+            "agent_state_path": str(state_path),
+            "events": [],
+            "processed_count": 0,
+        }
+
+    monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
+    run_agent_approval_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+    run_agent_approval_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _successful_iteration)
+    run_agent_approval_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
+    run_agent_approval_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    records = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(PaperStateStore(config).notifications_root.glob("*.json"))
+    ]
+    assert len(calls) == 2
+    assert len(records) == 2
+    assert all(record["stage"] == "paper-error" for record in records)

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -6,6 +6,7 @@ import types
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 from tests._paper_fakes import (
     FakeAlpacaBroker,
     FakeAlpacaProvider,
@@ -254,16 +255,18 @@ def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
         }
 
     monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
-    run_agent_approval_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
-    run_agent_approval_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
+    with pytest.raises(RuntimeError, match="approval backend exploded"):
+        run_agent_approval_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
+    with pytest.raises(RuntimeError, match="approval backend exploded"):
+        run_agent_approval_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
 
     monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _successful_iteration)
     run_agent_approval_loop(
@@ -273,11 +276,12 @@ def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
     )
 
     monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
-    run_agent_approval_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
+    with pytest.raises(RuntimeError, match="approval backend exploded"):
+        run_agent_approval_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
 
     records = [
         json.loads(path.read_text(encoding="utf-8"))
@@ -286,3 +290,32 @@ def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
     assert len(calls) == 2
     assert len(records) == 2
     assert all(record["stage"] == "paper-error" for record in records)
+
+
+def test_agent_worker_loop_once_propagates_iteration_failures_after_notifying(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    def _failing_iteration(*args, **kwargs):
+        raise RuntimeError("agent approval failed")
+
+    monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
+
+    with pytest.raises(RuntimeError, match="agent approval failed"):
+        run_agent_approval_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
+
+    records = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(PaperStateStore(config).notifications_root.glob("*.json"))
+    ]
+    assert len(calls) == 1
+    assert len(records) == 1
+    assert records[0]["stage"] == "paper-error"

--- a/tests/unit/test_paper_compose.py
+++ b/tests/unit/test_paper_compose.py
@@ -16,3 +16,8 @@ def test_paper_compose_includes_scheduler_agent_and_mcp_sidecar() -> None:
     assert "..:/app/repo:ro" in compose_text
     assert "OPENAI_API_KEY" in compose_text
     assert "ANTHROPIC_API_KEY" in compose_text
+    assert "TELEGRAM_BOT_TOKEN" in compose_text
+    assert "TELEGRAM_CHAT_ID" in compose_text
+    assert 'container_name: marketlab-paper-mcp' in compose_text
+    assert compose_text.count("TELEGRAM_BOT_TOKEN") == 6
+    assert compose_text.count("TELEGRAM_CHAT_ID") == 6

--- a/tests/unit/test_paper_notifications.py
+++ b/tests/unit/test_paper_notifications.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import build_phase7_paper_config
+
+from marketlab.paper.notifications import (
+    DELIVERY_DELIVERED,
+    DELIVERY_FAILED,
+    DELIVERY_SKIPPED_DISABLED,
+    DELIVERY_SKIPPED_MISSING_CREDENTIALS,
+    deliver_telegram_notification,
+)
+from marketlab.paper.service import PaperStateStore
+
+
+def test_disabled_telegram_notification_records_skipped_disabled(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=False)
+    store = PaperStateStore(config)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\noutcome: proposal_created",
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+    )
+    record_path = store.write_notification_record(
+        stage="paper-decision",
+        outcome="proposal_created",
+        payload=record,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+    )
+
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["delivery_status"] == DELIVERY_SKIPPED_DISABLED
+    assert persisted["delivery_status"] == DELIVERY_SKIPPED_DISABLED
+
+
+def test_enabled_telegram_notification_without_credentials_records_skip(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    store = PaperStateStore(config)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MARKETLAB_ENV_FILE", raising=False)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-approve",
+        outcome="approved",
+        message="paper-approve\noutcome: approved",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    record_path = store.write_notification_record(
+        stage="paper-approve",
+        outcome="approved",
+        payload=record,
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["delivery_status"] == DELIVERY_SKIPPED_MISSING_CREDENTIALS
+    assert persisted["missing_credentials"]["TELEGRAM_BOT_TOKEN"] is True
+    assert persisted["missing_credentials"]["TELEGRAM_CHAT_ID"] is True
+
+
+def test_successful_telegram_delivery_records_request_and_audit(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    store = PaperStateStore(config)
+    calls: list[dict[str, object]] = []
+
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        calls.append(
+            {
+                "url": url,
+                "payload": payload,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return 200, '{"ok": true, "result": {"message_id": 42}}'
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", "http://127.0.0.1:9999")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-submit",
+        outcome="submitted",
+        message="paper-submit\noutcome: submitted",
+        details={"order_id": "order-1"},
+        proposal_id="proposal-1",
+        trade_date="2026-04-13",
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        transport=_transport,
+    )
+    record_path = store.write_notification_record(
+        stage="paper-submit",
+        outcome="submitted",
+        payload=record,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+    )
+
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["delivery_status"] == DELIVERY_DELIVERED
+    assert len(calls) == 1
+    assert calls[0]["url"] == "http://127.0.0.1:9999/botbot-token/sendMessage"
+    assert calls[0]["payload"] == {
+        "chat_id": "chat-id",
+        "text": "paper-submit\noutcome: submitted",
+        "disable_web_page_preview": True,
+    }
+    assert persisted["request"]["chat_id"] == "chat-id"
+    assert persisted["response_body"]["result"]["message_id"] == 42
+
+
+def test_failed_telegram_delivery_records_failure_without_raising(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    store = PaperStateStore(config)
+
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-error",
+        outcome="error",
+        message="paper-error\nloop: scheduler",
+        now=datetime(2026, 4, 10, 23, 6, tzinfo=UTC),
+        transport=_transport,
+    )
+    record_path = store.write_notification_record(
+        stage="paper-error",
+        outcome="error",
+        payload=record,
+        now=datetime(2026, 4, 10, 23, 6, tzinfo=UTC),
+    )
+
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["delivery_status"] == DELIVERY_FAILED
+    assert "connection refused" in record["error"]
+    assert persisted["delivery_status"] == DELIVERY_FAILED

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
 from tests._paper_fakes import build_phase7_paper_config
 
 from marketlab.paper import scheduler
+
+
+def _capture_transport(calls: list[dict[str, object]]):
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        calls.append(
+            {
+                "url": url,
+                "payload": payload,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return 200, '{"ok": true, "result": {"message_id": 1}}'
+
+    return _transport
+
+
+def _configure_notification_env(monkeypatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
 
 
 def test_scheduler_iteration_runs_each_phase_once_per_market_date(
@@ -38,3 +58,60 @@ def test_scheduler_iteration_runs_each_phase_once_per_market_date(
     assert [event["phase"] for event in first["events"]] == ["decision", "submission"]
     assert second["events"] == []
     assert events == ["decision", "submission"]
+
+
+def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    def _failing_iteration(*args, **kwargs):
+        raise RuntimeError("decision phase failed")
+
+    def _successful_iteration(*args, **kwargs):
+        state = scheduler._load_scheduler_state(config)
+        scheduler._clear_scheduler_error_state(state)
+        state["last_checked_at"] = datetime(2026, 4, 10, 23, 20, tzinfo=UTC).isoformat()
+        state_path = scheduler._save_scheduler_state(config, state)
+        return {
+            "scheduler_state_path": str(state_path),
+            "events": [],
+            "market_date": "2026-04-10",
+        }
+
+    monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
+    scheduler.run_scheduler_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+    scheduler.run_scheduler_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    monkeypatch.setattr(scheduler, "run_scheduler_iteration", _successful_iteration)
+    scheduler.run_scheduler_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
+    scheduler.run_scheduler_loop(
+        config,
+        once=True,
+        notification_transport=_capture_transport(calls),
+    )
+
+    records = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted((config.paper_state_dir / "notifications").glob("*.json"))
+    ]
+    assert len(calls) == 2
+    assert len(records) == 2
+    assert all(record["stage"] == "paper-error" for record in records)

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -4,6 +4,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 from tests._paper_fakes import build_phase7_paper_config
 
 from marketlab.paper import scheduler
@@ -83,16 +84,18 @@ def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
         }
 
     monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
-    scheduler.run_scheduler_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
-    scheduler.run_scheduler_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
+    with pytest.raises(RuntimeError, match="decision phase failed"):
+        scheduler.run_scheduler_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
+    with pytest.raises(RuntimeError, match="decision phase failed"):
+        scheduler.run_scheduler_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
 
     monkeypatch.setattr(scheduler, "run_scheduler_iteration", _successful_iteration)
     scheduler.run_scheduler_loop(
@@ -102,11 +105,12 @@ def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
     )
 
     monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
-    scheduler.run_scheduler_loop(
-        config,
-        once=True,
-        notification_transport=_capture_transport(calls),
-    )
+    with pytest.raises(RuntimeError, match="decision phase failed"):
+        scheduler.run_scheduler_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
 
     records = [
         json.loads(path.read_text(encoding="utf-8"))
@@ -115,3 +119,32 @@ def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
     assert len(calls) == 2
     assert len(records) == 2
     assert all(record["stage"] == "paper-error" for record in records)
+
+
+def test_scheduler_loop_once_propagates_iteration_failures_after_notifying(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    def _failing_iteration(*args, **kwargs):
+        raise RuntimeError("submit phase failed")
+
+    monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
+
+    with pytest.raises(RuntimeError, match="submit phase failed"):
+        scheduler.run_scheduler_loop(
+            config,
+            once=True,
+            notification_transport=_capture_transport(calls),
+        )
+
+    records = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted((config.paper_state_dir / "notifications").glob("*.json"))
+    ]
+    assert len(calls) == 1
+    assert len(records) == 1
+    assert records[0]["stage"] == "paper-error"

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -21,16 +21,50 @@ from marketlab.paper.service import (
 )
 
 
-def test_run_paper_decision_writes_latest_daily_proposal(tmp_path: Path) -> None:
-    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+def _capture_transport(calls: list[dict[str, object]]):
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        calls.append(
+            {
+                "url": url,
+                "payload": payload,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return 200, '{"ok": true, "result": {"message_id": 1}}'
+
+    return _transport
+
+
+def _notification_records(config) -> list[dict[str, object]]:
+    store = PaperStateStore(config)
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(store.notifications_root.glob("*.json"))
+    ]
+
+
+def _configure_notification_env(monkeypatch) -> None:
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+
+def test_run_paper_decision_writes_latest_daily_proposal(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
     provider = FakeAlpacaProvider(symbol="VOO")
     broker = FakeAlpacaBroker(symbol="VOO")
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
 
     result = run_paper_decision(
         config,
         now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
         provider=provider,
         broker=broker,
+        notification_transport=_capture_transport(calls),
     )
 
     proposal_path = Path(result["proposal_path"])
@@ -48,6 +82,11 @@ def test_run_paper_decision_writes_latest_daily_proposal(tmp_path: Path) -> None
     assert proposal["train_rows"] >= 200
     assert len(evidence["models"]) == 6
     assert evidence["decision"] == proposal["decision"]
+    assert len(calls) == 1
+    assert calls[0]["payload"]["text"].startswith("paper-decision")
+    records = _notification_records(config)
+    assert records[-1]["stage"] == "paper-decision"
+    assert records[-1]["outcome"] == "proposal_created"
 
 
 def test_run_paper_decision_supports_configured_single_symbol(tmp_path: Path) -> None:
@@ -96,14 +135,20 @@ def test_run_paper_decision_rejects_empty_symbol_config(tmp_path: Path) -> None:
         )
 
 
-def test_decide_paper_proposal_records_agent_approval(tmp_path: Path) -> None:
-    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+def test_decide_paper_proposal_records_agent_approval(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
     proposal_result = run_paper_decision(
         config,
         now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
         provider=FakeAlpacaProvider(symbol="VOO"),
         broker=FakeAlpacaBroker(symbol="VOO"),
     )
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
 
     decision_result = decide_paper_proposal(
         config,
@@ -111,6 +156,7 @@ def test_decide_paper_proposal_records_agent_approval(tmp_path: Path) -> None:
         decision="approve",
         actor="agent",
         now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+        notification_transport=_capture_transport(calls),
     )
 
     approval_path = Path(decision_result["approval_path"])
@@ -121,21 +167,33 @@ def test_decide_paper_proposal_records_agent_approval(tmp_path: Path) -> None:
     assert approval["actor"] == "agent"
     assert proposal["approval_status"] == "approved"
     assert proposal["approval_actor"] == "agent"
+    assert len(calls) == 1
+    assert "outcome: approved" in calls[0]["payload"]["text"]
+    records = _notification_records(config)
+    assert records[-1]["stage"] == "paper-approve"
+    assert records[-1]["outcome"] == "approved"
 
 
-def test_run_paper_submit_skips_missing_agent_approval(tmp_path: Path) -> None:
-    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+def test_run_paper_submit_skips_missing_agent_approval(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
     proposal_result = run_paper_decision(
         config,
         now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
         provider=FakeAlpacaProvider(symbol="VOO"),
         broker=FakeAlpacaBroker(symbol="VOO"),
     )
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
 
     submission_result = run_paper_submit(
         config,
         now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
         broker=FakeAlpacaBroker(symbol="VOO"),
+        notification_transport=_capture_transport(calls),
     )
 
     submission = submission_result["submission"]
@@ -143,10 +201,19 @@ def test_run_paper_submit_skips_missing_agent_approval(tmp_path: Path) -> None:
     assert submission["proposal_id"] == proposal_result["proposal_id"]
     assert submission["status"] == "skipped"
     assert submission["reason"] == "missing_approval"
+    assert len(calls) == 1
+    assert "reason: missing_approval" in calls[0]["payload"]["text"]
+    records = _notification_records(config)
+    assert records[-1]["stage"] == "paper-submit"
+    assert records[-1]["outcome"] == "skipped"
 
 
-def test_run_paper_submit_places_fractional_order_after_agent_approval(tmp_path: Path) -> None:
-    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
+def test_run_paper_submit_places_fractional_order_after_agent_approval(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
     provider = FakeAlpacaProvider(symbol="VOO")
     broker = FakeAlpacaBroker(symbol="VOO")
     proposal_result = run_paper_decision(
@@ -162,19 +229,88 @@ def test_run_paper_submit_places_fractional_order_after_agent_approval(tmp_path:
         actor="agent",
         now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
     )
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
 
     submission_result = run_paper_submit(
         config,
         now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
         broker=broker,
+        notification_transport=_capture_transport(calls),
     )
 
     submission = submission_result["submission"]
 
     assert submission["status"] in {"submitted", "no_trade_required"}
+    assert len(calls) == 1
     if submission["status"] == "submitted":
         assert broker.submitted_orders
         assert submission["order_status"] == "accepted"
+        assert "outcome: submitted" in calls[0]["payload"]["text"]
+    else:
+        assert "outcome: no_trade_required" in calls[0]["payload"]["text"]
+
+
+def test_run_paper_decision_notifies_existing_proposal(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        telegram_enabled=True,
+    )
+    provider = FakeAlpacaProvider(symbol="VOO")
+    broker = FakeAlpacaBroker(symbol="VOO")
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+    )
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 11, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+        notification_transport=_capture_transport(calls),
+    )
+
+    assert result["status"]["status"] == "existing_proposal"
+    assert len(calls) == 1
+    assert "outcome: existing_proposal" in calls[0]["payload"]["text"]
+
+
+def test_decide_paper_proposal_notifies_manual_rejection(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="manual_approval",
+        telegram_enabled=True,
+    )
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+    calls: list[dict[str, object]] = []
+    _configure_notification_env(monkeypatch)
+
+    decision_result = decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="reject",
+        actor="manual",
+        rationale="Manual hold for review.",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+        notification_transport=_capture_transport(calls),
+    )
+
+    approval = json.loads(Path(decision_result["approval_path"]).read_text(encoding="utf-8"))
+    assert approval["approval_status"] == "rejected"
+    assert len(calls) == 1
+    assert "actor: manual" in calls[0]["payload"]["text"]
+    assert "outcome: rejected" in calls[0]["payload"]["text"]
 
 
 def test_get_paper_status_returns_latest_proposal_summary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- finalize the paper-sidecar MCP samples, local Codex/VS Code setup docs, and sample contract tests
- add the Telegram paper-ops feed, loop error alerts with dedupe, and shared notification audit records
- enable Telegram by default in the tracked QQQ paper config while keeping VOO explicit but disabled
- preserve fail-fast exit codes for `paper-scheduler --once` and `paper-agent-approve --once` while keeping error notifications and audit artifacts

## Commit Stack
- feat(mcp): finalize paper-sidecar MCP samples and docs
- feat(paper): add Telegram ops feed and harden paper loops
- test(paper): cover Telegram delivery, MCP side effects, and live smoke
- chore(paper): enable Telegram in tracked QQQ launch config
- fix(paper): preserve once-loop failure exits

## Validation
- `git diff --check`
- `py -3.14 -m tox -e preflight`
- `.tox\py312\Scripts\python.exe -m pytest -q tests/unit/test_paper_notifications.py tests/unit/test_paper_service.py tests/unit/test_paper_agent.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_compose.py tests/integration/test_paper_notification_flow.py tests/integration/test_mcp_server.py --basetemp .pytest_tmp_targeted_branchtip2`
- `$env:MARKETLAB_RUN_REAL_TELEGRAM='1'; .tox\py312\Scripts\python.exe -m pytest -q tests/integration/test_real_telegram_smoke.py --basetemp .pytest_tmp_real_telegram_dd107d2`

## Manual Verification
- Live Telegram smoke passed on the current PR head `dd107d2ee8e2fb8f8347af3506ba13168db37a87` and Telegram accepted the real message.
- Tracked `configs/experiment.qqq_paper_daily.yaml` is launch-ready with Telegram enabled by default.
