### PR TITLE
feat: add mypy gate for core paper modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,12 +5,15 @@
 .github/
 .pytest_cache/
 .pytest_tmp*/
+.tox_tmp*/
+.virtualenv_appdata/
 .tox/
 .tox-phase3/
 .venv/
 __pycache__/
 *.pyc
 .pt*/
+pytest_tmp*/
 scratch_*/
 tmp_*/
 artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,31 @@ jobs:
       - name: Build documentation
         run: uv run tox -e docs
 
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    env:
+      RUNNER_PYTHON: python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            tox.ini
+            mkdocs.yml
+      - name: Sync development dependencies
+        run: uv sync --group dev
+      - name: Run type checks
+        run: uv run tox -e typecheck
+
   package:
     name: package
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 .pytest_cache/
 .pytest_tmp/
+.tox_tmp/
+.virtualenv_appdata/
 .mypy_cache/
 .ruff_cache/
 .venv/
@@ -21,3 +23,4 @@ pytest-cache-files-*/
 artifacts/*
 !artifacts/.gitkeep
 .pytest_*/
+pytest_tmp*/

--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ powershell -ExecutionPolicy Bypass -File scripts/run-e2e.ps1
 python -m uv sync --group dev
 py -3.12 -m tox -e lint
 py -3.12 -m tox -e docs
+py -3.12 -m tox -e typecheck
 py -3.12 -m tox -e py312
 py -3.12 -m tox -e package
 py -3.12 -m tox -e integration
@@ -430,6 +431,7 @@ Current measured local Windows budgets are roughly:
 
 - `lint`: under `30s`
 - `docs`: under `30s`
+- `typecheck`: about `30s`
 - `py312`: under `60s`
 - `package`: about `4-6m`
 - `integration`: about `8-10m`
@@ -443,11 +445,12 @@ Use this sequence when `preflight` feels slow or unstable:
 
 1. `py -3.12 -m tox -e lint`
 2. `py -3.12 -m tox -e docs`
-3. `py -3.12 -m tox -e py312`
-4. `py -3.12 -m tox -e package`
-5. `py -3.12 -m tox -e integration`
-6. `py -3.12 scripts/profile_validation.py --env package --env integration`
-7. `py -3.12 -m tox -e preflight`
+3. `py -3.12 -m tox -e typecheck`
+4. `py -3.12 -m tox -e py312`
+5. `py -3.12 -m tox -e package`
+6. `py -3.12 -m tox -e integration`
+7. `py -3.12 scripts/profile_validation.py --env package --env integration`
+8. `py -3.12 -m tox -e preflight`
 
 Interpret the result this way:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "build>=1.2",
   "mcp>=1.27,<2",
   "mkdocs>=1.6",
+  "mypy>=1.20",
   "pytest>=8.0",
   "ruff>=0.11",
   "tox>=4.0",
@@ -54,6 +55,7 @@ dev = [
   "build>=1.2",
   "mcp>=1.27,<2",
   "mkdocs>=1.6",
+  "mypy>=1.20",
   "pytest>=8.0",
   "ruff>=0.11",
   "tox>=4.0",
@@ -76,10 +78,27 @@ where = ["src"]
 [tool.uv]
 default-groups = ["dev"]
 
+[tool.mypy]
+python_version = "3.12"
+warn_unused_configs = true
+ignore_missing_imports = true
+follow_imports = "silent"
+disable_error_code = ["import-untyped"]
+
 [tool.ruff]
 target-version = "py312"
 src = ["src", "tests", "scripts"]
-extend-exclude = ["artifacts", "build", "dist", "site", ".pytest_tmp*", "tmpk_x17fq8"]
+extend-exclude = [
+  "artifacts",
+  "build",
+  "dist",
+  "site",
+  ".pytest_tmp*",
+  ".tox_tmp*",
+  ".virtualenv_appdata",
+  "pytest_tmp*",
+  "tmpk_x17fq8",
+]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]

--- a/scripts/profile_validation.py
+++ b/scripts/profile_validation.py
@@ -7,8 +7,8 @@ import time
 from dataclasses import dataclass
 from typing import Callable
 
-VALID_ENVS = ("lint", "docs", "py312", "package", "integration", "mcp-docker")
-DEFAULT_ENVS = ("lint", "docs", "py312", "package", "integration")
+VALID_ENVS = ("lint", "docs", "typecheck", "py312", "package", "integration", "mcp-docker")
+DEFAULT_ENVS = ("lint", "docs", "typecheck", "py312", "package", "integration")
 CI_PYTHON = (3, 12)
 
 

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar, cast
 
 import yaml
 
@@ -18,6 +18,7 @@ PAPER_ORDER_TYPES = {"day_market"}
 PAPER_POSITION_SIZING = {"full_equity_fractional"}
 PAPER_AGENT_BACKENDS = {"claude", "deterministic_consensus", "openai"}
 WEIGHT_TOLERANCE = 1e-6
+_ConfigSectionT = TypeVar("_ConfigSectionT")
 
 
 @dataclass(slots=True)
@@ -260,9 +261,12 @@ class ExperimentConfig:
         return self.resolve_path(path)
 
 
-def _section(cls: type[Any], data: dict[str, Any] | None) -> Any:
+def _section(
+    cls: type[_ConfigSectionT],
+    data: dict[str, Any] | None,
+) -> _ConfigSectionT:
     values = data or {}
-    allowed = {field.name for field in cls.__dataclass_fields__.values()}
+    allowed = {item.name for item in fields(cast(Any, cls))}
     filtered = {key: value for key, value in values.items() if key in allowed}
     return cls(**filtered)
 
