### PR TITLE
docs: add tracked implementation roadmap for hardening phases 1 to 6

### DIFF
--- a/CLOUD_MIGRATION_PLAN.md
+++ b/CLOUD_MIGRATION_PLAN.md
@@ -1,0 +1,516 @@
+# Cloud Migration Plan
+
+## Purpose
+
+This document records the agreed long-term migration plan for moving MarketLab paper trading from the current local Docker plus file-backed runtime into a production-capable Google Cloud architecture.
+
+It is a planning and decision document, not an implementation record. The current local laptop setup remains the active runtime until the cloud migration work begins.
+
+Implementation is deferred until **April 27, 2026** or later.
+
+## Current State
+
+### Runtime Today
+
+The current paper-trading runtime is local and intentionally narrow:
+
+- local Docker Compose
+- `marketlab-paper-scheduler`
+- `marketlab-paper-agent`
+- `marketlab-paper-mcp`
+- file-backed shared state under `artifacts/paper/`
+- Telegram notifications for operational events
+- `30` second poll loops for scheduler and agent worker
+
+### Current Strengths
+
+- simple local recovery and inspection
+- explicit JSON artifacts for proposal, approval, submission, and order state
+- deterministic fallback path for approvals
+- working end-to-end paper-trading flow
+- clear local debugging path through artifacts, Telegram, and Docker logs
+
+### Current Limits
+
+- always-on polling is acceptable locally but is not the desired production control-plane shape
+- local filesystem state does not provide production-grade concurrency, durability, or multi-deployment isolation
+- no environment separation between dev, UAT, and prod
+- no cloud-native scheduling or queueing model
+- no centralized structured observability
+- no canonical deployment registry for multiple paper accounts or strategy variants
+
+## Locked Decisions
+
+### Runtime Model
+
+The first production-grade target is **managed-first GCP**, not Kubernetes-first:
+
+- **Cloud Run private service** for control-plane execution
+- **Cloud Scheduler** for time-based phase triggers
+- **Cloud Tasks** for async follow-up work and retries
+
+### State And Artifacts
+
+- **Cloud SQL Postgres** for canonical workflow state
+- **GCS** for artifacts and reports
+
+### Secrets
+
+- **Secret Manager**
+
+### Observability
+
+- **Cloud Logging**
+- **Cloud Monitoring**
+- **Error Reporting**
+- **Cloud Trace**
+- **OpenTelemetry instrumentation** for portability
+
+### Environment Model
+
+- separate **dev**, **uat**, and **prod** environments
+- separate GCP projects per environment
+
+### MCP Role
+
+MCP remains:
+
+- inspection
+- approval
+- troubleshooting
+
+MCP is explicitly **not** part of runtime orchestration.
+
+### Scale Target
+
+The first cloud architecture should optimize for:
+
+- **1-10 paper deployments/accounts**
+
+### GKE Posture
+
+GKE is explicitly deferred. Revisit it only if the managed-first design reaches concrete scale or control-plane limits.
+
+## Constraints
+
+- No production implementation before **April 27, 2026**.
+- The current local paper flow must keep working until the cloud control plane is ready.
+- Alpaca, OpenAI, Anthropic, and Telegram credentials must never be committed to source control.
+- The migrated design must preserve the current artifact semantics:
+  - proposal
+  - evidence
+  - approval
+  - order preview
+  - submission
+  - order status
+  - reports
+  - notification audit records
+- The production design must support multiple paper deployments without duplicating code per account.
+- The first cloud architecture should minimize ops burden and cost.
+- The first cloud architecture should avoid introducing Kubernetes unless there is a concrete need.
+- Existing local CLI and Docker-based development workflows should remain usable during the migration period.
+
+## Pre-Cloud Hardening Decisions
+
+Before hosted runtime work begins, the codebase should be hardened into a modular monolith.
+
+Locked pre-cloud decisions:
+
+- do not start with deployed microservices
+- the first production-oriented refactor target is the paper control plane
+- use one transactional control store as the future system of record
+- keep the application persistence boundary DB-agnostic
+- keep artifacts separate from canonical transactional state
+- keep MCP out of the execution path
+- preserve existing research timing and artifact contracts by default during the hardening track
+
+The companion audit document is:
+
+- [`docs/solid-architecture-audit.md`](docs/solid-architecture-audit.md)
+
+## Target Architecture
+
+### Phase Execution Contract
+
+The control plane should converge on one internal execution contract for workflow phases:
+
+- `decision`
+- `agent_approve`
+- `submit`
+- `reconcile`
+
+Each execution request should carry enough context to make the phase observable, idempotent, and environment-aware:
+
+- `deployment_id`
+- `environment`
+- `execution_id`
+- `correlation_id`
+- `trigger_source`
+- `requested_at`
+- `phase`
+
+### Internal Control-Plane API
+
+The target runtime should expose one internal control-plane endpoint:
+
+- `POST /internal/paper/run-phase`
+
+This endpoint should be:
+
+- private
+- authenticated only by internal service identities
+- idempotent for duplicate scheduler or task delivery
+- unsuitable for public internet access
+
+### Trigger Model
+
+- Cloud Scheduler triggers `decision`
+- Cloud Scheduler triggers `submit`
+- `decision` can enqueue `agent_approve` via Cloud Tasks
+- `reconcile` runs on a lower-frequency schedule or targeted retry path
+
+The current permanent poll loop should not be the production scheduling model.
+
+### Deployment Registry
+
+The target design should include a first-class deployment registry with fields such as:
+
+- `deployment_id`
+- `environment`
+- `enabled`
+- `account_slug`
+- `strategy_slug`
+- `symbol`
+- `execution_mode`
+- `agent_backend`
+- `agent_model`
+- `schedule_timezone`
+- `decision_time`
+- `submission_time`
+- `notification_profile`
+- `config_version`
+
+### Persistence Split
+
+Persistence should be split into two concerns:
+
+- canonical workflow state in Postgres
+- immutable or reviewable artifacts in GCS
+
+The application layer should reach that target through DB-agnostic ports first:
+
+- `TradeRepository`
+- `PhaseRunRepository`
+- `PositionRepository`
+- `DeploymentRepository`
+- `OutboxRepository`
+- `UnitOfWork`
+- `ArtifactStore`
+
+Workflow state should capture:
+
+- proposals
+- approvals
+- submissions
+- reconciliations
+- execution history
+- retry state
+- deployment metadata
+
+Artifacts should capture:
+
+- JSON snapshots that mirror the current paper artifacts
+- monthly reports
+- notification audit records
+- debug exports when needed
+
+### Artifact Addressing
+
+Artifacts should be environment-scoped, deployment-scoped, and trade-date-scoped. The exact naming can be finalized during implementation, but it should support:
+
+- environment isolation
+- deployment isolation
+- easy retrieval of one trade date or one month-run
+
+## Environment Model
+
+### Dev
+
+- lowest cost
+- lowest retention
+- experimentation allowed
+- safe for schema changes and control-plane iteration
+
+### UAT
+
+- mirrors production topology
+- paper-only validation environment
+- used to validate workflow behavior before prod promotion
+
+### Prod
+
+- production-grade paper control plane
+- strictest IAM and retention posture
+- no experimentation
+
+### Environment Isolation
+
+Each environment should have separate:
+
+- GCP project
+- service accounts
+- scheduler jobs
+- task queues
+- secrets
+- database
+- artifact bucket
+- dashboards
+- alerting policies
+
+## Observability And Debugging
+
+### Logging
+
+Runtime services should emit structured JSON logs to stdout. At minimum, logs should carry:
+
+- `environment`
+- `deployment_id`
+- `phase`
+- `execution_id`
+- `correlation_id`
+- `proposal_id`
+- `trade_date`
+- `order_id`
+- `provider`
+- `model`
+- `outcome`
+- `duration_ms`
+
+### Metrics
+
+The observability contract should include:
+
+- phase success and failure counts
+- phase duration
+- duplicate suppression counts
+- queue depth and retry counts
+- submission outcomes
+- broker rejection counts
+
+### Errors
+
+- uncaught exceptions should surface in Error Reporting
+- high-signal operational failures should be alertable through Cloud Monitoring
+
+### Tracing
+
+- request and phase traces should be instrumented with OpenTelemetry
+- the default backend should be Google Cloud observability
+- the instrumentation should remain portable to future vendor or OSS sinks
+
+### Durable Debugging Surfaces
+
+Debugging should rely on durable system records, not only container stdout:
+
+- workflow rows in Postgres
+- GCS artifact snapshots
+- Cloud Logging queryable runtime logs
+- execution metadata with correlation IDs
+
+### Deferred Observability Tooling
+
+The initial cloud design explicitly defers:
+
+- Splunk
+- Datadog
+- self-hosted Loki
+- self-hosted Tempo
+- self-hosted Grafana
+
+Those can be reconsidered later if scale, compliance, or cost signals justify them.
+
+## Security And Secret Handling
+
+Use Secret Manager for:
+
+- Alpaca credentials
+- OpenAI API key
+- Anthropic API key
+- Telegram bot token and chat ID
+
+Security expectations:
+
+- dedicated service accounts per environment
+- least-privilege IAM
+- no long-lived service account keys in repo or containers
+- no credentials in YAML or committed config files
+
+If GKE is adopted later, use **Workload Identity Federation for GKE** instead of key files.
+
+## Migration Phases
+
+### Phase 0: Planning Freeze
+
+- complete `CLOUD_MIGRATION_PLAN.md`
+- complete the SOLID-first architecture audit and hardening roadmap
+- confirm architecture decisions
+- confirm environment model
+- confirm observability posture
+- confirm what stays local until implementation starts
+
+### Phase 1: Pre-Cloud Hardening
+
+- add enforced static type-checking and typed service contracts
+- split paper orchestration into phase-oriented application services
+- introduce DB-agnostic repository and unit-of-work interfaces
+- isolate broker, notifier, approval-provider, and artifact-store adapters
+- add structured logging and execution context fields
+- prove artifact and behavior parity before changing any persistence source of truth
+
+### Phase 2: Runtime Foundation
+
+- extract deployment-aware phase execution contracts
+- separate local loop orchestration from one-shot phase handlers
+- preserve current local CLI behavior
+
+### Phase 3: State And Artifact Abstractions
+
+- introduce workflow-state repository abstraction
+- introduce artifact-store abstraction
+- keep filesystem adapters for local compatibility
+
+### Phase 4: Control-Plane API
+
+- add internal authenticated phase endpoint
+- add execution IDs and correlation IDs
+- add idempotency guarantees for duplicate scheduler or task delivery
+
+### Phase 5: Structured Observability
+
+- add structured logs
+- add OpenTelemetry tracing hooks
+- add monitoring and error-reporting-ready event shapes
+
+### Phase 6: GCP Deployment Scaffolding
+
+- add infrastructure definitions for:
+  - Cloud Run
+  - Cloud Scheduler
+  - Cloud Tasks
+  - Cloud SQL
+  - GCS
+  - Secret Manager
+  - service accounts and IAM
+- start with `dev`
+- then `uat`
+- then `prod`
+
+### Phase 7: Cutover Validation
+
+- run side-by-side validation against the local design
+- verify artifact parity
+- verify scheduler timing and idempotency
+- verify approval and submit outcomes
+- verify alerting and debugging workflows
+
+## Action Items
+
+### Planning Deliverables
+
+- write and approve `CLOUD_MIGRATION_PLAN.md`
+- write and approve the SOLID-first architecture audit
+- create an ADR for the managed-first GCP architecture
+- define the `PaperDeployment` contract
+- define the phase execution request and response schema
+- define the canonical workflow state model
+- define the GCS artifact layout
+- define the structured log schema
+- define the OpenTelemetry instrumentation baseline
+- define the environment and project naming convention
+- define the IAM and secret model
+- define rollback and retry rules
+- define the migration acceptance checklist
+- define explicit criteria for moving to GKE
+
+### Suggested Sequence After April 27, 2026
+
+1. Land the pre-cloud hardening work: types, application services, persistence ports, and adapter seams.
+2. Land the runtime foundation and execution contracts.
+3. Land the state and artifact abstraction layer while keeping filesystem adapters.
+4. Land the internal control-plane API and idempotency model.
+5. Land structured observability and tracing.
+6. Land dev-only GCP scaffolding.
+7. Validate in UAT.
+8. Promote to prod only after UAT parity is confirmed.
+
+## GKE Decision Gate
+
+GKE should only be reconsidered if one or more of the following become true:
+
+- scale grows beyond the small-fleet assumption
+- custom controllers or complex queue consumers become necessary
+- per-deployment runtime customization exceeds Cloud Run simplicity
+- multi-tenant workload isolation requires cluster-level scheduling control
+
+Until then, prefer managed GCP services.
+
+## Acceptance Criteria For Migration Readiness
+
+- architecture decisions are explicit and documented
+- no unresolved platform choices remain for the first implementation slice
+- dev, UAT, and prod boundaries are defined
+- observability and artifact strategy are explicit
+- the cloud target no longer depends on permanent poll loops
+- the next implementation PR can start without requiring new architecture decisions
+
+## Appendix
+
+### Glossary Of Runtime Phases
+
+- `decision`: generate or refresh the proposal for the next trading date
+- `agent_approve`: approve or reject a persisted proposal under agent-driven execution modes
+- `submit`: reconcile the proposal against the broker account and submit or no-op
+- `reconcile`: refresh broker-side terminal state after submission
+
+### Mapping From Current Local Artifacts To Future Cloud Surfaces
+
+| Current local surface | Future canonical home | Notes |
+| --- | --- | --- |
+| `artifacts/paper/inbox/*.json` | Postgres + optional debug artifact export | Inbox becomes logical workflow state, not a shared filesystem queue |
+| `artifacts/paper/state/trades/<trade-date>/proposal.json` | Postgres row + GCS snapshot | Keep JSON snapshot semantics for debugging |
+| `artifacts/paper/state/trades/<trade-date>/evidence.json` | Postgres row + GCS snapshot | Preserve reviewability |
+| `artifacts/paper/state/trades/<trade-date>/approval.json` | Postgres row + GCS snapshot | Preserve actor and rationale history |
+| `artifacts/paper/state/trades/<trade-date>/order_preview.json` | GCS artifact + execution record | Operational debug surface |
+| `artifacts/paper/state/trades/<trade-date>/account_snapshot.json` | GCS artifact + execution record | Operational debug surface |
+| `artifacts/paper/state/trades/<trade-date>/submission.json` | Postgres row + GCS snapshot | Canonical submission state lives in DB |
+| `artifacts/paper/state/trades/<trade-date>/order_status.json` | Postgres row + GCS snapshot | Preserve reconciliation audit trail |
+| `artifacts/paper/state/status.json` | control-plane status query + optional cached summary artifact | No longer the primary source of truth |
+| `artifacts/paper/state/notifications/*.json` | GCS artifact + optional relational audit row | Keep debug and compliance value |
+| `artifacts/paper/reports/<start>_<end>/` | GCS | Long-lived reporting artifacts |
+
+### Known Risks And Deferred Items
+
+- local-to-cloud parity can drift if artifact semantics are not preserved during refactoring
+- idempotency must be designed before cloud scheduling is introduced
+- queue retries can create duplicate submission risk if correlation and dedupe rules are weak
+- environment sprawl can become costly if dev, UAT, and prod are not right-sized
+- GKE remains intentionally deferred
+- vendor or OSS observability expansion remains intentionally deferred
+
+### Google Cloud References To Revisit During Implementation
+
+- Cloud Run private services
+- Cloud Scheduler for time-based triggers
+- Cloud Tasks for async service-to-service execution
+- Cloud SQL for workflow state
+- GCS for durable artifacts
+- Secret Manager for runtime secrets
+- Cloud Logging, Monitoring, Error Reporting, and Trace
+- Workload Identity Federation for GKE if Kubernetes is later introduced
+
+## Assumptions
+
+- This document lives at the repo root as `CLOUD_MIGRATION_PLAN.md`.
+- This is a planning artifact only for now.
+- Implementation begins no earlier than **April 27, 2026**.
+- The current local paper-trading stack remains the operational system until a later migration slice is approved.

