### PR TITLE
fix: harden paper approval guardrails and launch checks

### DIFF
--- a/configs/experiment.qqq_paper_daily.yaml
+++ b/configs/experiment.qqq_paper_daily.yaml
@@ -61,8 +61,8 @@ paper:
   data_provider: "alpaca"
   broker: "alpaca"
   execution_mode: "agent_approval"
-  agent_backend: "openai"
-  agent_model: "gpt-4o-mini"
+  agent_backend: "claude"
+  agent_model: "claude-sonnet-4-5"
   agent_timeout_seconds: 30
   agent_fallback_backend: "deterministic_consensus"
   consensus_min_long_votes: 4

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -87,7 +87,7 @@ If approval is still missing when the submission phase runs, the trade is skippe
 - `claude`
 - `deterministic_consensus`
 
-The tracked config defaults to `openai`, but the worker always falls back to `deterministic_consensus` when:
+The tracked `QQQ` config currently uses `claude`, but the worker always falls back to `deterministic_consensus` when:
 
 - the provider key is missing
 - the provider times out

--- a/scripts/run-paper-launch-checks.ps1
+++ b/scripts/run-paper-launch-checks.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipPull,
+    [string]$PytestBaseTemp = ".pytest_tmp_real_telegram_launch"
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+function Get-GitPorcelainStatus {
+    $status = & git status --porcelain=v1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to inspect git worktree state."
+    }
+
+    return @($status | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+Push-Location $RepoRoot
+try {
+    if (-not $SkipPull) {
+        $currentBranch = (& git branch --show-current).Trim()
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to resolve current git branch."
+        }
+
+        $dirtyEntries = Get-GitPorcelainStatus
+        if ($dirtyEntries.Count -gt 0) {
+            Write-Warning "Skipping git pull because the worktree has uncommitted changes. Re-run with a clean worktree or pass -SkipPull explicitly."
+        }
+        elseif ($currentBranch -ne "master") {
+            Write-Warning "Skipping git pull because the current branch is '$currentBranch', not 'master'. Re-run from master or pass -SkipPull explicitly."
+        }
+        else {
+            Write-Host "Pulling latest master..."
+            git pull --ff-only origin master
+        }
+    }
+
+    Write-Host "Running real Telegram smoke test..."
+    $env:MARKETLAB_RUN_REAL_TELEGRAM = "1"
+    .tox\py312\Scripts\python.exe -m pytest -q tests/integration/test_real_telegram_smoke.py --basetemp $PytestBaseTemp
+
+    Write-Host "Restarting paper Docker services..."
+    docker compose --env-file .env -f docker/compose.paper.yml up -d --build
+
+    Write-Host "Paper stack status:"
+    docker compose --env-file .env -f docker/compose.paper.yml ps
+
+    $statusPath = Join-Path $RepoRoot "artifacts/paper/state/status.json"
+    if (-not (Test-Path -LiteralPath $statusPath)) {
+        throw "Paper status file not found: $statusPath"
+    }
+
+    Write-Host "Paper status summary:"
+    Get-Content -LiteralPath $statusPath
+
+    Write-Host "Scheduler log tail:"
+    docker logs --tail 50 marketlab-paper-scheduler
+
+    Write-Host "Agent log tail:"
+    docker logs --tail 50 marketlab-paper-agent
+}
+finally {
+    Remove-Item Env:MARKETLAB_RUN_REAL_TELEGRAM -ErrorAction SilentlyContinue
+    Pop-Location
+}

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -215,20 +215,45 @@ def _proposal_is_consistent(proposal: dict[str, Any], evidence: dict[str, Any]) 
         return False, "effective_date mismatch"
     if proposal.get("decision_policy") != "consensus_vote":
         return False, "unsupported decision policy"