@@ -586,6 +590,8 @@ def _validate_config(config: ExperimentConfig) -> None:
 def load_config(path: str | Path) -> ExperimentConfig:
     config_path = Path(path).resolve()
     payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    baselines_payload = payload.get("baselines") or {}
+    optimized_payload = baselines_payload.get("optimized") or {}
     paper_payload = payload.get("paper") or {}
     paper_notifications_payload = paper_payload.get("notifications") or {}
     paper_defaults = PaperConfig()
@@ -610,16 +616,13 @@ def load_config(path: str | Path) -> ExperimentConfig:
             ),
         ),
         baselines=BaselinesConfig(
-            buy_hold=(payload.get("baselines") or {}).get("buy_hold", True),
-            sma=_section(SMAConfig, (payload.get("baselines") or {}).get("sma")),
+            buy_hold=baselines_payload.get("buy_hold", True),
+            sma=_section(SMAConfig, baselines_payload.get("sma")),
             allocation=_section(
                 AllocationConfig,
-                (payload.get("baselines") or {}).get("allocation"),
+                baselines_payload.get("allocation"),
             ),
-            optimized=_section(
-                OptimizedConfig,
-                (payload.get("baselines") or {}).get("optimized"),
-            ),
+            optimized=_section(OptimizedConfig, optimized_payload),
         ),
         models=[
             _section(ModelSpec, item)
@@ -686,7 +689,7 @@ def load_config(path: str | Path) -> ExperimentConfig:
     _normalize_mapping_sections(config)
     config.baselines.optimized.views = [
         _section(BlackLittermanViewConfig, view)
-        for view in config.baselines.optimized.views
+        for view in optimized_payload.get("views") or []
     ]
     _validate_config(config)
     return config

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -23,8 +23,8 @@ def _load_module():
 def test_resolve_envs_defaults_to_ci_matching_lanes() -> None:
     module = _load_module()
 
-    assert module.resolve_envs(None) == ["lint", "docs", "py312", "package", "integration"]
-    assert module.resolve_envs([]) == ["lint", "docs", "py312", "package", "integration"]
+    assert module.resolve_envs(None) == ["lint", "docs", "typecheck", "py312", "package", "integration"]
+    assert module.resolve_envs([]) == ["lint", "docs", "typecheck", "py312", "package", "integration"]
 
 
 def test_resolve_envs_preserves_requested_order() -> None:
@@ -104,16 +104,17 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
 
     assert "preflight-fast" in parser["tox"]["env_list"]
     assert "preflight-slow" in parser["tox"]["env_list"]
+    assert "typecheck" in parser["tox"]["env_list"]
 
-    for env_name in ("lint", "docs", "package", "integration"):
+    for env_name in ("lint", "docs", "typecheck", "package", "integration"):
         assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
 
     assert parser["testenv:preflight-fast"]["basepython"] == "py312"
-    assert parser["testenv:preflight-fast"]["commands"].strip() == "{envpython} -m tox -e lint,docs,py312"
+    assert parser["testenv:preflight-fast"]["commands"].strip() == "{envpython} -m tox -e lint,docs,typecheck,py312"
 
     assert parser["testenv:preflight-slow"]["basepython"] == "py312"
     assert parser["testenv:preflight-slow"]["commands"].strip() == "{envpython} -m tox -e package,integration"
 
     assert parser["testenv:preflight"]["basepython"] == "py312"
-    assert parser["testenv:preflight"]["commands"].strip() == "{envpython} -m tox -e lint,docs,package,py312,integration"
+    assert parser["testenv:preflight"]["commands"].strip() == "{envpython} -m tox -e lint,docs,typecheck,package,py312,integration"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = lint, docs, py312, py313, py314, integration, package, mcp-docker, preflight-fast, preflight-slow, preflight
+env_list = lint, docs, typecheck, py312, py313, py314, integration, package, mcp-docker, preflight-fast, preflight-slow, preflight
 skip_missing_interpreters = true
 isolated_build = true
 work_dir = {tox_root}{/}.tox
@@ -40,6 +40,15 @@ deps =
 commands =
     {envpython} -m mkdocs build --strict
 
+[testenv:typecheck]
+description = Run mypy across the current typed MarketLab module subset
+basepython = py312
+package = editable
+deps =
+    mypy>=1.20
+commands =
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py
+
 [testenv:package]
 description = Build source and wheel distributions
 basepython = py312
@@ -74,7 +83,7 @@ env_dir = {work_dir}{/}.preflight-fast-local
 deps =
     tox>=4.0
 commands =
-    {envpython} -m tox -e lint,docs,py312
+    {envpython} -m tox -e lint,docs,typecheck,py312
 
 [testenv:preflight-slow]
 description = Run the slow local validation gate through the CI-aligned tox envs
@@ -94,4 +103,4 @@ env_dir = {work_dir}{/}.preflight-local
 deps =
     tox>=4.0
 commands =
-    {envpython} -m tox -e lint,docs,package,py312,integration
+    {envpython} -m tox -e lint,docs,typecheck,package,py312,integration


### PR DESCRIPTION
## Summary
- add a narrow mypy bootstrap for core config and paper utility modules
- wire a new 	ypecheck tox lane into CI and local preflight flows
- tighten the scoped config typing without changing runtime paper behavior

## Validation
- py -3.14 -m tox -e typecheck
- 	ests/unit/test_config.py tests/unit/test_cli.py tests/unit/test_paper_alpaca.py tests/unit/test_paper_notifications.py tests/unit/test_profile_validation.py
- py -3.14 -m tox -e preflight

## Notes
- 	ypecheck remains intentionally narrow and non-strict in Phase 1.
- The local host needed a temp-dir workaround for tox and pytest; the validated repo behavior is unchanged.