--- a/IMPLEMENTATION_ROADMAP_PHASES_1_6.md
+++ b/IMPLEMENTATION_ROADMAP_PHASES_1_6.md
@@ -1,0 +1,592 @@
+# Implementation Roadmap: Hardening Phases 1-6
+
+## Purpose And Status
+
+This document is the tracked execution plan for hardening phases 1-6 from the SOLID-first architecture audit.
+
+It exists to turn the architecture and cloud-readiness planning into a sequence of small, reviewable PRs that keep the current MarketLab repo functional while tightening contracts, tests, and boundaries.
+
+This roadmap is intentionally implementation-oriented:
+
+- it names the phase goals
+- it defines the PR sequence
+- it records expected inputs and outputs
+- it shows how to use worker roles and `/parallelize`
+- it keeps the current working state of the repo as the protected baseline
+
+Status legend:
+
+- `not started`
+- `in progress`
+- `blocked`
+- `done`
+
+Current status:
+
+- Phase 1: `not started`
+- Phase 2: `not started`
+- Phase 3: `not started`
+- Phase 4: `not started`
+- Phase 5: `not started`
+- Phase 6: `not started`
+
+Companion planning documents:
+
+- [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md)
+- [CLOUD_MIGRATION_PLAN.md](CLOUD_MIGRATION_PLAN.md)
+- [docs/architecture.md](docs/architecture.md)
+
+## Global Guardrails
+
+These rules apply to every implementation PR in phases 1-6.
+
+- Preserve the current working paper runtime by default.
+- Do not change scheduler times, CLI commands, MCP paper tools, or tracked artifact meanings unless a PR explicitly says so.
+- Do not switch the default source of truth away from the current working path until parity is proven.
+- Keep all required CI checks green at every phase.
+- Keep PRs offline-safe by default; live Alpaca and Telegram checks remain manual only.
+- Keep CLI, scheduler, agent worker, and MCP as adapters over shared application services.
+- Preserve frozen research contracts by default:
+  - panel semantics
+  - feature timing
+  - Friday-close to next-open execution assumptions
+  - backtest performance outputs
+  - current reviewable artifact meanings
+- Treat silent changes to artifact paths, report shapes, or paper-state semantics as regressions.
+- Do not introduce cloud-specific types, SDKs, or deployment assumptions into domain or application services.
+- Prefer composition-first OOP, explicit interfaces, and KISS over broad abstraction layers.
+- Add parity tests before changing any persistence source-of-truth behavior.
+- Keep the repo mergeable after each PR. No phase may leave the default branch in a partially migrated state.
+
+## Role Map
+
+Use these roles consistently when planning or executing the phase PRs.
+
+### `/orchestrator`
+
+Primary planning role before each PR.
+
+Responsibilities:
+
+- slice the phase into small ordered packets
+- identify the critical path
+- define PR boundaries
+- assign worker ownership
+- set acceptance criteria
+- keep scope aligned with the hardening roadmap
+
+### `/architect`
+
+There is no dedicated installed `architect` skill in this session.
+
+Use the main agent as the architecture owner, grounded in:
+
+- `docs/architecture.md`
+- `docs/solid-architecture-audit.md`
+- `CLOUD_MIGRATION_PLAN.md`
+
+Every architecture decision should still go through a mandatory `/critic` pass.
+
+### `/worker`
+
+Implementation role for bounded change packets.
+
+Rules:
+
+- one worker per disjoint write scope
+- no overlapping edits unless the interface owner has landed first
+- keep changes small and behavior-preserving unless the PR explicitly changes behavior
+
+### `/qa`
+
+Validation and regression ownership.
+
+Responsibilities:
+
+- protect artifact and behavior parity
+- expand deterministic tests when contracts are not yet provable
+- verify current paper and research flows remain intact
+- reject silent regressions
+
+### `/critic`
+
+Adversarial design review.
+
+Responsibilities:
+
+- challenge SRP violations
+- challenge leaky abstractions
+- block cloud coupling too early
+- block changes that mutate frozen contracts without explicit justification
+- block CLI or MCP logic drift into orchestration
+
+### `/ci-engineer`
+
+CI and tox ownership.
+
+Responsibilities:
+
+- own `tox.ini`, `pyproject.toml`, and `.github/workflows/ci.yml` changes
+- keep required-check names stable
+- make new gates tox-first, not YAML-first
+- keep PR checks offline-safe by default
+
+### `/parallelize`
+
+Use only when write scopes are disjoint and the shared interface is already fixed.
+
+Do not parallelize:
+
+- highly coupled service extraction before the common interfaces are locked
+- phases where one packet depends on unfinished public contracts from another packet
+- changes that would create merge conflicts inside the same module
+
+## Phase Overview Table
+
+| Phase | Goal | Inputs | Outputs | PRs | Can Parallelize | Exit Gate |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Add type checking and typed paper contracts | `pyproject.toml`, `tox.ini`, CI workflow, `config.py`, paper modules/tests | `mypy` gate, typed DTOs, typed ports | 2 | Yes, after `mypy` scope is fixed | `typecheck` passes and behavior is unchanged |
+| 2 | Extract phase-oriented paper services | typed contracts, current paper modules, artifact semantics | shared application service layer, thin adapters | 2 | Mostly no | all adapters call the same services and artifacts are unchanged |
+| 3 | Add DB-agnostic persistence ports | extracted services, current `PaperStateStore`, current paper artifacts | repositories, `UnitOfWork`, filesystem adapter, optional SQLite adapter, contract tests | 2 | Yes, after port contracts are fixed | default local behavior still works and adapter contract tests pass |
+| 4 | Isolate external IO behind ports | services, persistence ports, Alpaca/Telegram/provider/artifact modules | `BrokerClient`, `NotificationSink`, `ApprovalClient`, `ArtifactStore` | 2 | Yes, after outbound interfaces are fixed | application services stop importing concrete IO adapters |
+| 5 | Add structured observability | `log.py`, paper services, entry adapters | structured log envelope, execution context propagation | 1 | Usually no | structured logs exist and behavior remains unchanged |
+| 6 | Define extraction readiness and add boundary guardrails | completed seams from phases 1-5, architecture docs | readiness criteria, boundary tests, explicit keep-package-first rules | 2 | Yes, after criteria are fixed | boundary rules are automated and the repo is still a modular monolith |
+
+## Detailed Phase Plans
+
+### Phase 1: Type System Foundation
+
+Status: `not started`
+
+Objective:
+
+- add static type checking and typed paper contracts without changing runtime behavior
+
+Inputs:
+
+- `pyproject.toml`
+- `tox.ini`
+- `.github/workflows/ci.yml`
+- `src/marketlab/config.py`
+- current paper modules and tests
+
+Expected outputs:
+
+- `mypy`-based type-check env and CI job
+- typed paper request and response DTOs
+- typed protocol interfaces for key paper seams
+- narrow initial type-check scope limited to shared config and paper-control modules
+
+PR sequence:
+
+1. Branch: `feat/typecheck-bootstrap`
+   PR title: `feat: add mypy gate for core paper modules`
+   Goal: wire type checking into tox and CI with a narrow initial scope
+
+2. Branch: `feat/paper-typed-contracts`
+   PR title: `feat: add typed paper phase contracts and protocol interfaces`
+   Goal: introduce DTOs and protocols for the paper application boundary
+
+Worker packet plan:
+
+- main/orchestrator critical path:
+  - lock the initial `mypy` scope
+  - lock the failure policy
+  - lock the required CI job name before parallel work starts
+- worker A:
+  - own typed paper DTOs and config annotations
+  - write scope: config and paper contract modules
+- worker B:
+  - own tox and CI wiring
+  - write scope: `tox.ini`, `pyproject.toml`, `.github/workflows/ci.yml`
+- `/qa`:
+  - review for behavior-preserving changes
+  - add missing contract tests if DTOs or protocols are unproven
+- `/critic`:
+  - block whole-repo gating too early
+  - block broad annotation churn outside the agreed narrow scope
+- `/ci-engineer`:
+  - verify stable required-check naming
+  - keep tox as the source of truth
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted gates:
+  - `tests/unit/test_config.py`
+  - `tests/unit/test_cli.py`
+  - `tests/unit/test_paper_service.py`
+  - `tests/unit/test_paper_agent.py`
+  - `tests/unit/test_paper_scheduler.py`
+  - `tests/unit/test_paper_alpaca.py`
+  - `tests/integration/test_mcp_server.py`
+
+Exit criteria:
+
+- the new `typecheck` gate passes
+- typed contracts exist for paper phase boundaries
+- no runtime behavior drift
+- existing paper and research tests remain green
+
+### Phase 2: Phase-Oriented Paper Services
+
+Status: `not started`
+
+Objective:
+
+- extract paper application services while keeping CLI, scheduler, MCP, and agent behavior unchanged
+
+Inputs:
+
+- phase 1 typed contracts
+- current `paper/service.py`, `paper/agent.py`, `paper/scheduler.py`
+- current paper artifact semantics
+
+Expected outputs:
+
+- shared paper application service layer
+- thin adapters for CLI, scheduler, agent, and MCP
+- unchanged proposal, approval, submission, and reconciliation artifacts
+
+PR sequence:
+
+1. Branch: `refactor/decision-approval-services`
+   PR title: `refactor: extract paper decision and approval services`
+   Goal: move decision and approval orchestration into shared application services
+
+2. Branch: `refactor/submit-reconcile-services`
+   PR title: `refactor: extract paper submission and reconciliation services`
+   Goal: move submission and reconciliation orchestration into shared application services
+
+Worker packet plan:
+
+- default mode:
+  - single implementation owner because write scope is highly coupled
+- allowed parallelization mode:
+  - only after one seed commit creates the application package and fixes constructor contracts
+  - worker A: decision and approval extraction
+  - worker B: submit and reconcile extraction
+  - write scopes must stay disjoint after the seed interface commit
+- `/qa`:
+  - own regression proof for artifact parity
+  - verify CLI, scheduler, MCP, and agent all reuse the same services
+- `/critic`:
+  - block changes to trade timing
+  - block orchestration drift into CLI or MCP handlers
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted paper regressions:
+  - `tests/unit/test_paper_service.py`
+  - `tests/unit/test_paper_agent.py`
+  - `tests/unit/test_paper_scheduler.py`
+  - `tests/unit/test_paper_notifications.py`
+  - `tests/integration/test_mcp_server.py`
+  - `tests/integration/test_paper_notification_flow.py`
+
+Exit criteria:
+
+- scheduler, CLI, MCP, and agent all call the same extracted services
+- current paper artifact meanings remain unchanged
+- no timing or trading behavior drift
+
+### Phase 3: DB-Agnostic Persistence Ports
+
+Status: `not started`
+
+Objective:
+
+- introduce transactional persistence seams without breaking the current working path
+
+Inputs:
+
+- extracted paper services
+- current `PaperStateStore` behavior
+- current artifact layout under `artifacts/paper/`
+
+Expected outputs:
+
+- repository interfaces
+- `UnitOfWork`
+- filesystem-backed default adapter
+- optional SQLite adapter behind the same contracts
+- contract tests for multiple adapters
+
+PR sequence:
+
+1. Branch: `refactor/paper-persistence-ports`
+   PR title: `refactor: add paper repositories and unit-of-work ports`
+   Goal: introduce the transactional persistence interfaces and keep the filesystem path as the default adapter
+
+2. Branch: `feat/sqlite-paper-store-adapter`
+   PR title: `feat: add sqlite paper control-store adapter behind persistence ports`
+   Goal: prove the interfaces are DB-agnostic with a simple local transactional backend
+
+Worker packet plan:
+
+- main/orchestrator critical path:
+  - lock repository interfaces
+  - lock transaction rules
+  - lock adapter contract tests before parallel work
+- worker A:
+  - filesystem-backed adapter migration
+  - write scope: persistence ports plus filesystem adapter
+- worker B:
+  - SQLite adapter and contract-test harness
+  - write scope: adapter module and parity tests
+- `/qa`:
+  - own parity testing against current artifact semantics
+  - require transaction-boundary tests
+- `/critic`:
+  - block ORM leakage
+  - block distributed-transaction thinking
+  - block premature service-owned DB splits
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted paper regression set
+- new repository contract tests across at least two adapter shapes
+- parity tests for proposal, approval, submission, and order-status artifact behavior
+
+Exit criteria:
+
+- default local behavior still works
+- repository contract tests pass against more than one adapter shape
+- side effects remain outside DB transactions
+
+### Phase 4: Adapter Isolation
+
+Status: `not started`
+
+Objective:
+
+- move all external IO behind ports so application services are implementation-agnostic
+
+Inputs:
+
+- paper application services
+- persistence ports
+- current Alpaca, Telegram, LLM, and artifact-writing modules
+
+Expected outputs:
+
+- `BrokerClient`
+- `NotificationSink`
+- `ApprovalClient`
+- `ArtifactStore`
+- application services with no direct imports of concrete SDK adapters
+
+PR sequence:
+
+1. Branch: `refactor/broker-artifact-ports`
+   PR title: `refactor: isolate paper broker and artifact store adapters`
+   Goal: move broker and artifact-writing IO behind outbound ports
+
+2. Branch: `refactor/notifier-approval-ports`
+   PR title: `refactor: isolate paper notification and approval-provider adapters`
+   Goal: move notification and LLM approval-provider IO behind outbound ports
+
+Worker packet plan:
+
+- main/orchestrator critical path:
+  - lock outbound port interfaces
+  - lock ownership boundaries before parallel work
+- worker A:
+  - broker and artifact store write scope
+- worker B:
+  - notifier and approval-provider write scope
+- `/qa`:
+  - own deterministic adapter substitution tests
+  - verify no behavior drift in current paper flows
+- `/critic`:
+  - reject generic abstractions that erase domain meaning
+  - reject adapters that still leak SDK types into application code
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted paper regressions
+- relevant MCP unit tests
+- deterministic adapter substitution tests
+
+Exit criteria:
+
+- business logic no longer imports concrete broker, notifier, or provider implementations
+- substitutions are testable with fixtures
+- current behavior remains unchanged
+
+### Phase 5: Structured Observability
+
+Status: `not started`
+
+Objective:
+
+- add structured execution context without changing business logic or cloud-coupling the repo
+
+Inputs:
+
+- `src/marketlab/log.py`
+- paper services and entry adapters
+- current local debugging surfaces
+
+Expected outputs:
+
+- structured log envelope
+- execution ID propagation
+- correlation ID propagation
+- phase, deployment, trade, proposal, order, provider, outcome, and duration context fields
+
+PR sequence:
+
+1. Branch: `refactor/structured-paper-logging`
+   PR title: `refactor: add structured execution logging for paper control plane`
+   Goal: add transport-agnostic structured execution logging
+
+Worker packet plan:
+
+- recommended single-owner change because logging touches shared execution paths
+- `/qa`:
+  - verify logs do not replace artifact-based debugging
+  - verify current debugging surfaces remain usable
+- `/critic`:
+  - block logging changes that become hidden control flow
+  - block cloud-vendor assumptions in the log shape
+- `/ci-engineer`:
+  - only involved if CI log capture or required checks change
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted paper regressions
+- any new log-shape tests
+
+Exit criteria:
+
+- structured logs exist and remain transport-agnostic
+- current local debugging via artifacts and tests still works
+- no behavior change
+
+### Phase 6: Extraction Readiness Rules
+
+Status: `not started`
+
+Objective:
+
+- define when the paper control plane is safe to split later and add light boundary enforcement
+
+Inputs:
+
+- services, ports, logging, and persistence seams from phases 1-5
+- current architecture and audit docs
+
+Expected outputs:
+
+- extraction-readiness criteria
+- architecture boundary guardrail tests
+- explicit keep-package-first decision for research modules
+
+PR sequence:
+
+1. Branch: `feat/paper-extraction-readiness`
+   PR title: `feat: define paper service-extraction readiness rules`
+   Goal: define measurable criteria for future service extraction
+
+2. Branch: `test/architecture-boundary-guardrails`
+   PR title: `test: add lightweight architecture boundary guardrails`
+   Goal: enforce the key modular-monolith boundaries in tests
+
+Worker packet plan:
+
+- main/orchestrator critical path:
+  - lock the readiness checklist
+  - lock prohibited dependency rules
+- worker A:
+  - docs and readiness criteria
+- worker B:
+  - `pytest`-based boundary guardrails
+- `/qa`:
+  - confirm the new tests are stable and useful
+  - reject flaky or overly brittle boundary checks
+- `/critic`:
+  - challenge any readiness claim not backed by actual implemented boundaries
+
+Validation:
+
+- `py -3.14 -m tox -e preflight`
+- targeted paper regressions
+- new architecture-boundary tests
+
+Exit criteria:
+
+- extraction criteria are explicit
+- boundary guardrails are automated
+- the repo is still a modular monolith, not prematurely split services
+
+## Merge Rules
+
+- Branch every PR from clean `master`.
+- Do not stack unrelated scope into a phase PR.
+- Do not merge a persistence PR unless parity tests are in place.
+- Add new required CI jobs only after the job is stable in PR CI.
+- Keep job names stable once branch protection depends on them.
+- Prefer 1 to 3 focused commits per PR:
+  - contracts or interfaces
+  - integration into current entry adapters
+  - tests and docs
+- If a phase requires more than two PRs, split by stable interface boundary, not by arbitrary file count.
+- If the working tree already contains unmerged docs changes, land the docs baseline first or explicitly include it in the roadmap PR before phase implementation starts.
+
+## Tracking Checklist
+
+### Docs Baseline
+
+- [ ] Merge the SOLID audit and cloud-migration docs baseline first, or fold that baseline into the roadmap doc PR.
+- [ ] Merge this roadmap doc so phases 1-6 have a tracked execution source.
+
+### Phase 1
+
+- [ ] PR: `feat: add mypy gate for core paper modules`
+- [ ] PR: `feat: add typed paper phase contracts and protocol interfaces`
+- [ ] Confirm `typecheck` is stable in PR CI
+
+### Phase 2
+
+- [ ] PR: `refactor: extract paper decision and approval services`
+- [ ] PR: `refactor: extract paper submission and reconciliation services`
+- [ ] Confirm CLI, scheduler, MCP, and agent all reuse the same services
+
+### Phase 3
+
+- [ ] PR: `refactor: add paper repositories and unit-of-work ports`
+- [ ] PR: `feat: add sqlite paper control-store adapter behind persistence ports`
+- [ ] Confirm adapter contract tests pass and parity is proven
+
+### Phase 4
+
+- [ ] PR: `refactor: isolate paper broker and artifact store adapters`
+- [ ] PR: `refactor: isolate paper notification and approval-provider adapters`
+- [ ] Confirm business logic no longer imports concrete IO adapters
+
+### Phase 5
+
+- [ ] PR: `refactor: add structured execution logging for paper control plane`
+- [ ] Confirm current local debugging still works
+
+### Phase 6
+
+- [ ] PR: `feat: define paper service-extraction readiness rules`
+- [ ] PR: `test: add lightweight architecture boundary guardrails`
+- [ ] Confirm the repo remains a modular monolith with automated boundary checks
+
+### Safe To Begin Cloud Implementation
+
+- [ ] typed contracts exist for paper phase boundaries
+- [ ] phase services are shared across CLI, scheduler, agent, and MCP
+- [ ] transactional persistence ports are in place
+- [ ] more than one persistence adapter shape is proven by contract tests
+- [ ] external IO is isolated behind ports
+- [ ] structured execution context exists
+- [ ] extraction readiness rules are explicit
+- [ ] current paper runtime and frozen research contracts remain intact

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly and daily supervised timing rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, reviewable artifact summaries, and a local Alpaca paper-trading MVP for a configurable daily single-ETF timing loop.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
+See [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md) for the SOLID-first technical-debt audit and the pre-cloud persistence-hardening roadmap.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
 See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ This site is the canonical home for MarketLab's public documentation.
 
 - [How It Works](how-it-works.md)
 - [Architecture](architecture.md)
