### PR TITLE
fix: hold existing long paper positions on repeat signals

### DIFF
--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -1269,7 +1269,12 @@ def run_paper_submit(
     buying_power = _safe_float(account.get("buying_power"), default=_safe_float(account.get("cash"), default=equity))
     reference_price = float(proposal["reference_price"])
     target_weight = _safe_float(proposal.get("target_weight"))
-    hold_existing_long = target_weight > 0.0 and current_market_value >= ALPACA_MIN_NOTIONAL_ORDER
+    current_signed_market_value = current_qty * reference_price
+    hold_existing_long = (
+        target_weight > 0.0
+        and current_qty > 0.0
+        and current_market_value >= ALPACA_MIN_NOTIONAL_ORDER
+    )
     desired_notional = 0.0
     order_notional = 0.0
     gap_notional = 0.0
@@ -1282,10 +1287,10 @@ def run_paper_submit(
             desired_notional, order_notional = _buy_order_notional(
                 equity=equity,
                 buying_power=buying_power,
-                current_market_value=current_market_value,
+                current_market_value=current_signed_market_value,
                 target_weight=target_weight,
             )
-            gap_notional = max(desired_notional - current_market_value, 0.0)
+            gap_notional = max(desired_notional - current_signed_market_value, 0.0)
             order_notional = _rounded_notional(order_notional)
             desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
     delta_qty = round(desired_qty - current_qty, 6)

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -46,6 +46,7 @@ CONSENSUS_POLICY = "consensus_vote"
 TERMINAL_ORDER_STATUSES = {"canceled", "expired", "filled", "rejected"}
 FAILED_ORDER_STATUSES = {"canceled", "expired", "rejected"}
 BUY_NOTIONAL_BUFFER_RATIO = 0.99
+ALPACA_MIN_NOTIONAL_ORDER = 1.0
 
 
 def _now_utc(now: datetime | None = None) -> datetime:
@@ -121,6 +122,10 @@ def _buy_order_notional(
     available_notional = max(buying_power * BUY_NOTIONAL_BUFFER_RATIO, 0.0)
     order_notional = min(max(desired_notional - current_market_value, 0.0), available_notional)
     return desired_notional, order_notional
+
+
+def _rounded_notional(value: float) -> float:
+    return float(f"{max(value, 0.0):.2f}")
 
 
 def _paper_symbol(config: ExperimentConfig) -> str:
@@ -1264,17 +1269,25 @@ def run_paper_submit(
     buying_power = _safe_float(account.get("buying_power"), default=_safe_float(account.get("cash"), default=equity))
     reference_price = float(proposal["reference_price"])
     target_weight = _safe_float(proposal.get("target_weight"))
+    hold_existing_long = target_weight > 0.0 and current_market_value >= ALPACA_MIN_NOTIONAL_ORDER
     desired_notional = 0.0
     order_notional = 0.0
+    gap_notional = 0.0
     desired_qty = 0.0
     if target_weight > 0.0:
-        desired_notional, order_notional = _buy_order_notional(
-            equity=equity,
-            buying_power=buying_power,
-            current_market_value=current_market_value,
-            target_weight=target_weight,
-        )
-        desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
+        if hold_existing_long:
+            desired_notional = current_market_value
+            desired_qty = current_qty
+        else:
+            desired_notional, order_notional = _buy_order_notional(
+                equity=equity,
+                buying_power=buying_power,
+                current_market_value=current_market_value,
+                target_weight=target_weight,
+            )
+            gap_notional = max(desired_notional - current_market_value, 0.0)
+            order_notional = _rounded_notional(order_notional)
+            desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
     delta_qty = round(desired_qty - current_qty, 6)
     if delta_qty > 1e-6:
         side = "buy"
@@ -1300,12 +1313,15 @@ def run_paper_submit(
     }
     _json_dump(store.trade_order_preview_path(trade_date), order_preview)
 
-    if side == "none" or (side == "buy" and order_notional <= 1e-6):
+    if side == "none" or (side == "buy" and order_notional < ALPACA_MIN_NOTIONAL_ORDER):
+        buy_reason = "already_at_target"
+        if _rounded_notional(gap_notional) >= ALPACA_MIN_NOTIONAL_ORDER:
+            buy_reason = "insufficient_buying_power"
         submission = {
             "proposal_id": proposal["proposal_id"],
             "trade_date": trade_date,
             "status": SUBMISSION_NOOP,
-            "reason": "already_at_target" if side == "none" else "insufficient_buying_power",
+            "reason": "already_at_target" if side == "none" else buy_reason,
             "order_preview_path": str(store.trade_order_preview_path(trade_date)),
             "updated_at": _now_utc(now).isoformat(),
         }

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -412,6 +412,49 @@ def test_run_paper_submit_treats_sub_dollar_long_gap_as_already_at_target(tmp_pa
     assert not broker.submitted_orders
 
 
+def test_run_paper_submit_covers_short_position_on_long_signal(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=1000.0,
+        cash=1000.0,
+        current_qty=-1.0,
+        market_price=500.0,
+    )
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 500.0
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )["submission"]
+
+    assert submission["status"] == "submitted"
+    assert submission["side"] == "buy"
+    assert submission["notional"] == 990.0
+    assert broker.submitted_orders[-1]["side"] == "buy"
+    assert broker.submitted_orders[-1]["notional"] == "990.00"
+
+
 def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
     broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -330,6 +330,88 @@ def test_run_paper_submit_does_not_sell_when_long_signal_has_no_buying_power(tmp
     assert not broker.submitted_orders
 
 
+def test_run_paper_submit_does_not_top_up_existing_long_position(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=500.0,
+        cash=500.0,
+        current_qty=1.0,
+        market_price=500.0,
+    )
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 500.0
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )["submission"]
+
+    assert submission["status"] == "no_trade_required"
+    assert submission["reason"] == "already_at_target"
+    assert not broker.submitted_orders
+
+
+def test_run_paper_submit_treats_sub_dollar_long_gap_as_already_at_target(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=999.37,
+        buying_power=10.0,
+        cash=10.0,
+        current_qty=1.525090041,
+        market_price=648.73,
+    )
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 648.73
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+
+    submission = run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )["submission"]
+
+    assert submission["status"] == "no_trade_required"
+    assert submission["reason"] == "already_at_target"
+    assert not broker.submitted_orders
+
+
 def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
     broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")
@@ -454,6 +536,7 @@ def test_run_paper_submit_can_retry_failed_submission(tmp_path: Path) -> None:
     )["submission"]
 
     broker.order_status = "accepted"
+    broker.current_qty = 0.0
     second_submission = run_paper_submit(
         config,
         now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),


### PR DESCRIPTION
This fixes a paper-submit edge case in the local unattended ETF flow.

## What changed
- treat repeated long signals as hold/no-op when the paper account already has a real long position
- round buy notionals to broker precision before submit/no-op decisions
- treat sub-dollar residual long gaps as `already_at_target` instead of sending a 422-producing Alpaca order
- cover existing-long hold and sub-dollar residual-gap behavior in paper service tests

## Validation
- `.\\.tox\\py312\\Scripts\\python.exe -m pytest -q tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py --basetemp .pytest_tmp_hold_existing_long_pr`
- `.\\.tox\\lint\\Scripts\\python.exe -m ruff check src/marketlab/paper/service.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py`
- `py -3.14 -m tox -e preflight`

## Context
Validated against the real April 17, 2026 paper-account scenario where the account already held `QQQ` and the scheduler was looping on Alpaca 422 errors from a residual buy notional below the broker minimum.
