### PR TITLE
feat: add typed paper phase contracts and protocol interfaces

### DIFF
--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from marketlab.config import ExperimentConfig
 from marketlab.env import load_env_file
-from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+from marketlab.paper.contracts import PaperApprovalResult, PaperBroker
 from marketlab.paper.notifications import (
     PaperLoopStageError,
     TelegramTransport,
@@ -533,10 +533,15 @@ def _evaluate_with_fallback(
 def _current_account_context(
     config: ExperimentConfig,
     *,
-    broker: AlpacaPaperBrokerClient | None = None,
+    broker: PaperBroker | None = None,
 ) -> dict[str, Any]:
     symbol = str(config.data.symbols[0])
-    client = broker or AlpacaPaperBrokerClient()
+    if broker is None:
+        from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+
+        client: PaperBroker = AlpacaPaperBrokerClient()
+    else:
+        client = broker
     account = client.get_account()
     position = client.get_position(symbol)
     return {
@@ -549,7 +554,7 @@ def run_agent_approval_iteration(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
-    broker: AlpacaPaperBrokerClient | None = None,
+    broker: PaperBroker | None = None,
     notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
@@ -604,6 +609,7 @@ def run_agent_approval_iteration(
                 now=now,
                 notification_transport=notification_transport,
             )
+            approval_result = PaperApprovalResult.from_legacy(result)
             events.append(
                 {
                     "proposal_id": proposal["proposal_id"],
@@ -612,7 +618,7 @@ def run_agent_approval_iteration(
                     "model": "",
                     "fallback_used": False,
                     "fallback_reason": str(exc),
-                    "approval_path": result["approval_path"],
+                    "approval_path": approval_result.approval_path,
                 }
             )
             continue
@@ -637,6 +643,7 @@ def run_agent_approval_iteration(
                 now=now,
                 notification_transport=notification_transport,
             )
+            approval_result = PaperApprovalResult.from_legacy(result)
         except Exception as exc:
             raise PaperLoopStageError(
                 loop_name="agent",
@@ -653,7 +660,7 @@ def run_agent_approval_iteration(
                 "model": decision.model,
                 "fallback_used": decision.fallback_used,
                 "fallback_reason": decision.fallback_reason,
-                "approval_path": result["approval_path"],
+                "approval_path": approval_result.approval_path,
             }
         )
 

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, runtime_checkable
+
+import pandas as pd
+from typing_extensions import Protocol
+
+
+def _string_field(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key, "")
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _status_field(payload: dict[str, Any]) -> dict[str, Any]:
+    status = payload.get("status", {})
+    if not isinstance(status, dict):
+        return {}
+    return dict(status)
+
+
+@runtime_checkable
+class PaperHistoryProvider(Protocol):
+    def download_symbol_history(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        interval: str,
+    ) -> pd.DataFrame: ...
+
+
+@runtime_checkable
+class PaperBroker(Protocol):
+    def get_calendar(
+        self,
+        *,
+        start_date: date,
+        end_date: date,
+    ) -> list[dict[str, Any]]: ...
+
+    def get_account(self) -> dict[str, Any]: ...
+
+    def get_position(self, symbol: str) -> dict[str, Any] | None: ...
+
+    def submit_fractional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        qty: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, Any]: ...
+
+    def submit_notional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        notional: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, Any]: ...
+
+    def get_order(self, order_id: str) -> dict[str, Any]: ...
+
+
+@dataclass(slots=True, frozen=True)
+class PaperDecisionResult:
+    proposal_id: str = ""
+    proposal_path: str = ""
+    evidence_path: str = ""
+    status_path: str = ""
+    status: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_legacy(cls, payload: dict[str, Any]) -> PaperDecisionResult:
+        return cls(
+            proposal_id=_string_field(payload, "proposal_id"),
+            proposal_path=_string_field(payload, "proposal_path"),
+            evidence_path=_string_field(payload, "evidence_path"),
+            status_path=_string_field(payload, "status_path"),
+            status=_status_field(payload),
+        )
+
+    def as_legacy_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status_path": self.status_path,
+            "status": dict(self.status),
+        }
+        if self.proposal_id:
+            payload["proposal_id"] = self.proposal_id
+        if self.proposal_path:
+            payload["proposal_path"] = self.proposal_path
+        if self.evidence_path:
+            payload["evidence_path"] = self.evidence_path
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class PaperApprovalResult:
+    proposal_id: str = ""
+    proposal_path: str = ""
+    approval_path: str = ""
+    status_path: str = ""
+    status: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_legacy(cls, payload: dict[str, Any]) -> PaperApprovalResult:
+        return cls(
+            proposal_id=_string_field(payload, "proposal_id"),
+            proposal_path=_string_field(payload, "proposal_path"),
+            approval_path=_string_field(payload, "approval_path"),
+            status_path=_string_field(payload, "status_path"),
+            status=_status_field(payload),
+        )
+
+    def as_legacy_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status_path": self.status_path,
+            "status": dict(self.status),
+        }
+        if self.proposal_id:
+            payload["proposal_id"] = self.proposal_id
+        if self.proposal_path:
+            payload["proposal_path"] = self.proposal_path
+        if self.approval_path:
+            payload["approval_path"] = self.approval_path
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class PaperSubmissionResult:
+    proposal_id: str = ""
+    submission_path: str = ""
+    status_path: str = ""
+    status: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_legacy(cls, payload: dict[str, Any]) -> PaperSubmissionResult:
+        return cls(
+            proposal_id=_string_field(payload, "proposal_id"),
+            submission_path=_string_field(payload, "submission_path"),
+            status_path=_string_field(payload, "status_path"),
+            status=_status_field(payload),
+        )
+
+    def as_legacy_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status_path": self.status_path,
+            "status": dict(self.status),
+        }
+        if self.proposal_id:
+            payload["proposal_id"] = self.proposal_id
+        if self.submission_path:
+            payload["submission_path"] = self.submission_path
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class PaperReconciliationResult:
+    proposal_id: str
+    submission_path: str
+    order_status_path: str
+    order_status: str
+    poll_status: str
+
+    @classmethod
+    def from_legacy(cls, payload: dict[str, Any]) -> PaperReconciliationResult:
+        return cls(
+            proposal_id=_string_field(payload, "proposal_id"),
+            submission_path=_string_field(payload, "submission_path"),
+            order_status_path=_string_field(payload, "order_status_path"),
+            order_status=_string_field(payload, "order_status"),
+            poll_status=_string_field(payload, "poll_status"),
+        )
+
+    def as_legacy_payload(self) -> dict[str, Any]:
+        return {
+            "proposal_id": self.proposal_id,
+            "submission_path": self.submission_path,
+            "order_status_path": self.order_status_path,
+            "order_status": self.order_status,
+            "poll_status": self.poll_status,
+        }

