### PR TITLE
fix: make paper submit buying-power safe and reconcile broker rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `paper-status`: read the latest persisted paper-trading status plus the latest proposal summary.
 - `paper-approve`: approve or reject one persisted proposal by actor `agent` or `manual`.
 - `paper-agent-approve`: run the autonomous agent worker once or in a loop, using `openai`, `claude`, or deterministic fallback to approve or reject pending proposals.
-- `paper-submit`: reconcile the approved proposal against the Alpaca paper account and persist either a submitted fractional `DAY` market order, a no-op, or a skipped submission.
+- `paper-submit`: reconcile the approved proposal against the Alpaca paper account, refresh any previously submitted broker status, and persist either a submitted buy-side notional `DAY` market order, a submitted sell-side fractional `DAY` market order, a no-op, or a skipped submission.
 - `paper-scheduler`: run the long-lived local paper loop for the configured decision and submission windows.
 - `paper-report`: build a month-run paper report comparing the realized paper path, the consensus path, each model path, `buy_hold`, and `sma`.
 

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -65,7 +65,7 @@ Behavior:
 - `paper-status` reads the latest persisted status plus the latest proposal summary.
 - `paper-approve` records an `approve` or `reject` decision by actor `agent` or `manual`.
 - `paper-agent-approve` runs the autonomous agent worker once or in a loop. It may use `openai`, `claude`, or `deterministic_consensus`, but it may only approve or reject the existing proposal as written.
-- `paper-submit` enforces the approval mode, reconciles against the current paper position, and either submits one fractional `DAY` market order or records a skipped or no-op submission.
+- `paper-submit` enforces the approval mode, refreshes the latest broker order status when a submission already exists, reconciles against the current paper position, and either submits one buy-side notional `DAY` market order, one sell-side fractional `DAY` market order, or records a skipped or no-op submission.
 - `paper-scheduler` is the long-running local loop used by Docker Compose.
 - `paper-report` reconstructs the paper-run outcome over a chosen date range and compares the realized paper path, the consensus path, each model path, `buy_hold`, and `sma`.
 