+- [SOLID-First Architecture Audit](solid-architecture-audit.md)
 - [Phase 5 Scenario Pack](phase5-scenarios.md)
 - [Plan](PLAN.md)
 

--- a/docs/solid-architecture-audit.md
+++ b/docs/solid-architecture-audit.md
@@ -1,0 +1,364 @@
+# SOLID-First Architecture Audit
+
+## Purpose
+
+This document is the pre-cloud architecture and technical-debt audit for MarketLab.
+
+It is intentionally critical. The goal is not to defend the current implementation, but to identify what must stay simple, what must be modularized, and what must be separated behind stable interfaces before any hosted control plane or transactional persistence work begins.
+
+This audit complements:
+
+- [Architecture](architecture.md) for the current system map
+- [Phase 7 Paper Trading](paper-trading.md) for the local paper runtime
+- `CLOUD_MIGRATION_PLAN.md` at the repo root for the later hosted deployment path
+
+## Locked Design Posture
+
+- Use OOP with composition-first boundaries.
+- Apply SOLID as a review gate, especially SRP and dependency inversion at IO boundaries.
+- Bias toward KISS. Keep pure local logic simple and explicit.
+- Apply DRY only when duplication is structural, not merely similar-looking.
+- Keep the application layer open to new implementations through ports and adapters.
+- Do not couple business logic to cloud vendors, database clients, container runtimes, or MCP transports.
+- Do not jump directly to microservices. First build a modular monolith with explicit boundaries, typed contracts, and transactional seams.
+- Preserve the frozen research contracts unless a later PR proves a concrete need to change them:
+  - panel semantics
+  - feature timing
+  - Friday-close to next-open execution assumptions
+  - backtest performance outputs
+  - current reviewable artifact meanings
+
+## Repo-Wide Review Rubric
+
+Every module group should be reviewed with the same questions:
+
+- What is its actual responsibility today?
+- Does it have more than one reason to change?
+- Which external dependencies or side effects does it own?
+- Which inputs and outputs should be explicit typed contracts?
+- Where is it coupled to filesystem paths, SDKs, CLI behavior, environment variables, or container assumptions?
+- Which duplication is worth unifying, and which duplication is clearer left alone?
+- Which abstractions are missing at external boundaries?
+- Which abstractions would be premature or harmful?
+
+## Audit Findings By Module Group
+
+### Shared Foundation
+
+Targets:
+
+- `src/marketlab/config.py`
+- `src/marketlab/cli.py`
+- `src/marketlab/log.py`
+- shared utility surfaces
+
+Current assessment:
+
+- `cli.py` is already close to the right shape. It should remain a transport layer, not an orchestration layer.
+- `config.py` is explicit and readable, but it is becoming a central dependency for both research and runtime concerns.
+- `log.py` is too thin for the next stage. Basic stdlib logging is fine locally, but it does not provide execution context, structured fields, or future observability seams.
+
+Keep:
+
+- dataclass-based config objects
+- thin CLI command handlers
+- simple local logging bootstrap for dev ergonomics
+
+Harden:
+
+- add a structured logging envelope without pushing logging concerns into domain logic
+- separate config loading from higher-level runtime validation rules where cross-field checks become non-trivial
+- keep shared helpers boring and explicit; do not hide side effects behind convenience wrappers
+
+### Research Runtime
+
+Targets:
+
+- `pipeline`
+- `data`
+- `features`
+- `targets`
+- `evaluation`
+- `models`
+- `strategies`
+- `backtest`
+- `reports`
+
+Current assessment:
+
+- the research stack is mostly package-first and should stay that way
+- `data`, `features`, `targets`, `strategies`, and most of `backtest` are good candidates to remain pure or near-pure modules
+- `pipeline.py` is the main orchestration hotspot in the research path; it mixes workflow coordination with artifact persistence and reporting assembly
+- reporting is valuable, but artifact-writing concerns should not keep spreading into orchestration surfaces
+
+Keep:
+
+- package-first research execution
+- pure function style for feature, target, strategy, and backtest logic
+- explicit artifact generation for reviewable outputs
+- current market-data and performance contracts unless a dedicated PR proves a required contract change
+
+Harden:
+
+- split workflow coordination from artifact persistence in the research path
+- introduce typed input/output contracts at stage boundaries where DataFrame-based handoffs are currently implicit
+- add type-checking coverage to catch hidden coupling between modeling, reporting, and artifact assembly
+
+Do not do:
+
+- do not force the research stack into service boundaries early
+- do not add abstraction layers around pure math, feature engineering, or deterministic reporting logic without a concrete substitution need
+
+### Paper Control Plane
+
+Targets:
+
+- `src/marketlab/paper/service.py`
+- `src/marketlab/paper/agent.py`
+- `src/marketlab/paper/scheduler.py`
+- `src/marketlab/paper/alpaca.py`
+- `src/marketlab/paper/notifications.py`
+- `src/marketlab/paper/report.py`
+
+Current assessment:
+
+- this is the highest-risk part of the codebase for the next phase
+- `paper/service.py` is the main orchestration hotspot and currently carries too many responsibilities
+- `paper/agent.py` mixes worker control, provider policy, prompting, fallback behavior, and approval orchestration
+- scheduler and agent loops are acceptable as local adapters, but they should not own business rules
+- the current filesystem-first state model is workable for the laptop flow, but it is too tightly coupled to orchestration logic for a future transactional runtime
+
+Keep:
+
+- explicit phase language: `decision`, `agent_approve`, `submit`, `reconcile`
+- reviewable artifacts and deterministic fallback semantics
+- adapters for local scheduler and local agent loops
+
+Harden:
+
+- split phase orchestration into application services:
+  - `DecisionService`
+  - `ApprovalService`
+  - `SubmissionService`
+  - `ReconciliationService`
+- move Alpaca, Telegram, artifact writing, and provider calls behind explicit interfaces
+- make scheduler, CLI, MCP, and agent worker thin entry adapters over the same one-shot service contracts
+- define typed request/response objects for each phase instead of relying on raw dicts and ad hoc file payloads
+- preserve current paper-state artifact semantics while transactional persistence is being introduced, so parity can be proven before any source-of-truth transition
+
+### MCP And Ops Tooling
+
+Targets:
+
+- `src/marketlab/mcp/server.py`
+- `src/marketlab/mcp/jobs.py`
+- MCP tool modules
+- workspace sandbox
+
+Current assessment:
+
+- MCP is correctly positioned as an ops and review surface, not the execution backend
+- `mcp/jobs.py` is a local in-process queue for repo workflows; it should not become the production control-plane model
+- MCP tools should stay thin and call application services rather than growing their own runtime logic
+
+Keep:
+
+- sandboxed MCP tool surface
+- queued local workflow control for research and local ops
+- artifact inspection and paper review tools
+
+Harden:
+
+- ensure MCP approval and status tools depend on the same application services as CLI and local workers
+- keep MCP-side abstractions separate from future cloud scheduling abstractions
+
+Do not do:
+
+- do not let MCP become a hidden dependency of the future runtime
+- do not move business rules into tool handlers
+
+### Tests And Tooling
+
+Targets:
+
+- `tox.ini`
+- `pyproject.toml`
+- unit and integration suites
+
+Current assessment:
+
+- the repo has meaningful behavioral coverage, especially around the paper path
+- static typing is not enforced today; that is a real gap for the next phase
+- many tests still prove behavior through filesystem artifacts, which is useful, but not enough for a future DB-backed control plane
+
+Keep:
+
+- behavioral tests that validate current paper artifacts and local workflow outcomes
+- docs, packaging, and integration gates in tox
+
+Harden:
+
+- add a real type-check gate to tox and CI
+- add contract tests for phase services, repositories, and adapters
+- keep artifact parity tests while adding persistence-agnostic service tests
+- prepare for multi-adapter testing of the same repository contracts
+
+Required QA posture:
+
+- treat silent changes to artifact paths, report shapes, or paper-state semantics as regressions
+- keep deterministic fixture coverage for pure logic and transition rules
+- add parity checks before any persistence source-of-truth change
+- require one clear acceptance checklist per hardening packet, not only broad architectural intent
+
+## Target Modular Monolith Shape
+
+The next architecture step is a modular monolith, not deployed microservices.
+
+Application layer:
+
+- `DecisionService`
+- `ApprovalService`
+- `SubmissionService`
+- `ReconciliationService`
+
+Outbound ports:
+
+- `TradeRepository`
+- `PhaseRunRepository`
+- `PositionRepository`
+- `DeploymentRepository`
+- `OutboxRepository`
+- `UnitOfWork`
+- `ArtifactStore`
+- `BrokerClient`
+- `NotificationSink`
+- `ApprovalClient`
+
+Inbound adapters:
+
+- CLI commands
+- scheduler loop
+- agent worker loop
+- MCP paper tools
+
+Pure domain logic should stay independent of IO:
+
+- consensus evaluation
+- signal validation
+- position sizing policy
+- state-transition rules
+- idempotency and retry rules
+
+## Transactional Persistence Target
+
+The future source of truth is one transactional control store.
+
+Application-layer persistence must remain DB-agnostic:
+
+- local development can start with a simple adapter such as SQLite
+- production can later use a Postgres-compatible adapter
+- business logic must not depend on ORM sessions, SQL dialects, or cloud-managed database types
+
+Canonical records to preserve later:
+
+- deployments
+- proposals
+- evidence
+- approvals
+- submission attempts
+- broker order state
+- positions and account snapshots
+- phase executions and idempotency keys
+- notification events and outbox items
+
+Artifact snapshots remain separate from transactional state:
+
+- reviewable JSON artifacts still matter
+- artifacts are a debugging and audit surface
+- artifacts do not replace the canonical transactional record
+
+### Transaction Rules
+
+- Persist internal state changes atomically inside one application-level transaction.
+- Do not hold a transaction open across:
+  - broker calls
+  - LLM/provider calls
+  - Telegram delivery
+- Use persisted phase-run state plus an outbox or event handoff for side effects.
+- Treat idempotency as a first-class persistence concern, not as a best-effort filesystem convention.
+
+## Ordered Hardening Packets
+
+1. `feat(types): add enforced type-checking and typed service contracts`
+2. `refactor(paper): split orchestration into phase-oriented application services`
+3. `refactor(persistence): introduce DB-agnostic repositories and unit-of-work`
+4. `refactor(adapters): isolate broker, notifier, LLM, and artifact store behind ports`
+5. `refactor(obs): add structured logging and execution context`
+6. `feat(readiness): define service-extraction readiness rules`
+
+### Packet-Level Validation Expectations
+
+`feat(types)` must prove:
+
+- type-check gate is wired into tox and CI
+- typed contracts cover config, phase requests/responses, and adapter interfaces
+- no behavioral drift in existing paper and research flows
+
+`refactor(paper)` must prove:
+
+- scheduler, CLI, MCP, and agent paths still call the same business rules
+- current paper proposal, approval, submission, and reconciliation artifacts remain reviewable
+- no change to current trade semantics or timing assumptions
+
+`refactor(persistence)` must prove:
+
+- repository contracts pass the same behavioral tests across at least one local adapter and one future-ready adapter shape
+- transaction boundaries are explicit and tested
+- side effects remain outside DB transactions
+
+`refactor(adapters)` must prove:
+
+- business logic no longer imports concrete broker, notifier, or provider SDKs directly
+- adapter substitutions can be tested with deterministic fixtures
+- no new abstraction erases domain meaning
+
+`refactor(obs)` must prove:
+
+- structured logs carry execution context without polluting domain logic
+- existing local debugging remains usable
+- log changes do not become hidden control flow
+
+`feat(readiness)` must prove:
+
+- extraction criteria are explicit
+- the paper control plane can be split later without reopening core contracts
+- research/runtime modules still remain package-first unless a later decision changes that
+
+## Module Review Sequence
+
+Use this order so the highest-coupling seams are reviewed first:
+
+1. shared foundation
+2. research orchestration hotspots
+3. paper control plane
+4. MCP and ops tooling
+5. tests, typing, and validation tooling
+
+For each review packet, produce:
+
+- current responsibility summary
+- SRP and coupling findings
+- missing contracts and adapter seams
+- concrete keep/split/defer recommendations
+- required tests and regression coverage
+
+## Acceptance Criteria
+
+- every major module group has a completed audit entry
+- the paper control plane has a documented modular-monolith target shape
+- the persistence boundary is explicitly DB-agnostic
+- transaction rules are documented
+- MCP is explicitly preserved as ops-only
+- frozen research and artifact contracts are explicitly called out as protected by default
+- future hardening packets have concrete validation obligations, not only architectural goals
+- the next implementation PR can start without reopening architecture decisions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Overview: index.md
   - How It Works: how-it-works.md
   - Architecture: architecture.md
+  - SOLID Audit: solid-architecture-audit.md
   - Phase 5 Scenarios: phase5-scenarios.md
   - Phase 7 Paper Trading: paper-trading.md
   - MCP Server: mcp-server.md


### PR DESCRIPTION
## Summary
- add the Phase 0 architecture docs baseline for pre-cloud hardening
- add the SOLID-first architecture audit and cloud migration plan
- add a tracked implementation roadmap for hardening phases 1 to 6

## Validation
- `git diff --check`
- `.tox\\docs\\Scripts\\python.exe -m mkdocs build --strict`

## Notes
- docs-only PR
- preserves the current working paper runtime and existing artifact semantics as the protected baseline for later hardening work