--- a/src/marketlab/paper/report.py
+++ b/src/marketlab/paper/report.py
@@ -8,7 +8,7 @@ from typing import Any
 import pandas as pd
 
 from marketlab.config import ExperimentConfig
-from marketlab.paper.alpaca import AlpacaMarketDataProvider
+from marketlab.paper.contracts import PaperHistoryProvider
 from marketlab.paper.service import (
     PaperStateStore,
     _paper_symbol,
@@ -63,11 +63,17 @@ def _load_price_frame(
     symbol: str,
     start_date: str,
     end_date: str,
-    provider: AlpacaMarketDataProvider | None = None,
+    provider: PaperHistoryProvider | None = None,
 ) -> pd.DataFrame:
     slow_window = int(config.baselines.sma.slow_window)
     start_lookup = (pd.Timestamp(start_date) - timedelta(days=max(120, slow_window * 3))).date()
-    frame = (provider or AlpacaMarketDataProvider()).download_symbol_history(
+    if provider is None:
+        from marketlab.paper.alpaca import AlpacaMarketDataProvider
+
+        history_provider: PaperHistoryProvider = AlpacaMarketDataProvider()
+    else:
+        history_provider = provider
+    frame = history_provider.download_symbol_history(
         symbol,
         start_lookup.isoformat(),
         end_date,
@@ -258,7 +264,7 @@ def run_paper_report(
     *,
     start_date: str,
     end_date: str,
-    provider: AlpacaMarketDataProvider | None = None,
+    provider: PaperHistoryProvider | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     symbol = _paper_symbol(config)

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.paper.contracts import (
+    PaperDecisionResult,
+    PaperReconciliationResult,
+    PaperSubmissionResult,
+)
 from marketlab.paper.notifications import (
     PaperLoopStageError,
     TelegramTransport,
@@ -143,13 +148,14 @@ def run_scheduler_iteration(
                 now=now,
                 notification_transport=notification_transport,
             )
+            decision_result = PaperDecisionResult.from_legacy(result)
         except Exception as exc:
             raise PaperLoopStageError(
                 loop_name="scheduler",
                 stage="paper-decision",
                 cause=exc,
             ) from exc
-        events.append({"phase": "decision", **result})
+        events.append({"phase": "decision", **decision_result.as_legacy_payload()})
         state["last_decision_market_date"] = market_date
         state["last_decision_at"] = _now_utc(now).isoformat()
 
@@ -160,6 +166,7 @@ def run_scheduler_iteration(
                 now=now,
                 notification_transport=notification_transport,
             )
+            submission_result = PaperSubmissionResult.from_legacy(result)
         except Exception as exc:
             proposal = PaperStateStore(config).latest_proposal()
             raise PaperLoopStageError(
@@ -169,7 +176,7 @@ def run_scheduler_iteration(
                 proposal_id=str((proposal or {}).get("proposal_id", "")),
                 trade_date=str((proposal or {}).get("effective_date", "")),
             ) from exc
-        events.append({"phase": "submission", **result})
+        events.append({"phase": "submission", **submission_result.as_legacy_payload()})
         state["last_submission_market_date"] = market_date
         state["last_submission_at"] = _now_utc(now).isoformat()
 
@@ -185,7 +192,8 @@ def run_scheduler_iteration(
             trade_date=str((proposal or {}).get("effective_date", "")),
         ) from exc
     if reconciliation is not None:
-        events.append({"phase": "submission_reconcile", **reconciliation})
+        reconciliation_result = PaperReconciliationResult.from_legacy(reconciliation)
+        events.append({"phase": "submission_reconcile", **reconciliation_result.as_legacy_payload()})
 
     _clear_scheduler_error_state(state)
     state["last_checked_at"] = _now_utc(now).isoformat()

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -25,6 +25,7 @@ from marketlab.paper.alpaca import (
     AlpacaMarketDataProvider,
     AlpacaPaperBrokerClient,
 )
+from marketlab.paper.contracts import PaperBroker, PaperHistoryProvider
 from marketlab.paper.notifications import (
     TelegramTransport,
     build_approval_message,
@@ -475,7 +476,7 @@ def _notify_paper_submission(
 
 def _build_alpaca_panel(
     config: ExperimentConfig,
-    provider: AlpacaMarketDataProvider | None = None,
+    provider: PaperHistoryProvider | None = None,
 ) -> pd.DataFrame:
     frames = load_symbol_frames(
         config,
@@ -486,7 +487,7 @@ def _build_alpaca_panel(
 
 
 def _is_trading_day(
-    broker: AlpacaPaperBrokerClient,
+    broker: PaperBroker,
     *,
     market_date: date,
 ) -> bool:
@@ -495,7 +496,7 @@ def _is_trading_day(
 
 
 def _next_trading_date(
-    broker: AlpacaPaperBrokerClient,
+    broker: PaperBroker,
     *,
     market_date: date,
 ) -> date:
@@ -632,8 +633,8 @@ def run_paper_decision(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
-    provider: AlpacaMarketDataProvider | None = None,
-    broker: AlpacaPaperBrokerClient | None = None,
+    provider: PaperHistoryProvider | None = None,
+    broker: PaperBroker | None = None,
     notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
@@ -1089,7 +1090,7 @@ def reconcile_latest_submission_status(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
-    broker: AlpacaPaperBrokerClient | None = None,
+    broker: PaperBroker | None = None,
 ) -> dict[str, Any] | None:
     validate_paper_trading_config(config)
     store = PaperStateStore(config)
@@ -1142,7 +1143,7 @@ def run_paper_submit(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
-    broker: AlpacaPaperBrokerClient | None = None,
+    broker: PaperBroker | None = None,
     notification_transport: TelegramTransport | None = None,
     retry_failed_submission: bool = False,
 ) -> dict[str, Any]:

--- a/tests/unit/test_paper_contracts.py
+++ b/tests/unit/test_paper_contracts.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from tests._paper_fakes import FakeAlpacaBroker, FakeAlpacaProvider
+
+from marketlab.paper.contracts import (
+    PaperApprovalResult,
+    PaperBroker,
+    PaperDecisionResult,
+    PaperHistoryProvider,
+    PaperReconciliationResult,
+    PaperSubmissionResult,
+)
+
+
+def test_paper_protocols_match_existing_fake_adapters() -> None:
+    assert isinstance(FakeAlpacaProvider(), PaperHistoryProvider)
+    assert isinstance(FakeAlpacaBroker(), PaperBroker)
+
+
+def test_paper_decision_result_round_trips_legacy_payload() -> None:
+    payload = {
+        "proposal_id": "proposal-1",
+        "proposal_path": "proposal.json",
+        "evidence_path": "evidence.json",
+        "status_path": "status.json",
+        "status": {"event": "paper-decision", "status": "proposal_created"},
+    }
+
+    result = PaperDecisionResult.from_legacy(payload)
+
+    assert result.as_legacy_payload() == payload
+
+
+def test_paper_approval_result_round_trips_legacy_payload() -> None:
+    payload = {
+        "proposal_id": "proposal-1",
+        "proposal_path": "proposal.json",
+        "approval_path": "approval.json",
+        "status_path": "status.json",
+        "status": {"event": "paper-approve", "status": "approved"},
+    }
+
+    result = PaperApprovalResult.from_legacy(payload)
+
+    assert result.as_legacy_payload() == payload
+
+
+def test_paper_submission_result_round_trips_legacy_payload() -> None:
+    payload = {
+        "proposal_id": "proposal-1",
+        "submission_path": "submission.json",
+        "status_path": "status.json",
+        "status": {"event": "paper-submit", "status": "submitted"},
+    }
+
+    result = PaperSubmissionResult.from_legacy(payload)
+
+    assert result.as_legacy_payload() == payload
+
+
+def test_paper_reconciliation_result_round_trips_legacy_payload() -> None:
+    payload = {
+        "proposal_id": "proposal-1",
+        "submission_path": "submission.json",
+        "order_status_path": "order_status.json",
+        "order_status": "rejected",
+        "poll_status": "observed",
+    }
+
+    result = PaperReconciliationResult.from_legacy(payload)
+
+    assert result.as_legacy_payload() == payload

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -108,6 +108,12 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
 
     for env_name in ("lint", "docs", "typecheck", "package", "integration"):
         assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
+    assert parser["testenv:typecheck"]["commands"].strip() == (
+        "{envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py "
+        "src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py "
+        "src/marketlab/paper/contracts.py src/marketlab/paper/agent.py "
+        "src/marketlab/paper/scheduler.py"
+    )
 
     assert parser["testenv:preflight-fast"]["basepython"] == "py312"
     assert parser["testenv:preflight-fast"]["commands"].strip() == "{envpython} -m tox -e lint,docs,typecheck,py312"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
Summary: add typed internal paper contracts, extend the narrow Phase 1 mypy scope to contracts plus agent and scheduler seams, and add focused contract tests. Validation: direct mypy on contracts/agent/scheduler, targeted pytest for paper contracts and call sites, tox typecheck, and tox preflight. Notes: no runtime behavior, artifact semantics, scheduler timing, CLI commands, or MCP behavior changed; paper/service.py remains outside the mypy gate in Phase 1.