@@ -195,6 +195,8 @@ docker compose --env-file .env -f docker/compose.paper.yml up -d --build
 ```
 
 The scheduler uses the tracked repo config at `/app/repo/configs/experiment.qqq_paper_daily.yaml` and a writable artifact submount at `/app/repo/artifacts`.
+
+On each loop, the scheduler also refreshes the latest persisted submission against Alpaca so later broker-side terminal states such as `filled` or `rejected` are written back into `submission.json` and `order_status.json`.
 
 The agent worker uses the same tracked config and artifact mount, so the approval loop and the scheduler see the same proposal, approval, and submission state.
 

--- a/src/marketlab/paper/alpaca.py
+++ b/src/marketlab/paper/alpaca.py
@@ -254,6 +254,34 @@ class AlpacaPaperBrokerClient:
             raise RuntimeError("Alpaca order submission response must be an object.")
         return payload
 
+    def submit_notional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        notional: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, Any]:
+        payload = _json_request(
+            method="POST",
+            base_url=self._credentials.trading_base_url,
+            path="/v2/orders",
+            api_key_id=self._credentials.api_key_id,
+            api_secret_key=self._credentials.api_secret_key,
+            timeout_seconds=self._credentials.timeout_seconds,
+            payload={
+                "symbol": symbol,
+                "notional": f"{notional:.2f}",
+                "side": side,
+                "type": "market",
+                "time_in_force": "day",
+                "client_order_id": client_order_id,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise RuntimeError("Alpaca order submission response must be an object.")
+        return payload
+
     def get_order(self, order_id: str) -> dict[str, Any]:
         payload = _json_request(
             method="GET",

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -175,6 +175,9 @@ def build_submission_message(
     qty = (submission or {}).get("qty")
     if qty is not None:
         _append_line(lines, "qty", _format_number(qty))
+    notional = (submission or {}).get("notional")
+    if notional is not None:
+        _append_line(lines, "notional", _format_number(notional))
     _append_line(lines, "order_id", (submission or {}).get("order_id"))
     _append_line(lines, "order_status", (submission or {}).get("order_status"))
     return "\n".join(lines)

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -19,6 +19,7 @@ from marketlab.paper.service import (
     _local_now,
     _now_utc,
     _write_notification_record,
+    reconcile_latest_submission_status,
     run_paper_decision,
     run_paper_submit,
 )
@@ -171,6 +172,20 @@ def run_scheduler_iteration(
         events.append({"phase": "submission", **result})
         state["last_submission_market_date"] = market_date
         state["last_submission_at"] = _now_utc(now).isoformat()
+
+    try:
+        reconciliation = reconcile_latest_submission_status(config, now=now)
+    except Exception as exc:
+        proposal = PaperStateStore(config).latest_proposal()
+        raise PaperLoopStageError(
+            loop_name="scheduler",
+            stage="paper-submit-reconcile",
+            cause=exc,
+            proposal_id=str((proposal or {}).get("proposal_id", "")),
+            trade_date=str((proposal or {}).get("effective_date", "")),
+        ) from exc
+    if reconciliation is not None:
+        events.append({"phase": "submission_reconcile", **reconciliation})
 
     _clear_scheduler_error_state(state)
     state["last_checked_at"] = _now_utc(now).isoformat()

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -1005,6 +1005,26 @@ def _poll_order_status(
     return order_status, poll_status
 
 
+def _latest_submitted_proposal_requiring_reconciliation(
+    store: PaperStateStore,
+) -> tuple[dict[str, Any], dict[str, Any], Path] | None:
+    for proposal in store.list_proposals():
+        trade_date = str(proposal.get("effective_date", ""))
+        if trade_date == "":
+            continue
+        submission_path = store.trade_submission_path(trade_date)
+        if not submission_path.exists():
+            continue
+        submission = _json_load(submission_path)
+        if submission.get("status") != SUBMISSION_SUBMITTED:
+            continue
+        order_status = str(submission.get("order_status", "")).lower()
+        if order_status in TERMINAL_ORDER_STATUSES:
+            continue
+        return proposal, submission, submission_path
+    return None
+
+
 def _refresh_submission_order_status(
     config: ExperimentConfig,
     store: PaperStateStore,
@@ -1068,16 +1088,11 @@ def reconcile_latest_submission_status(
 ) -> dict[str, Any] | None:
     validate_paper_trading_config(config)
     store = PaperStateStore(config)
-    proposal = store.latest_proposal()
-    if proposal is None:
+    latest_submitted = _latest_submitted_proposal_requiring_reconciliation(store)
+    if latest_submitted is None:
         return None
-
-    trade_date = str(proposal["effective_date"])
-    submission_path = store.trade_submission_path(trade_date)
-    if not submission_path.exists():
-        return None
-
-    submission = _json_load(submission_path)
+    proposal, submission, submission_path = latest_submitted
+    trade_date = str(submission["trade_date"])
     broker_client = broker or AlpacaPaperBrokerClient()
     refreshed_submission = _refresh_submission_order_status(
         config,
@@ -1261,7 +1276,12 @@ def run_paper_submit(
         )
         desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
     delta_qty = round(desired_qty - current_qty, 6)
-    side = "buy" if target_weight > 0.0 and order_notional > 0.0 else "sell"
+    if delta_qty > 1e-6:
+        side = "buy"
+    elif delta_qty < -1e-6:
+        side = "sell"
+    else:
+        side = "none"
     order_preview = {
         "proposal_id": proposal["proposal_id"],
         "trade_date": trade_date,
@@ -1275,17 +1295,17 @@ def run_paper_submit(
         "order_notional": order_notional,
         "desired_qty": desired_qty,
         "delta_qty": delta_qty,
-        "side": side if (order_notional > 0.0 or abs(delta_qty) > 0.0) else "none",
+        "side": side,
         "updated_at": _now_utc(now).isoformat(),
     }
     _json_dump(store.trade_order_preview_path(trade_date), order_preview)
 
-    if order_notional <= 1e-6 and abs(delta_qty) < 1e-6:
+    if side == "none" or (side == "buy" and order_notional <= 1e-6):
         submission = {
             "proposal_id": proposal["proposal_id"],
             "trade_date": trade_date,
             "status": SUBMISSION_NOOP,
-            "reason": "already_at_target",
+            "reason": "already_at_target" if side == "none" else "insufficient_buying_power",
             "order_preview_path": str(store.trade_order_preview_path(trade_date)),
             "updated_at": _now_utc(now).isoformat(),
         }

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -44,6 +44,7 @@ SUBMISSION_NOOP = "no_trade_required"
 SUBMISSION_SKIPPED = "skipped"
 CONSENSUS_POLICY = "consensus_vote"
 TERMINAL_ORDER_STATUSES = {"canceled", "expired", "filled", "rejected"}
+FAILED_ORDER_STATUSES = {"canceled", "expired", "rejected"}
 BUY_NOTIONAL_BUFFER_RATIO = 0.99
 
 
@@ -91,8 +92,13 @@ def _safe_float(value: Any, *, default: float = 0.0) -> float:
         return default
 
 
-def _client_order_id(proposal_id: str) -> str:
-    return f"marketlab-{proposal_id}".replace("_", "-")[:48]
+def _client_order_id(proposal_id: str, *, retry_suffix: str = "") -> str:
+    base = f"marketlab-{proposal_id}".replace("_", "-")
+    if retry_suffix == "":
+        return base[:48]
+    suffix = f"-{retry_suffix}".replace("_", "-")
+    max_base_length = max(1, 48 - len(suffix))
+    return f"{base[:max_base_length]}{suffix}"
 
 
 def _position_market_value(position: dict[str, Any] | None, *, reference_price: float) -> float:
@@ -999,12 +1005,126 @@ def _poll_order_status(
     return order_status, poll_status
 
 
+def _refresh_submission_order_status(
+    config: ExperimentConfig,
+    store: PaperStateStore,
+    *,
+    proposal: dict[str, Any],
+    submission: dict[str, Any],
+    broker_client: AlpacaPaperBrokerClient,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if submission.get("status") != SUBMISSION_SUBMITTED:
+        return None
+
+    order_id = str(submission.get("order_id", "")).strip()
+    if order_id == "":
+        return None
+
+    current_order_status = str(submission.get("order_status", "")).lower()
+    if current_order_status in TERMINAL_ORDER_STATUSES:
+        return None
+
+    order_status, poll_status = _poll_order_status(
+        broker_client=broker_client,
+        order_id=order_id,
+        fallback_status=current_order_status or "unknown",
+        client_order_id=str(submission.get("client_order_id", "")),
+    )
+    refreshed_order_status = str(order_status.get("status", current_order_status or "unknown")).lower()
+    current_poll_status = str(submission.get("poll_status", "")).lower()
+    if (
+        refreshed_order_status == current_order_status
+        and poll_status == current_poll_status
+        and store.trade_order_status_path(str(proposal["effective_date"])).exists()
+    ):
+        return None
+
+    trade_date = str(submission["trade_date"])
+    _json_dump(store.trade_order_status_path(trade_date), order_status)
+    refreshed_submission = dict(submission)
+    refreshed_submission["order_status"] = refreshed_order_status
+    refreshed_submission["poll_status"] = poll_status
+    refreshed_submission["order_status_path"] = str(store.trade_order_status_path(trade_date))
+    refreshed_submission["updated_at"] = _now_utc(now).isoformat()
+    _json_dump(store.trade_submission_path(trade_date), refreshed_submission)
+    status = {
+        "event": "paper-submit",
+        "status": refreshed_submission["status"],
+        "proposal_id": refreshed_submission["proposal_id"],
+        "submission_path": str(store.trade_submission_path(trade_date)),
+        "order_status": refreshed_order_status,
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    store.write_status(status)
+    return refreshed_submission
+
+
+def reconcile_latest_submission_status(
+    config: ExperimentConfig,
+    *,
+    now: datetime | None = None,
+    broker: AlpacaPaperBrokerClient | None = None,
+) -> dict[str, Any] | None:
+    validate_paper_trading_config(config)
+    store = PaperStateStore(config)
+    proposal = store.latest_proposal()
+    if proposal is None:
+        return None
+
+    trade_date = str(proposal["effective_date"])
+    submission_path = store.trade_submission_path(trade_date)
+    if not submission_path.exists():
+        return None
+
+    submission = _json_load(submission_path)
+    broker_client = broker or AlpacaPaperBrokerClient()
+    refreshed_submission = _refresh_submission_order_status(
+        config,
+        store,
+        proposal=proposal,
+        submission=submission,
+        broker_client=broker_client,
+        now=now,
+    )
+    if refreshed_submission is None:
+        return None
+
+    return {
+        "proposal_id": proposal["proposal_id"],
+        "submission_path": str(submission_path),
+        "order_status_path": str(store.trade_order_status_path(trade_date)),
+        "order_status": refreshed_submission["order_status"],
+        "poll_status": refreshed_submission.get("poll_status", ""),
+    }
+
+
+def _backup_submission_attempt_artifacts(
+    store: PaperStateStore,
+    *,
+    trade_date: str,
+    now: datetime | None = None,
+) -> None:
+    timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
+    for path in (
+        store.trade_submission_path(trade_date),
+        store.trade_order_status_path(trade_date),
+        store.trade_order_preview_path(trade_date),
+        store.trade_account_snapshot_path(trade_date),
+    ):
+        if not path.exists():
+            continue
+        backup_path = path.with_name(f"{path.stem}.retry-backup.{timestamp}.bak")
+        path.rename(backup_path)
+
+
 def run_paper_submit(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
     broker: AlpacaPaperBrokerClient | None = None,
     notification_transport: TelegramTransport | None = None,
+    retry_failed_submission: bool = False,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     paper_symbol = _paper_symbol(config)
@@ -1028,44 +1148,62 @@ def run_paper_submit(
         )
         return {"status_path": str(status_path), "status": status}
 
-    local_now = _local_now(config, now)
-    submission_clock = _clock_value(config.paper.submission_time)
-    if local_now.time() < submission_clock:
-        raise RuntimeError(
-            "paper-submit is only allowed at or after "
-            f"{config.paper.submission_time} {config.paper.schedule_timezone}."
-        )
-
     trade_date = proposal["effective_date"]
     submission_path = store.trade_submission_path(trade_date)
     if submission_path.exists():
         submission = _json_load(submission_path)
-        status = {
-            "event": "paper-submit",
-            "status": "existing_submission",
-            "proposal_id": proposal["proposal_id"],
-            "submission_path": str(submission_path),
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        _notify_paper_submission(
+        broker_client = broker or AlpacaPaperBrokerClient()
+        refreshed_submission = _refresh_submission_order_status(
             config,
             store,
-            outcome="existing_submission",
-            status=status,
             proposal=proposal,
             submission=submission,
+            broker_client=broker_client,
             now=now,
-            transport=notification_transport,
         )
-        return {
-            "submission_path": str(submission_path),
-            "status_path": str(status_path),
-            "status": status,
-            "submission": submission,
-        }
+        if refreshed_submission is not None:
+            submission = refreshed_submission
+        order_status = str(submission.get("order_status", "")).lower()
+        if not retry_failed_submission or order_status not in FAILED_ORDER_STATUSES:
+            status = {
+                "event": "paper-submit",
+                "status": "existing_submission",
+                "proposal_id": proposal["proposal_id"],
+                "submission_path": str(submission_path),
+                "order_status": submission.get("order_status", ""),
+                "updated_at": _now_utc(now).isoformat(),
+            }
+            status_path = store.write_status(status)
+            _notify_paper_submission(
+                config,
+                store,
+                outcome="existing_submission",
+                status=status,
+                proposal=proposal,
+                submission=submission,
+                now=now,
+                transport=notification_transport,
+            )
+            return {
+                "submission_path": str(submission_path),
+                "status_path": str(status_path),
+                "status": status,
+                "submission": submission,
+            }
 
-    broker_client = broker or AlpacaPaperBrokerClient()
+        _backup_submission_attempt_artifacts(store, trade_date=trade_date, now=now)
+        retry_suffix = _now_utc(now).strftime("retry%H%M%S")
+    else:
+        local_now = _local_now(config, now)
+        submission_clock = _clock_value(config.paper.submission_time)
+        if local_now.time() < submission_clock:
+            raise RuntimeError(
+                "paper-submit is only allowed at or after "
+                f"{config.paper.submission_time} {config.paper.schedule_timezone}."
+            )
+        broker_client = broker or AlpacaPaperBrokerClient()
+        retry_suffix = ""
+
     gate_status, gate_reason = _submission_gate_status(config, proposal)
     if gate_status != "ready":
         submission = {
@@ -1122,7 +1260,6 @@ def run_paper_submit(
             target_weight=target_weight,
         )
         desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
-
     delta_qty = round(desired_qty - current_qty, 6)
     side = "buy" if target_weight > 0.0 and order_notional > 0.0 else "sell"
     order_preview = {
@@ -1178,7 +1315,7 @@ def run_paper_submit(
             "submission": submission,
         }
 
-    client_order_id = _client_order_id(proposal["proposal_id"])
+    client_order_id = _client_order_id(proposal["proposal_id"], retry_suffix=retry_suffix)
     if side == "buy":
         order = broker_client.submit_notional_day_market_order(
             symbol=paper_symbol,

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -44,6 +44,7 @@ SUBMISSION_NOOP = "no_trade_required"
 SUBMISSION_SKIPPED = "skipped"
 CONSENSUS_POLICY = "consensus_vote"
 TERMINAL_ORDER_STATUSES = {"canceled", "expired", "filled", "rejected"}
+BUY_NOTIONAL_BUFFER_RATIO = 0.99
 
 
 def _now_utc(now: datetime | None = None) -> datetime:
@@ -81,6 +82,39 @@ def _json_dump(path: Path, payload: dict[str, Any]) -> Path:
 
 def _json_load(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _safe_float(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _client_order_id(proposal_id: str) -> str:
+    return f"marketlab-{proposal_id}".replace("_", "-")[:48]
+
+
+def _position_market_value(position: dict[str, Any] | None, *, reference_price: float) -> float:
+    if position is None:
+        return 0.0
+    market_value = _safe_float(position.get("market_value"), default=float("nan"))
+    if pd.notna(market_value):
+        return abs(market_value)
+    return abs(_safe_float(position.get("qty"))) * reference_price
+
+
+def _buy_order_notional(
+    *,
+    equity: float,
+    buying_power: float,
+    current_market_value: float,
+    target_weight: float,
+) -> tuple[float, float]:
+    desired_notional = max(equity * target_weight * BUY_NOTIONAL_BUFFER_RATIO, 0.0)
+    available_notional = max(buying_power * BUY_NOTIONAL_BUFFER_RATIO, 0.0)
+    order_notional = min(max(desired_notional - current_market_value, 0.0), available_notional)
+    return desired_notional, order_notional
 
 
 def _paper_symbol(config: ExperimentConfig) -> str:
@@ -404,6 +438,7 @@ def _notify_paper_submission(
         "reason": (submission or {}).get("reason") or status.get("reason"),
         "side": (submission or {}).get("side"),
         "qty": (submission or {}).get("qty"),
+        "notional": (submission or {}).get("notional"),
         "order_id": (submission or {}).get("order_id"),
         "order_status": (submission or {}).get("order_status"),
     }
@@ -943,6 +978,27 @@ def _submission_gate_status(
     return "ready", ""
 
 
+def _poll_order_status(
+    *,
+    broker_client: AlpacaPaperBrokerClient,
+    order_id: str,
+    fallback_status: str,
+    client_order_id: str,
+) -> tuple[dict[str, Any], str]:
+    try:
+        order_status = broker_client.get_order(order_id)
+        poll_status = "observed"
+    except RuntimeError as exc:
+        order_status = {
+            "id": order_id,
+            "client_order_id": client_order_id,
+            "status": fallback_status,
+            "poll_error": str(exc),
+        }
+        poll_status = "timeout"
+    return order_status, poll_status
+
+
 def run_paper_submit(
     config: ExperimentConfig,
     *,
@@ -1049,30 +1105,45 @@ def run_paper_submit(
     account = broker_client.get_account()
     _json_dump(store.trade_account_snapshot_path(trade_date), account)
     position = broker_client.get_position(paper_symbol)
-    current_qty = float(position["qty"]) if position is not None else 0.0
-    equity = float(account["equity"])
+    current_qty = _safe_float((position or {}).get("qty"))
+    current_market_value = _position_market_value(position, reference_price=float(proposal["reference_price"]))
+    equity = _safe_float(account.get("equity"))
+    buying_power = _safe_float(account.get("buying_power"), default=_safe_float(account.get("cash"), default=equity))
     reference_price = float(proposal["reference_price"])
+    target_weight = _safe_float(proposal.get("target_weight"))
+    desired_notional = 0.0
+    order_notional = 0.0
     desired_qty = 0.0
-    if float(proposal["target_weight"]) > 0.0:
-        desired_qty = equity / reference_price
+    if target_weight > 0.0:
+        desired_notional, order_notional = _buy_order_notional(
+            equity=equity,
+            buying_power=buying_power,
+            current_market_value=current_market_value,
+            target_weight=target_weight,
+        )
+        desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
 
     delta_qty = round(desired_qty - current_qty, 6)
-    side = "buy" if delta_qty > 0.0 else "sell"
+    side = "buy" if target_weight > 0.0 and order_notional > 0.0 else "sell"
     order_preview = {
         "proposal_id": proposal["proposal_id"],
         "trade_date": trade_date,
         "symbol": paper_symbol,
         "equity": equity,
+        "buying_power": buying_power,
         "reference_price": reference_price,
         "current_qty": current_qty,
+        "current_market_value": current_market_value,
+        "desired_notional": desired_notional,
+        "order_notional": order_notional,
         "desired_qty": desired_qty,
         "delta_qty": delta_qty,
-        "side": side if abs(delta_qty) > 0.0 else "none",
+        "side": side if (order_notional > 0.0 or abs(delta_qty) > 0.0) else "none",
         "updated_at": _now_utc(now).isoformat(),
     }
     _json_dump(store.trade_order_preview_path(trade_date), order_preview)
 
-    if abs(delta_qty) < 1e-6:
+    if order_notional <= 1e-6 and abs(delta_qty) < 1e-6:
         submission = {
             "proposal_id": proposal["proposal_id"],
             "trade_date": trade_date,
@@ -1107,24 +1178,27 @@ def run_paper_submit(
             "submission": submission,
         }
 
-    client_order_id = f"marketlab-{proposal['proposal_id']}".replace("_", "-")[:48]
-    order = broker_client.submit_fractional_day_market_order(
-        symbol=paper_symbol,
-        qty=abs(delta_qty),
-        side=side,
-        client_order_id=client_order_id,
+    client_order_id = _client_order_id(proposal["proposal_id"])
+    if side == "buy":
+        order = broker_client.submit_notional_day_market_order(
+            symbol=paper_symbol,
+            notional=order_notional,
+            side=side,
+            client_order_id=client_order_id,
+        )
+    else:
+        order = broker_client.submit_fractional_day_market_order(
+            symbol=paper_symbol,
+            qty=abs(delta_qty),
+            side=side,
+            client_order_id=client_order_id,
+        )
+    order_status, poll_status = _poll_order_status(
+        broker_client=broker_client,
+        order_id=str(order["id"]),
+        fallback_status=str(order.get("status", "unknown")),
+        client_order_id=str(order.get("client_order_id", client_order_id)),
     )
-    try:
-        order_status = broker_client.get_order(str(order["id"]))
-        poll_status = "observed"
-    except RuntimeError as exc:
-        order_status = {
-            "id": order.get("id"),
-            "client_order_id": order.get("client_order_id", client_order_id),
-            "status": order.get("status", "unknown"),
-            "poll_error": str(exc),
-        }
-        poll_status = "timeout"
     _json_dump(store.trade_order_status_path(trade_date), order_status)
 
     submission = {
@@ -1132,10 +1206,11 @@ def run_paper_submit(
         "trade_date": trade_date,
         "status": SUBMISSION_SUBMITTED,
         "side": side,
-        "qty": abs(delta_qty),
+        "qty": abs(delta_qty) if side == "sell" else None,
+        "notional": order_notional if side == "buy" else None,
         "order_id": order["id"],
         "client_order_id": order.get("client_order_id", client_order_id),
-        "order_status": order_status.get("status", order.get("status", "unknown")),
+        "order_status": str(order_status.get("status", order.get("status", "unknown"))).lower(),
         "poll_status": poll_status,
         "order_preview_path": str(store.trade_order_preview_path(trade_date)),
         "account_snapshot_path": str(store.trade_account_snapshot_path(trade_date)),
@@ -1148,6 +1223,7 @@ def run_paper_submit(
         "status": SUBMISSION_SUBMITTED,
         "proposal_id": proposal["proposal_id"],
         "submission_path": str(submission_path),
+        "order_status": submission["order_status"],
         "updated_at": _now_utc(now).isoformat(),
     }
     status_path = store.write_status(status)

--- a/tests/_paper_fakes.py
+++ b/tests/_paper_fakes.py
@@ -152,7 +152,10 @@ class FakeAlpacaBroker:
         *,
         trading_days: Sequence[date] | None = None,
         equity: float = 10_000.0,
+        buying_power: float | None = None,
+        cash: float | None = None,
         current_qty: float = 0.0,
+        market_price: float = 100.0,
         order_status: str = "accepted",
         symbol: str = "VOO",
     ) -> None:
@@ -162,7 +165,10 @@ class FakeAlpacaBroker:
             )
         self.trading_days = list(trading_days)
         self.equity = equity
+        self.buying_power = buying_power if buying_power is not None else equity
+        self.cash = cash if cash is not None else self.buying_power
         self.current_qty = current_qty
+        self.market_price = market_price
         self.order_status = order_status
         self.symbol = symbol
         self.submitted_orders: list[dict[str, object]] = []
@@ -178,13 +184,19 @@ class FakeAlpacaBroker:
         return {
             "account_number": "PA123456",
             "equity": f"{self.equity:.2f}",
+            "buying_power": f"{self.buying_power:.2f}",
+            "cash": f"{self.cash:.2f}",
             "status": "ACTIVE",
         }
 
     def get_position(self, symbol: str) -> dict[str, object] | None:
         if symbol != self.symbol or self.current_qty == 0.0:
             return None
-        return {"symbol": symbol, "qty": f"{self.current_qty:.6f}"}
+        return {
+            "symbol": symbol,
+            "qty": f"{self.current_qty:.6f}",
+            "market_value": f"{self.current_qty * self.market_price:.2f}",
+        }
 
     def submit_fractional_day_market_order(
         self,
@@ -207,6 +219,29 @@ class FakeAlpacaBroker:
             self.current_qty += qty
         else:
             self.current_qty = max(0.0, self.current_qty - qty)
+        return order
+
+    def submit_notional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        notional: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, object]:
+        order = {
+            "id": f"order-{len(self.submitted_orders) + 1}",
+            "symbol": symbol,
+            "notional": f"{notional:.2f}",
+            "side": side,
+            "client_order_id": client_order_id,
+            "status": self.order_status,
+        }
+        self.submitted_orders.append(order)
+        if side == "buy" and self.market_price > 0:
+            self.current_qty += notional / self.market_price
+            self.buying_power = max(0.0, self.buying_power - notional)
+            self.cash = max(0.0, self.cash - notional)
         return order
 
     def get_order(self, order_id: str) -> dict[str, object]:

--- a/tests/unit/test_paper_alpaca.py
+++ b/tests/unit/test_paper_alpaca.py
@@ -53,10 +53,23 @@ class _FakeAlpacaHandler(BaseHTTPRequestHandler):
             )
             return
         if parsed.path == "/v2/account":
-            self._json_response({"equity": "10000.00", "status": "ACTIVE"})
+            self._json_response(
+                {
+                    "equity": "10000.00",
+                    "buying_power": "10000.00",
+                    "cash": "10000.00",
+                    "status": "ACTIVE",
+                }
+            )
             return
         if parsed.path == "/v2/positions/VOO":
-            self._json_response({"symbol": "VOO", "qty": "0.250000"})
+            self._json_response(
+                {
+                    "symbol": "VOO",
+                    "qty": "0.250000",
+                    "market_value": "25.00",
+                }
+            )
             return
         if parsed.path == "/v2/orders/order-1":
             self._json_response(
@@ -74,13 +87,16 @@ class _FakeAlpacaHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v2/orders":
             length = int(self.headers.get("Content-Length", "0"))
             payload = json.loads(self.rfile.read(length).decode("utf-8"))
-            self._json_response(
-                {
-                    "id": "order-1",
-                    "status": "accepted",
-                    "client_order_id": payload["client_order_id"],
-                }
-            )
+            response = {
+                "id": "order-1",
+                "status": "accepted",
+                "client_order_id": payload["client_order_id"],
+            }
+            if "qty" in payload:
+                response["qty"] = payload["qty"]
+            if "notional" in payload:
+                response["notional"] = payload["notional"]
+            self._json_response(response)
             return
         self.send_error(404)
 
@@ -132,6 +148,12 @@ def test_alpaca_clients_parse_local_fake_server(
         client_order_id="marketlab-test-order",
     )
     order_status = broker.get_order("order-1")
+    notional_order = broker.submit_notional_day_market_order(
+        symbol="VOO",
+        notional=500.0,
+        side="buy",
+        client_order_id="marketlab-test-notional",
+    )
 
     assert list(frame.columns) == ["Date", "Open", "High", "Low", "Close", "Adj Close", "Volume"]
     assert len(frame) == 2
@@ -140,6 +162,7 @@ def test_alpaca_clients_parse_local_fake_server(
     assert position["qty"] == "0.250000"
     assert order["id"] == "order-1"
     assert order_status["status"] == "accepted"
+    assert notional_order["notional"] == "500.00"
 
 
 def test_alpaca_client_reads_configured_symbol_position(

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -44,8 +44,12 @@ def test_scheduler_iteration_runs_each_phase_once_per_market_date(
         events.append("submission")
         return {"submission_path": "submission.json", "status_path": "status.json", "status": {}}
 
+    def _fake_reconcile(*args, **kwargs):
+        return None
+
     monkeypatch.setattr(scheduler, "run_paper_decision", _fake_decision)
     monkeypatch.setattr(scheduler, "run_paper_submit", _fake_submit)
+    monkeypatch.setattr(scheduler, "reconcile_latest_submission_status", _fake_reconcile)
 
     first = scheduler.run_scheduler_iteration(
         config,
@@ -59,6 +63,32 @@ def test_scheduler_iteration_runs_each_phase_once_per_market_date(
     assert [event["phase"] for event in first["events"]] == ["decision", "submission"]
     assert second["events"] == []
     assert events == ["decision", "submission"]
+
+
+def test_scheduler_iteration_appends_submission_reconciliation_events(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path)
+
+    monkeypatch.setattr(
+        scheduler,
+        "reconcile_latest_submission_status",
+        lambda *args, **kwargs: {
+            "proposal_id": "proposal-1",
+            "order_status": "rejected",
+            "submission_path": "submission.json",
+            "order_status_path": "order_status.json",
+            "poll_status": "observed",
+        },
+    )
+
+    result = scheduler.run_scheduler_iteration(
+        config,
+        now=datetime(2026, 4, 10, 18, 0, tzinfo=UTC),
+    )
+
+    assert [event["phase"] for event in result["events"]] == ["submission_reconcile"]
 
 
 def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -296,6 +296,40 @@ def test_run_paper_submit_uses_notional_buy_buffer_for_long_entries(tmp_path: Pa
     assert broker.submitted_orders[-1]["notional"] == "990.00"
 
 
+def test_run_paper_submit_does_not_sell_when_long_signal_has_no_buying_power(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", equity=1000.0, buying_power=0.0, cash=0.0)
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )["submission"]
+
+    assert submission["status"] == "no_trade_required"
+    assert submission["reason"] == "insufficient_buying_power"
+    assert not broker.submitted_orders
+
+
 def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
     broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")
@@ -337,6 +371,58 @@ def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path:
     assert reconciliation is not None
     assert reconciliation["order_status"] == "rejected"
     assert submission["order_status"] == "rejected"
+
+
+def test_reconcile_latest_submission_status_uses_latest_submitted_trade(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    newer_proposal = dict(proposal)
+    newer_proposal["proposal_id"] = "2026-04-14-QQQ-2026-04-13"
+    newer_proposal["signal_date"] = "2026-04-13"
+    newer_proposal["effective_date"] = "2026-04-14"
+    newer_proposal["approval_status"] = "pending"
+    newer_proposal["approval_actor"] = ""
+    store.save_proposal(newer_proposal)
+
+    broker.order_status = "rejected"
+    reconciliation = reconcile_latest_submission_status(
+        config,
+        now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),
+        broker=broker,
+    )
+
+    older_submission = json.loads(
+        store.trade_submission_path("2026-04-13").read_text(encoding="utf-8")
+    )
+    assert reconciliation is not None
+    assert reconciliation["proposal_id"] == proposal_result["proposal_id"]
+    assert reconciliation["order_status"] == "rejected"
+    assert older_submission["order_status"] == "rejected"
 
 
 def test_run_paper_submit_can_retry_failed_submission(tmp_path: Path) -> None:

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -16,6 +16,7 @@ from marketlab.paper.service import (
     decide_paper_proposal,
     get_paper_status,
     read_paper_evidence,
+    reconcile_latest_submission_status,
     run_paper_decision,
     run_paper_submit,
 )
@@ -293,6 +294,92 @@ def test_run_paper_submit_uses_notional_buy_buffer_for_long_entries(tmp_path: Pa
     assert submission["notional"] == pytest.approx(990.0)
     assert submission["qty"] is None
     assert broker.submitted_orders[-1]["notional"] == "990.00"
+
+
+def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    broker.order_status = "rejected"
+    reconciliation = reconcile_latest_submission_status(
+        config,
+        now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),
+        broker=broker,
+    )
+
+    submission = json.loads(
+        (PaperStateStore(config).trade_submission_path("2026-04-13")).read_text(encoding="utf-8")
+    )
+    assert reconciliation is not None
+    assert reconciliation["order_status"] == "rejected"
+    assert submission["order_status"] == "rejected"
+
+
+def test_run_paper_submit_can_retry_failed_submission(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", order_status="rejected")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    first_submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )["submission"]
+
+    broker.order_status = "accepted"
+    second_submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),
+        broker=broker,
+        retry_failed_submission=True,
+    )["submission"]
+
+    trade_dir = PaperStateStore(config).trade_dir("2026-04-13")
+    assert first_submission["order_status"] == "rejected"
+    assert second_submission["order_status"] == "accepted"
+    assert second_submission["client_order_id"] != first_submission["client_order_id"]
+    assert list(trade_dir.glob("submission.retry-backup.*.bak"))
 
 
 def test_run_paper_decision_notifies_existing_proposal(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -245,10 +245,54 @@ def test_run_paper_submit_places_fractional_order_after_agent_approval(monkeypat
     assert len(calls) == 1
     if submission["status"] == "submitted":
         assert broker.submitted_orders
+        order = broker.submitted_orders[-1]
         assert submission["order_status"] == "accepted"
+        if submission["side"] == "buy":
+            assert "notional" in order
+            assert submission["notional"] is not None
+            assert submission["qty"] is None
+        else:
+            assert "qty" in order
         assert "outcome: submitted" in calls[0]["payload"]["text"]
     else:
         assert "outcome: no_trade_required" in calls[0]["payload"]["text"]
+
+
+def test_run_paper_submit_uses_notional_buy_buffer_for_long_entries(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", equity=1000.0, buying_power=1000.0, cash=1000.0)
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission_result = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    submission = submission_result["submission"]
+    assert submission["status"] == "submitted"
+    assert submission["side"] == "buy"
+    assert submission["notional"] == pytest.approx(990.0)
+    assert submission["qty"] is None
+    assert broker.submitted_orders[-1]["notional"] == "990.00"
 
 
 def test_run_paper_decision_notifies_existing_proposal(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- size buy-side paper entries with a buffered notional order instead of a raw fractional qty
- reconcile persisted paper submissions against later broker terminal states and keep retry recovery artifacts
- document the updated `paper-submit` and scheduler reconciliation behavior

## Validation
- `.\\.tox\\py312\\Scripts\\python.exe -m pytest -q tests/unit/test_paper_alpaca.py tests/unit/test_paper_service.py --basetemp .pytest_tmp_commit1`
- `.\\.tox\\lint\\Scripts\\python.exe -m ruff check src/marketlab/paper/alpaca.py src/marketlab/paper/service.py src/marketlab/paper/notifications.py tests/_paper_fakes.py tests/unit/test_paper_alpaca.py tests/unit/test_paper_service.py`
- `.\\.tox\\py312\\Scripts\\python.exe -m pytest -q tests/unit/test_paper_alpaca.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py --basetemp .pytest_tmp_commit2`
- `.\\.tox\\lint\\Scripts\\python.exe -m ruff check src/marketlab/paper/alpaca.py src/marketlab/paper/service.py src/marketlab/paper/scheduler.py src/marketlab/paper/notifications.py tests/_paper_fakes.py tests/unit/test_paper_alpaca.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py`
- `py -3.14 -m tox -e preflight`
- `git diff --check`

## Notes
- validated against the April 17, 2026 paper-order rejection scenario and a successful replacement fill on the same paper account
- no new CLI flag or MCP tool is added; retry remains service-internal