-    if proposal.get("decision") != evidence.get("decision"):
-        return False, "decision mismatch"
-    if float(proposal.get("target_weight", 0.0)) != float(evidence.get("target_weight", 0.0)):
-        return False, "target_weight mismatch"
-    if int(proposal.get("long_vote_count", -1)) != int(evidence.get("long_vote_count", -2)):
-        return False, "long_vote_count mismatch"
-    if int(proposal.get("cash_vote_count", -1)) != int(evidence.get("cash_vote_count", -2)):
-        return False, "cash_vote_count mismatch"
     models = evidence.get("models", [])
     if not isinstance(models, list) or len(models) == 0:
         return False, "missing model evidence"
+    consensus_rule = evidence.get("consensus_rule")
+    if not isinstance(consensus_rule, dict):
+        return False, "missing consensus rule"
+    try:
+        proposal_target_weight = float(proposal.get("target_weight", 0.0))
+        evidence_target_weight = float(evidence.get("target_weight", 0.0))
+        proposal_long_vote_count = int(proposal.get("long_vote_count", -1))
+        evidence_long_vote_count = int(evidence.get("long_vote_count", -2))
+        proposal_cash_vote_count = int(proposal.get("cash_vote_count", -1))
+        evidence_cash_vote_count = int(evidence.get("cash_vote_count", -2))
+        threshold = int(consensus_rule.get("min_long_votes", -1))
+        model_count = int(consensus_rule.get("model_count", len(models)))
+    except (TypeError, ValueError):
+        return False, "invalid numeric proposal or evidence fields"
+    if proposal.get("decision") != evidence.get("decision"):
+        return False, "decision mismatch"
+    if proposal_target_weight != evidence_target_weight:
+        return False, "target_weight mismatch"
+    if proposal_long_vote_count != evidence_long_vote_count:
+        return False, "long_vote_count mismatch"
+    if proposal_cash_vote_count != evidence_cash_vote_count:
+        return False, "cash_vote_count mismatch"
     long_votes = sum(1 for row in models if row.get("vote") == "long")
-    if long_votes != int(evidence.get("long_vote_count", -1)):
+    if long_votes != evidence_long_vote_count:
         return False, "model vote tally mismatch"
+    cash_votes = len(models) - long_votes
+    if cash_votes != evidence_cash_vote_count:
+        return False, "cash vote tally mismatch"
+    if model_count != len(models):
+        return False, "consensus model_count mismatch"
+    expected_target_weight = 1.0 if long_votes >= threshold else 0.0
+    expected_decision = "long" if expected_target_weight > 0.0 else "cash"
+    if proposal.get("decision") != expected_decision:
+        return False, "consensus decision mismatch"
+    if proposal_target_weight != expected_target_weight:
+        return False, "consensus target_weight mismatch"
     return True, ""
 
 
@@ -279,7 +304,7 @@ def _guardrail_primary_decision(
     account_context: dict[str, Any],
     primary_result: AgentDecision,
 ) -> AgentDecision:
-    if requested_backend == "deterministic_consensus":
+    if requested_backend == "deterministic_consensus" or primary_result.decision != "reject":
         return primary_result
 
     deterministic_result = DeterministicConsensusBackend().evaluate(
@@ -289,7 +314,7 @@ def _guardrail_primary_decision(
         status=status,
         account_context=account_context,
     )
-    if primary_result.decision == deterministic_result.decision:
+    if deterministic_result.decision != "approve":
         return primary_result
 
     return AgentDecision(

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -180,8 +180,12 @@ def _approval_policy_prompt() -> str:
     return (
         "Review the attached paper-trading proposal evidence and decide whether to "
         "approve or reject the existing proposal. You may only approve or reject the "
-        "proposal as written. Do not invent a different trade, symbol, quantity, side, "
-        "target weight, threshold, or date. Return only the required structured output."
+        "proposal as written. The consensus rule has already been applied by the system. "
+        "If the persisted proposal and evidence are internally consistent for the same "
+        "trade, approve it. Reject only when the persisted proposal or evidence is "
+        "malformed, inconsistent, or refers to a different trade. Do not invent a "
+        "different trade, symbol, quantity, side, target weight, threshold, or date. "
+        "Return only the required structured output."
     )
 
 
@@ -263,6 +267,43 @@ class DeterministicConsensusBackend(AgentBackend):
             provider=self.provider_name,
             model=self.provider_name,
         )
+
+
+def _guardrail_primary_decision(
+    *,
+    config: ExperimentConfig,
+    requested_backend: str,
+    proposal: dict[str, Any],
+    evidence: dict[str, Any],
+    status: dict[str, Any] | None,
+    account_context: dict[str, Any],
+    primary_result: AgentDecision,
+) -> AgentDecision:
+    if requested_backend == "deterministic_consensus":
+        return primary_result
+
+    deterministic_result = DeterministicConsensusBackend().evaluate(
+        config=config,
+        proposal=proposal,
+        evidence=evidence,
+        status=status,
+        account_context=account_context,
+    )
+    if primary_result.decision == deterministic_result.decision:
+        return primary_result
+
+    return AgentDecision(
+        decision=deterministic_result.decision,
+        rationale=deterministic_result.rationale,
+        provider=deterministic_result.provider,
+        model=deterministic_result.model,
+        fallback_used=True,
+        fallback_reason=(
+            f"{requested_backend} backend returned {primary_result.decision!r}, but "
+            f"deterministic_consensus requires {deterministic_result.decision!r} for "
+            "the persisted proposal evidence."
+        ),
+    )
 
 
 def _extract_openai_text(response: Any) -> str:
@@ -426,12 +467,21 @@ def _evaluate_with_fallback(
     requested_backend = config.paper.agent_backend
     primary = _build_backend(config, requested_backend)
     try:
-        return primary.evaluate(
+        primary_result = primary.evaluate(
             config=config,
             proposal=proposal,
             evidence=evidence,
             status=status,
             account_context=account_context,
+        )
+        return _guardrail_primary_decision(
+            config=config,
+            requested_backend=requested_backend,
+            proposal=proposal,
+            evidence=evidence,
+            status=status,
+            account_context=account_context,
+            primary_result=primary_result,
         )
     except Exception as exc:
         fallback_backend_name = config.paper.agent_fallback_backend

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -234,6 +234,190 @@ def test_agent_worker_overrides_primary_rejection_when_evidence_requires_approva
     assert "requires 'approve'" in proposal["approval_fallback_reason"]
 
 
+def test_agent_worker_does_not_override_rejection_for_under_threshold_consensus(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="claude",
+        agent_model="claude-sonnet-4-5",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    store = PaperStateStore(config)
+    proposal = store.latest_proposal()
+    assert proposal is not None
+    evidence = store.load_evidence(proposal["effective_date"])
+    models = evidence["models"]
+    for index, row in enumerate(models):
+        vote = "long" if index == 0 else "cash"
+        row["vote"] = vote
+        row["target_weight"] = 1.0 if vote == "long" else 0.0
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["long_vote_count"] = 1
+    proposal["cash_vote_count"] = len(models) - 1
+    evidence["decision"] = "long"
+    evidence["target_weight"] = 1.0
+    evidence["long_vote_count"] = 1
+    evidence["cash_vote_count"] = len(models) - 1
+    evidence["consensus_rule"]["min_long_votes"] = 4
+    evidence["consensus_rule"]["model_count"] = len(models)
+    store.update_proposal(proposal)
+    store.save_evidence(evidence)
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    types.SimpleNamespace(
+                        text='{"decision":"reject","rationale":"The proposal does not meet the threshold."}'
+                    )
+                ]
+            )
+
+    class FakeAnthropicClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.messages = FakeMessages()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        types.SimpleNamespace(Anthropic=FakeAnthropicClient),
+    )
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "rejected"
+    assert proposal["approval_backend"] == "claude"
+    assert proposal["approval_model"] == "claude-sonnet-4-5"
+    assert proposal["approval_fallback_used"] is False
+
+
+def test_agent_worker_preserves_primary_decision_when_guardrail_cannot_validate(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="claude",
+        agent_model="claude-sonnet-4-5",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    store = PaperStateStore(config)
+    proposal = store.latest_proposal()
+    assert proposal is not None
+    proposal["target_weight"] = "not-a-float"
+    store.update_proposal(proposal)
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    types.SimpleNamespace(
+                        text='{"decision":"approve","rationale":"Approve the persisted proposal."}'
+                    )
+                ]
+            )
+
+    class FakeAnthropicClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.messages = FakeMessages()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        types.SimpleNamespace(Anthropic=FakeAnthropicClient),
+    )
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_backend"] == "claude"
+    assert proposal["approval_model"] == "claude-sonnet-4-5"
+    assert proposal["approval_fallback_used"] is False
+
+
+def test_agent_worker_fallback_rejects_cleanly_on_malformed_persisted_values(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="openai",
+        agent_model="gpt-4o-mini",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    store = PaperStateStore(config)
+    proposal = store.latest_proposal()
+    assert proposal is not None
+    proposal["target_weight"] = "not-a-float"
+    store.update_proposal(proposal)
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(output_text="not-json")
+
+    class FakeOpenAIClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.responses = FakeResponses()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=FakeOpenAIClient))
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "rejected"
+    assert proposal["approval_backend"] == "deterministic_consensus"
+    assert proposal["approval_model"] == "deterministic_consensus"
+    assert proposal["approval_fallback_used"] is True
+    assert "openai backend failed" in proposal["approval_fallback_reason"]
+
+
 def test_agent_worker_is_idempotent_after_first_approval(monkeypatch, tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
     run_paper_decision(

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -176,6 +176,64 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
     assert "fallback_reason: openai backend failed" in calls[0]["payload"]["text"]
 
 
+def test_agent_worker_overrides_primary_rejection_when_evidence_requires_approval(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path,
+        execution_mode="agent_approval",
+        agent_backend="claude",
+        agent_model="claude-sonnet-4-5",
+    )
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="VOO"),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    types.SimpleNamespace(
+                        text=(
+                            '{"decision":"reject","rationale":"The proposal does not meet '
+                            'the threshold."}'
+                        )
+                    )
+                ]
+            )
+
+    class FakeAnthropicClient:
+        def __init__(self, api_key: str, timeout: int) -> None:
+            self.messages = FakeMessages()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        types.SimpleNamespace(Anthropic=FakeAnthropicClient),
+    )
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="VOO"),
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert proposal is not None
+    assert proposal["approval_status"] == "approved"
+    assert proposal["approval_backend"] == "deterministic_consensus"
+    assert proposal["approval_model"] == "deterministic_consensus"
+    assert proposal["approval_fallback_used"] is True
+    assert "claude backend returned 'reject'" in proposal["approval_fallback_reason"]
+    assert "requires 'approve'" in proposal["approval_fallback_reason"]
+
+
 def test_agent_worker_is_idempotent_after_first_approval(monkeypatch, tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval")
     run_paper_decision(


### PR DESCRIPTION
## Summary
- harden paper approval so persisted consensus-valid proposals cannot be rejected by an inconsistent LLM response
- keep the tracked QQQ paper config on Claude and align the paper-trading docs with that default
- make the launch check script skip `git pull` automatically when the worktree is dirty or the branch is not `master`

## Validation
- py -3.14 -m tox -e preflight
- .tox\py312\Scripts\python.exe -m pytest -q tests/unit/test_paper_agent.py --basetemp .pytest_tmp_agent_guardrail_commit
- .tox\py312\Scripts\python.exe -m pytest -q tests/unit/test_paper_service.py --basetemp .pytest_tmp_service_guardrail
- git diff --check
