### PR TITLE
refactor: extract paper submission and reconciliation services

### DIFF
--- a/src/marketlab/paper/application/__init__.py
+++ b/src/marketlab/paper/application/__init__.py
@@ -1,7 +1,11 @@
 from .approval import ApprovalService
 from .decision import DecisionService
+from .reconciliation import ReconciliationService
+from .submission import SubmissionService
 
 __all__ = [
     "ApprovalService",
     "DecisionService",
+    "ReconciliationService",
+    "SubmissionService",
 ]

--- a/src/marketlab/paper/application/reconciliation.py
+++ b/src/marketlab/paper/application/reconciliation.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from marketlab.config import ExperimentConfig
+from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+from marketlab.paper.contracts import (
+    PaperBroker,
+    PaperReconciliationRequest,
+    PaperReconciliationResult,
+)
+from marketlab.paper.core import (
+    SUBMISSION_SUBMITTED,
+    TERMINAL_ORDER_STATUSES,
+    _now_utc,
+    validate_paper_trading_config,
+)
+from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+
+
+def _poll_order_status(
+    *,
+    broker_client: PaperBroker,
+    order_id: str,
+    fallback_status: str,
+    client_order_id: str,
+) -> tuple[dict[str, Any], str]:
+    try:
+        order_status = broker_client.get_order(order_id)
+        poll_status = "observed"
+    except RuntimeError as exc:
+        order_status = {
+            "id": order_id,
+            "client_order_id": client_order_id,
+            "status": fallback_status,
+            "poll_error": str(exc),
+        }
+        poll_status = "timeout"
+    return order_status, poll_status
+
+
+def _latest_submitted_proposal_requiring_reconciliation(
+    store: PaperStateStore,
+) -> tuple[dict[str, Any], dict[str, Any], Path] | None:
+    for proposal in store.list_proposals():
+        trade_date = str(proposal.get("effective_date", ""))
+        if trade_date == "":
+            continue
+        submission_path = store.trade_submission_path(trade_date)
+        if not submission_path.exists():
+            continue
+        submission = _json_load(submission_path)
+        if submission.get("status") != SUBMISSION_SUBMITTED:
+            continue
+        order_status = str(submission.get("order_status", "")).lower()
+        if order_status in TERMINAL_ORDER_STATUSES:
+            continue
+        return proposal, submission, submission_path
+    return None
+
+
+def _refresh_submission_order_status(
+    store: PaperStateStore,
+    *,
+    proposal: dict[str, Any],
+    submission: dict[str, Any],
+    broker_client: PaperBroker,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if submission.get("status") != SUBMISSION_SUBMITTED:
+        return None
+
+    order_id = str(submission.get("order_id", "")).strip()
+    if order_id == "":
+        return None
+
+    current_order_status = str(submission.get("order_status", "")).lower()
+    if current_order_status in TERMINAL_ORDER_STATUSES:
+        return None
+
+    order_status, poll_status = _poll_order_status(
+        broker_client=broker_client,
+        order_id=order_id,
+        fallback_status=current_order_status or "unknown",
+        client_order_id=str(submission.get("client_order_id", "")),
+    )
+    refreshed_order_status = str(order_status.get("status", current_order_status or "unknown")).lower()
+    current_poll_status = str(submission.get("poll_status", "")).lower()
+    trade_date = str(submission["trade_date"])
+    order_status_path = store.trade_order_status_path(trade_date)
+    if (
+        refreshed_order_status == current_order_status
+        and poll_status == current_poll_status
+        and order_status_path.exists()
+    ):
+        return None
+
+    _json_dump(order_status_path, order_status)
+    refreshed_submission = dict(submission)
+    refreshed_submission["order_status"] = refreshed_order_status
+    refreshed_submission["poll_status"] = poll_status
+    refreshed_submission["order_status_path"] = str(order_status_path)
+    refreshed_submission["updated_at"] = _now_utc(now).isoformat()
+    submission_path = store.trade_submission_path(trade_date)
+    _json_dump(submission_path, refreshed_submission)
+    status = {
+        "event": "paper-submit",
+        "status": refreshed_submission["status"],
+        "proposal_id": refreshed_submission["proposal_id"],
+        "submission_path": str(submission_path),
+        "order_status": refreshed_order_status,
+        "updated_at": _now_utc(now).isoformat(),
+    }
+    store.write_status(status)
+    return refreshed_submission
+
+
+class ReconciliationService:
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._config = config
+
+    def run(
+        self,
+        request: PaperReconciliationRequest,
+    ) -> PaperReconciliationResult | None:
+        validate_paper_trading_config(self._config)
+        store = PaperStateStore(self._config)
+        latest_submitted = _latest_submitted_proposal_requiring_reconciliation(store)
+        if latest_submitted is None:
+            return None
+
+        proposal, submission, submission_path = latest_submitted
+        trade_date = str(submission["trade_date"])
+        broker_client = request.broker or AlpacaPaperBrokerClient()
+        refreshed_submission = _refresh_submission_order_status(
+            store,
+            proposal=proposal,
+            submission=submission,
+            broker_client=broker_client,
+            now=request.now,
+        )
+        if refreshed_submission is None:
+            return None
+
+        return PaperReconciliationResult(
+            proposal_id=str(proposal["proposal_id"]),
+            submission_path=str(submission_path),
+            order_status_path=str(store.trade_order_status_path(trade_date)),
+            order_status=str(refreshed_submission["order_status"]),
+            poll_status=str(refreshed_submission.get("poll_status", "")),
+            submission=refreshed_submission,
+        )

--- a/src/marketlab/paper/application/submission.py
+++ b/src/marketlab/paper/application/submission.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from marketlab.config import ExperimentConfig
+from marketlab.paper.alpaca import AlpacaPaperBrokerClient
+from marketlab.paper.contracts import (
+    PaperSubmissionRequest,
+    PaperSubmissionResult,
+)
+from marketlab.paper.core import (
+    ALPACA_MIN_NOTIONAL_ORDER,
+    APPROVAL_APPROVED,
+    APPROVAL_PENDING,
+    APPROVAL_REJECTED,
+    FAILED_ORDER_STATUSES,
+    SUBMISSION_NOOP,
+    SUBMISSION_SKIPPED,
+    SUBMISSION_SUBMITTED,
+    _buy_order_notional,
+    _client_order_id,
+    _clock_value,
+    _local_now,
+    _now_utc,
+    _paper_symbol,
+    _position_market_value,
+    _rounded_notional,
+    _safe_float,
+    validate_paper_trading_config,
+)
+from marketlab.paper.notifications import notify_paper_submission
+from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+
+from .reconciliation import _poll_order_status, _refresh_submission_order_status
+
+
+def _submission_gate_status(
+    config: ExperimentConfig,
+    proposal: dict[str, object],
+) -> tuple[str, str]:
+    if config.paper.execution_mode == "autonomous":
+        return "ready", ""
+
+    approval_status = proposal.get("approval_status", APPROVAL_PENDING)
+    if approval_status == APPROVAL_REJECTED:
+        return SUBMISSION_SKIPPED, "rejected"
+    if approval_status != APPROVAL_APPROVED:
+        return SUBMISSION_SKIPPED, "missing_approval"
+
+    required_actor = "agent" if config.paper.execution_mode == "agent_approval" else "manual"
+    if proposal.get("approval_actor") != required_actor:
+        return SUBMISSION_SKIPPED, "wrong_actor"
+    return "ready", ""
+
+
+def _backup_submission_attempt_artifacts(
+    store: PaperStateStore,
+    *,
+    trade_date: str,
+    now: datetime | None = None,
+) -> None:
+    timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
+    for path in (
+        store.trade_submission_path(trade_date),
+        store.trade_order_status_path(trade_date),
+        store.trade_order_preview_path(trade_date),
+        store.trade_account_snapshot_path(trade_date),
+    ):
+        if not path.exists():
+            continue
+        backup_path = path.with_name(f"{path.stem}.retry-backup.{timestamp}.bak")
+        path.rename(backup_path)
+
+
+class SubmissionService:
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._config = config
+
+    def run(self, request: PaperSubmissionRequest) -> PaperSubmissionResult:
+        config = self._config
+        validate_paper_trading_config(config)
+        paper_symbol = _paper_symbol(config)
+        store = PaperStateStore(config)
+        proposal = store.latest_proposal()
+        if proposal is None:
+            status = {
+                "event": "paper-submit",
+                "status": SUBMISSION_SKIPPED,
+                "reason": "no_proposal",
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            status_path = store.write_status(status)
+            notify_paper_submission(
+                config,
+                store,
+                outcome=SUBMISSION_SKIPPED,
+                status=status,
+                now=request.now,
+                transport=request.notification_transport,
+            )
+            return PaperSubmissionResult(
+                status_path=str(status_path),
+                status=status,
+            )
+
+        trade_date = str(proposal["effective_date"])
+        submission_path = store.trade_submission_path(trade_date)
+        if submission_path.exists():
+            submission = _json_load(submission_path)
+            broker_client = request.broker or AlpacaPaperBrokerClient()
+            refreshed_submission = _refresh_submission_order_status(
+                store,
+                proposal=proposal,
+                submission=submission,
+                broker_client=broker_client,
+                now=request.now,
+            )
+            if refreshed_submission is not None:
+                submission = refreshed_submission
+            order_status = str(submission.get("order_status", "")).lower()
+            if not request.retry_failed_submission or order_status not in FAILED_ORDER_STATUSES:
+                status = {
+                    "event": "paper-submit",
+                    "status": "existing_submission",
+                    "proposal_id": proposal["proposal_id"],
+                    "submission_path": str(submission_path),
+                    "order_status": submission.get("order_status", ""),
+                    "updated_at": _now_utc(request.now).isoformat(),
+                }
+                status_path = store.write_status(status)
+                notify_paper_submission(
+                    config,
+                    store,
+                    outcome="existing_submission",
+                    status=status,
+                    proposal=proposal,
+                    submission=submission,
+                    now=request.now,
+                    transport=request.notification_transport,
+                )
+                return PaperSubmissionResult(
+                    proposal_id=str(proposal["proposal_id"]),
+                    submission_path=str(submission_path),
+                    status_path=str(status_path),
+                    status=status,
+                    submission=submission,
+                )
+
+            _backup_submission_attempt_artifacts(store, trade_date=trade_date, now=request.now)
+            retry_suffix = _now_utc(request.now).strftime("retry%H%M%S")
+        else:
+            local_now = _local_now(config, request.now)
+            submission_clock = _clock_value(config.paper.submission_time)
+            if local_now.time() < submission_clock:
+                raise RuntimeError(
+                    "paper-submit is only allowed at or after "
+                    f"{config.paper.submission_time} {config.paper.schedule_timezone}."
+                )
+            broker_client = request.broker or AlpacaPaperBrokerClient()
+            retry_suffix = ""
+
+        gate_status, gate_reason = _submission_gate_status(config, proposal)
+        if gate_status != "ready":
+            submission = {
+                "proposal_id": proposal["proposal_id"],
+                "trade_date": trade_date,
+                "status": gate_status,
+                "reason": gate_reason,
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            _json_dump(submission_path, submission)
+            status = {
+                "event": "paper-submit",
+                "status": gate_status,
+                "reason": gate_reason,
+                "proposal_id": proposal["proposal_id"],
+                "submission_path": str(submission_path),
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            status_path = store.write_status(status)
+            notify_paper_submission(
+                config,
+                store,
+                outcome=gate_status,
+                status=status,
+                proposal=proposal,
+                submission=submission,
+                now=request.now,
+                transport=request.notification_transport,
+            )
+            return PaperSubmissionResult(
+                proposal_id=str(proposal["proposal_id"]),
+                submission_path=str(submission_path),
+                status_path=str(status_path),
+                status=status,
+                submission=submission,
+            )
+
+        account = broker_client.get_account()
+        _json_dump(store.trade_account_snapshot_path(trade_date), account)
+        position = broker_client.get_position(paper_symbol)
+        current_qty = _safe_float((position or {}).get("qty"))
+        current_market_value = _position_market_value(
+            position,
+            reference_price=float(proposal["reference_price"]),
+        )
+        equity = _safe_float(account.get("equity"))
+        buying_power = _safe_float(
+            account.get("buying_power"),
+            default=_safe_float(account.get("cash"), default=equity),
+        )
+        reference_price = float(proposal["reference_price"])
+        target_weight = _safe_float(proposal.get("target_weight"))
+        current_signed_market_value = current_qty * reference_price
+        hold_existing_long = (
+            target_weight > 0.0
+            and current_qty > 0.0
+            and current_market_value >= ALPACA_MIN_NOTIONAL_ORDER
+        )
+        desired_notional = 0.0
+        order_notional = 0.0
+        gap_notional = 0.0
+        desired_qty = 0.0
+        if target_weight > 0.0:
+            if hold_existing_long:
+                desired_notional = current_market_value
+                desired_qty = current_qty
+            else:
+                desired_notional, order_notional = _buy_order_notional(
+                    equity=equity,
+                    buying_power=buying_power,
+                    current_market_value=current_signed_market_value,
+                    target_weight=target_weight,
+                )
+                gap_notional = max(desired_notional - current_signed_market_value, 0.0)
+                order_notional = _rounded_notional(order_notional)
+                desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
+        delta_qty = round(desired_qty - current_qty, 6)
+        if delta_qty > 1e-6:
+            side = "buy"
+        elif delta_qty < -1e-6:
+            side = "sell"
+        else:
+            side = "none"
+        order_preview = {
+            "proposal_id": proposal["proposal_id"],
+            "trade_date": trade_date,
+            "symbol": paper_symbol,
+            "equity": equity,
+            "buying_power": buying_power,
+            "reference_price": reference_price,
+            "current_qty": current_qty,
+            "current_market_value": current_market_value,
+            "desired_notional": desired_notional,
+            "order_notional": order_notional,
+            "desired_qty": desired_qty,
+            "delta_qty": delta_qty,
+            "side": side,
+            "updated_at": _now_utc(request.now).isoformat(),
+        }
+        _json_dump(store.trade_order_preview_path(trade_date), order_preview)
+
+        if side == "none" or (side == "buy" and order_notional < ALPACA_MIN_NOTIONAL_ORDER):
+            buy_reason = "already_at_target"
+            if _rounded_notional(gap_notional) >= ALPACA_MIN_NOTIONAL_ORDER:
+                buy_reason = "insufficient_buying_power"
+            submission = {
+                "proposal_id": proposal["proposal_id"],
+                "trade_date": trade_date,
+                "status": SUBMISSION_NOOP,
+                "reason": "already_at_target" if side == "none" else buy_reason,
+                "order_preview_path": str(store.trade_order_preview_path(trade_date)),
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            _json_dump(submission_path, submission)
+            status = {
+                "event": "paper-submit",
+                "status": SUBMISSION_NOOP,
+                "proposal_id": proposal["proposal_id"],
+                "submission_path": str(submission_path),
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            status_path = store.write_status(status)
+            notify_paper_submission(
+                config,
+                store,
+                outcome=SUBMISSION_NOOP,
+                status=status,
+                proposal=proposal,
+                submission=submission,
+                now=request.now,
+                transport=request.notification_transport,
+            )
+            return PaperSubmissionResult(
+                proposal_id=str(proposal["proposal_id"]),
+                submission_path=str(submission_path),
+                status_path=str(status_path),
+                status=status,
+                submission=submission,
+            )
+
+        client_order_id = _client_order_id(str(proposal["proposal_id"]), retry_suffix=retry_suffix)
+        if side == "buy":
+            order = broker_client.submit_notional_day_market_order(
+                symbol=paper_symbol,
+                notional=order_notional,
+                side=side,
+                client_order_id=client_order_id,
+            )
+        else:
+            order = broker_client.submit_fractional_day_market_order(
+                symbol=paper_symbol,
+                qty=abs(delta_qty),
+                side=side,
+                client_order_id=client_order_id,
+            )
+        order_status, poll_status = _poll_order_status(
+            broker_client=broker_client,
+            order_id=str(order["id"]),
+            fallback_status=str(order.get("status", "unknown")),
+            client_order_id=str(order.get("client_order_id", client_order_id)),
+        )
+        _json_dump(store.trade_order_status_path(trade_date), order_status)
+
+        submission = {
+            "proposal_id": proposal["proposal_id"],
+            "trade_date": trade_date,
+            "status": SUBMISSION_SUBMITTED,
+            "side": side,
+            "qty": abs(delta_qty) if side == "sell" else None,
+            "notional": order_notional if side == "buy" else None,
+            "order_id": order["id"],
+            "client_order_id": order.get("client_order_id", client_order_id),
+            "order_status": str(order_status.get("status", order.get("status", "unknown"))).lower(),
+            "poll_status": poll_status,
+            "order_preview_path": str(store.trade_order_preview_path(trade_date)),
+            "account_snapshot_path": str(store.trade_account_snapshot_path(trade_date)),
+            "order_status_path": str(store.trade_order_status_path(trade_date)),
+            "updated_at": _now_utc(request.now).isoformat(),
+        }
+        _json_dump(submission_path, submission)
+        status = {
+            "event": "paper-submit",
+            "status": SUBMISSION_SUBMITTED,
+            "proposal_id": proposal["proposal_id"],
+            "submission_path": str(submission_path),
+            "order_status": submission["order_status"],
+            "updated_at": _now_utc(request.now).isoformat(),
+        }
+        status_path = store.write_status(status)
+        notify_paper_submission(
+            config,
+            store,
+            outcome=SUBMISSION_SUBMITTED,
+            status=status,
+            proposal=proposal,
+            submission=submission,
+            now=request.now,
+            transport=request.notification_transport,
+        )
+        return PaperSubmissionResult(
+            proposal_id=str(proposal["proposal_id"]),
+            submission_path=str(submission_path),
+            status_path=str(status_path),
+            status=status,
+            submission=submission,
+        )

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -1,48 +1,49 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 from marketlab.config import ExperimentConfig
-from marketlab.paper.alpaca import AlpacaPaperBrokerClient
-from marketlab.paper.application.approval import ApprovalService
-from marketlab.paper.application.decision import DecisionService
+from marketlab.paper.application import (
+    ApprovalService,
+    DecisionService,
+    ReconciliationService,
+    SubmissionService,
+)
 from marketlab.paper.contracts import (
     PaperApprovalRequest,
     PaperBroker,
     PaperDecisionRequest,
     PaperHistoryProvider,
+    PaperReconciliationRequest,
+    PaperSubmissionRequest,
 )
 from marketlab.paper.core import (
-    ALPACA_MIN_NOTIONAL_ORDER,
-    APPROVAL_APPROVED,
-    APPROVAL_PENDING,
-    APPROVAL_REJECTED,
-    FAILED_ORDER_STATUSES,
-    SUBMISSION_NOOP,
-    SUBMISSION_SKIPPED,
-    SUBMISSION_SUBMITTED,
-    TERMINAL_ORDER_STATUSES,
-    _buy_order_notional,
-    _client_order_id,
-    _clock_value,
-    _local_now,
-    _now_utc,
-    _paper_symbol,
-    _position_market_value,
-    _rounded_notional,
-    _safe_float,
+    APPROVAL_PENDING as _APPROVAL_PENDING,
+)
+from marketlab.paper.core import (
+    _clock_value as _core_clock_value,
+)
+from marketlab.paper.core import (
+    _local_now as _core_local_now,
+)
+from marketlab.paper.core import (
+    _now_utc as _core_now_utc,
+)
+from marketlab.paper.core import (
+    _paper_symbol as _core_paper_symbol,
+)
+from marketlab.paper.core import (
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import (
-    TelegramTransport,
-    notify_paper_submission,
-    write_notification_record,
-)
-from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+from marketlab.paper.notifications import TelegramTransport, write_notification_record
+from marketlab.paper.state import PaperStateStore
 
-_notify_paper_submission = notify_paper_submission
+APPROVAL_PENDING = _APPROVAL_PENDING
+_clock_value = _core_clock_value
+_local_now = _core_local_now
+_now_utc = _core_now_utc
+_paper_symbol = _core_paper_symbol
 _write_notification_record = write_notification_record
 
 
@@ -121,172 +122,21 @@ def decide_paper_proposal(
     return result.as_legacy_payload()
 
 
-def _submission_gate_status(
-    config: ExperimentConfig,
-    proposal: dict[str, Any],
-) -> tuple[str, str]:
-    if config.paper.execution_mode == "autonomous":
-        return "ready", ""
-
-    approval_status = proposal.get("approval_status", APPROVAL_PENDING)
-    if approval_status == APPROVAL_REJECTED:
-        return SUBMISSION_SKIPPED, "rejected"
-    if approval_status != APPROVAL_APPROVED:
-        return SUBMISSION_SKIPPED, "missing_approval"
-
-    required_actor = "agent" if config.paper.execution_mode == "agent_approval" else "manual"
-    if proposal.get("approval_actor") != required_actor:
-        return SUBMISSION_SKIPPED, "wrong_actor"
-    return "ready", ""
-
-
-def _poll_order_status(
-    *,
-    broker_client: AlpacaPaperBrokerClient,
-    order_id: str,
-    fallback_status: str,
-    client_order_id: str,
-) -> tuple[dict[str, Any], str]:
-    try:
-        order_status = broker_client.get_order(order_id)
-        poll_status = "observed"
-    except RuntimeError as exc:
-        order_status = {
-            "id": order_id,
-            "client_order_id": client_order_id,
-            "status": fallback_status,
-            "poll_error": str(exc),
-        }
-        poll_status = "timeout"
-    return order_status, poll_status
-
-
-def _latest_submitted_proposal_requiring_reconciliation(
-    store: PaperStateStore,
-) -> tuple[dict[str, Any], dict[str, Any], Path] | None:
-    for proposal in store.list_proposals():
-        trade_date = str(proposal.get("effective_date", ""))
-        if trade_date == "":
-            continue
-        submission_path = store.trade_submission_path(trade_date)
-        if not submission_path.exists():
-            continue
-        submission = _json_load(submission_path)
-        if submission.get("status") != SUBMISSION_SUBMITTED:
-            continue
-        order_status = str(submission.get("order_status", "")).lower()
-        if order_status in TERMINAL_ORDER_STATUSES:
-            continue
-        return proposal, submission, submission_path
-    return None
-
-
-def _refresh_submission_order_status(
-    config: ExperimentConfig,
-    store: PaperStateStore,
-    *,
-    proposal: dict[str, Any],
-    submission: dict[str, Any],
-    broker_client: AlpacaPaperBrokerClient,
-    now: datetime | None = None,
-) -> dict[str, Any] | None:
-    if submission.get("status") != SUBMISSION_SUBMITTED:
-        return None
-
-    order_id = str(submission.get("order_id", "")).strip()
-    if order_id == "":
-        return None
-
-    current_order_status = str(submission.get("order_status", "")).lower()
-    if current_order_status in TERMINAL_ORDER_STATUSES:
-        return None
-
-    order_status, poll_status = _poll_order_status(
-        broker_client=broker_client,
-        order_id=order_id,
-        fallback_status=current_order_status or "unknown",
-        client_order_id=str(submission.get("client_order_id", "")),
-    )
-    refreshed_order_status = str(order_status.get("status", current_order_status or "unknown")).lower()
-    current_poll_status = str(submission.get("poll_status", "")).lower()
-    if (
-        refreshed_order_status == current_order_status
-        and poll_status == current_poll_status
-        and store.trade_order_status_path(str(proposal["effective_date"])).exists()
-    ):
-        return None
-
-    trade_date = str(submission["trade_date"])
-    _json_dump(store.trade_order_status_path(trade_date), order_status)
-    refreshed_submission = dict(submission)
-    refreshed_submission["order_status"] = refreshed_order_status
-    refreshed_submission["poll_status"] = poll_status
-    refreshed_submission["order_status_path"] = str(store.trade_order_status_path(trade_date))
-    refreshed_submission["updated_at"] = _now_utc(now).isoformat()
-    _json_dump(store.trade_submission_path(trade_date), refreshed_submission)
-    status = {
-        "event": "paper-submit",
-        "status": refreshed_submission["status"],
-        "proposal_id": refreshed_submission["proposal_id"],
-        "submission_path": str(store.trade_submission_path(trade_date)),
-        "order_status": refreshed_order_status,
-        "updated_at": _now_utc(now).isoformat(),
-    }
-    store.write_status(status)
-    return refreshed_submission
-
-
 def reconcile_latest_submission_status(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
     broker: PaperBroker | None = None,
 ) -> dict[str, Any] | None:
-    validate_paper_trading_config(config)
-    store = PaperStateStore(config)
-    latest_submitted = _latest_submitted_proposal_requiring_reconciliation(store)
-    if latest_submitted is None:
-        return None
-    proposal, submission, submission_path = latest_submitted
-    trade_date = str(submission["trade_date"])
-    broker_client = broker or AlpacaPaperBrokerClient()
-    refreshed_submission = _refresh_submission_order_status(
-        config,
-        store,
-        proposal=proposal,
-        submission=submission,
-        broker_client=broker_client,
-        now=now,
+    result = ReconciliationService(config).run(
+        PaperReconciliationRequest(
+            now=now,
+            broker=broker,
+        )
     )
-    if refreshed_submission is None:
+    if result is None:
         return None
-
-    return {
-        "proposal_id": proposal["proposal_id"],
-        "submission_path": str(submission_path),
-        "order_status_path": str(store.trade_order_status_path(trade_date)),
-        "order_status": refreshed_submission["order_status"],
-        "poll_status": refreshed_submission.get("poll_status", ""),
-    }
-
-
-def _backup_submission_attempt_artifacts(
-    store: PaperStateStore,
-    *,
-    trade_date: str,
-    now: datetime | None = None,
-) -> None:
-    timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
-    for path in (
-        store.trade_submission_path(trade_date),
-        store.trade_order_status_path(trade_date),
-        store.trade_order_preview_path(trade_date),
-        store.trade_account_snapshot_path(trade_date),
-    ):
-        if not path.exists():
-            continue
-        backup_path = path.with_name(f"{path.stem}.retry-backup.{timestamp}.bak")
-        path.rename(backup_path)
+    return result.as_legacy_payload()
 
 
 def run_paper_submit(
@@ -297,281 +147,19 @@ def run_paper_submit(
     notification_transport: TelegramTransport | None = None,
     retry_failed_submission: bool = False,
 ) -> dict[str, Any]:
-    validate_paper_trading_config(config)
-    paper_symbol = _paper_symbol(config)
-    store = PaperStateStore(config)
-    proposal = store.latest_proposal()
-    if proposal is None:
-        status = {
-            "event": "paper-submit",
-            "status": SUBMISSION_SKIPPED,
-            "reason": "no_proposal",
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        _notify_paper_submission(
-            config,
-            store,
-            outcome=SUBMISSION_SKIPPED,
-            status=status,
+    result = SubmissionService(config).run(
+        PaperSubmissionRequest(
             now=now,
-            transport=notification_transport,
+            broker=broker,
+            notification_transport=notification_transport,
+            retry_failed_submission=retry_failed_submission,
         )
-        return {"status_path": str(status_path), "status": status}
-
-    trade_date = proposal["effective_date"]
-    submission_path = store.trade_submission_path(trade_date)
-    if submission_path.exists():
-        submission = _json_load(submission_path)
-        broker_client = broker or AlpacaPaperBrokerClient()
-        refreshed_submission = _refresh_submission_order_status(
-            config,
-            store,
-            proposal=proposal,
-            submission=submission,
-            broker_client=broker_client,
-            now=now,
-        )
-        if refreshed_submission is not None:
-            submission = refreshed_submission
-        order_status = str(submission.get("order_status", "")).lower()
-        if not retry_failed_submission or order_status not in FAILED_ORDER_STATUSES:
-            status = {
-                "event": "paper-submit",
-                "status": "existing_submission",
-                "proposal_id": proposal["proposal_id"],
-                "submission_path": str(submission_path),
-                "order_status": submission.get("order_status", ""),
-                "updated_at": _now_utc(now).isoformat(),
-            }
-            status_path = store.write_status(status)
-            _notify_paper_submission(
-                config,
-                store,
-                outcome="existing_submission",
-                status=status,
-                proposal=proposal,
-                submission=submission,
-                now=now,
-                transport=notification_transport,
-            )
-            return {
-                "submission_path": str(submission_path),
-                "status_path": str(status_path),
-                "status": status,
-                "submission": submission,
-            }
-
-        _backup_submission_attempt_artifacts(store, trade_date=trade_date, now=now)
-        retry_suffix = _now_utc(now).strftime("retry%H%M%S")
-    else:
-        local_now = _local_now(config, now)
-        submission_clock = _clock_value(config.paper.submission_time)
-        if local_now.time() < submission_clock:
-            raise RuntimeError(
-                "paper-submit is only allowed at or after "
-                f"{config.paper.submission_time} {config.paper.schedule_timezone}."
-            )
-        broker_client = broker or AlpacaPaperBrokerClient()
-        retry_suffix = ""
-
-    gate_status, gate_reason = _submission_gate_status(config, proposal)
-    if gate_status != "ready":
-        submission = {
-            "proposal_id": proposal["proposal_id"],
-            "trade_date": trade_date,
-            "status": gate_status,
-            "reason": gate_reason,
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        _json_dump(submission_path, submission)
-        status = {
-            "event": "paper-submit",
-            "status": gate_status,
-            "reason": gate_reason,
-            "proposal_id": proposal["proposal_id"],
-            "submission_path": str(submission_path),
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        _notify_paper_submission(
-            config,
-            store,
-            outcome=gate_status,
-            status=status,
-            proposal=proposal,
-            submission=submission,
-            now=now,
-            transport=notification_transport,
-        )
-        return {
-            "submission_path": str(submission_path),
-            "status_path": str(status_path),
-            "status": status,
-            "submission": submission,
-        }
-
-    account = broker_client.get_account()
-    _json_dump(store.trade_account_snapshot_path(trade_date), account)
-    position = broker_client.get_position(paper_symbol)
-    current_qty = _safe_float((position or {}).get("qty"))
-    current_market_value = _position_market_value(position, reference_price=float(proposal["reference_price"]))
-    equity = _safe_float(account.get("equity"))
-    buying_power = _safe_float(account.get("buying_power"), default=_safe_float(account.get("cash"), default=equity))
-    reference_price = float(proposal["reference_price"])
-    target_weight = _safe_float(proposal.get("target_weight"))
-    current_signed_market_value = current_qty * reference_price
-    hold_existing_long = (
-        target_weight > 0.0
-        and current_qty > 0.0
-        and current_market_value >= ALPACA_MIN_NOTIONAL_ORDER
     )
-    desired_notional = 0.0
-    order_notional = 0.0
-    gap_notional = 0.0
-    desired_qty = 0.0
-    if target_weight > 0.0:
-        if hold_existing_long:
-            desired_notional = current_market_value
-            desired_qty = current_qty
-        else:
-            desired_notional, order_notional = _buy_order_notional(
-                equity=equity,
-                buying_power=buying_power,
-                current_market_value=current_signed_market_value,
-                target_weight=target_weight,
-            )
-            gap_notional = max(desired_notional - current_signed_market_value, 0.0)
-            order_notional = _rounded_notional(order_notional)
-            desired_qty = desired_notional / reference_price if reference_price > 0.0 else 0.0
-    delta_qty = round(desired_qty - current_qty, 6)
-    if delta_qty > 1e-6:
-        side = "buy"
-    elif delta_qty < -1e-6:
-        side = "sell"
-    else:
-        side = "none"
-    order_preview = {
-        "proposal_id": proposal["proposal_id"],
-        "trade_date": trade_date,
-        "symbol": paper_symbol,
-        "equity": equity,
-        "buying_power": buying_power,
-        "reference_price": reference_price,
-        "current_qty": current_qty,
-        "current_market_value": current_market_value,
-        "desired_notional": desired_notional,
-        "order_notional": order_notional,
-        "desired_qty": desired_qty,
-        "delta_qty": delta_qty,
-        "side": side,
-        "updated_at": _now_utc(now).isoformat(),
-    }
-    _json_dump(store.trade_order_preview_path(trade_date), order_preview)
-
-    if side == "none" or (side == "buy" and order_notional < ALPACA_MIN_NOTIONAL_ORDER):
-        buy_reason = "already_at_target"
-        if _rounded_notional(gap_notional) >= ALPACA_MIN_NOTIONAL_ORDER:
-            buy_reason = "insufficient_buying_power"
-        submission = {
-            "proposal_id": proposal["proposal_id"],
-            "trade_date": trade_date,
-            "status": SUBMISSION_NOOP,
-            "reason": "already_at_target" if side == "none" else buy_reason,
-            "order_preview_path": str(store.trade_order_preview_path(trade_date)),
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        _json_dump(submission_path, submission)
-        status = {
-            "event": "paper-submit",
-            "status": SUBMISSION_NOOP,
-            "proposal_id": proposal["proposal_id"],
-            "submission_path": str(submission_path),
-            "updated_at": _now_utc(now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        _notify_paper_submission(
-            config,
-            store,
-            outcome=SUBMISSION_NOOP,
-            status=status,
-            proposal=proposal,
-            submission=submission,
-            now=now,
-            transport=notification_transport,
-        )
-        return {
-            "submission_path": str(submission_path),
-            "status_path": str(status_path),
-            "status": status,
-            "submission": submission,
-        }
-
-    client_order_id = _client_order_id(proposal["proposal_id"], retry_suffix=retry_suffix)
-    if side == "buy":
-        order = broker_client.submit_notional_day_market_order(
-            symbol=paper_symbol,
-            notional=order_notional,
-            side=side,
-            client_order_id=client_order_id,
-        )
-    else:
-        order = broker_client.submit_fractional_day_market_order(
-            symbol=paper_symbol,
-            qty=abs(delta_qty),
-            side=side,
-            client_order_id=client_order_id,
-        )
-    order_status, poll_status = _poll_order_status(
-        broker_client=broker_client,
-        order_id=str(order["id"]),
-        fallback_status=str(order.get("status", "unknown")),
-        client_order_id=str(order.get("client_order_id", client_order_id)),
-    )
-    _json_dump(store.trade_order_status_path(trade_date), order_status)
-
-    submission = {
-        "proposal_id": proposal["proposal_id"],
-        "trade_date": trade_date,
-        "status": SUBMISSION_SUBMITTED,
-        "side": side,
-        "qty": abs(delta_qty) if side == "sell" else None,
-        "notional": order_notional if side == "buy" else None,
-        "order_id": order["id"],
-        "client_order_id": order.get("client_order_id", client_order_id),
-        "order_status": str(order_status.get("status", order.get("status", "unknown"))).lower(),
-        "poll_status": poll_status,
-        "order_preview_path": str(store.trade_order_preview_path(trade_date)),
-        "account_snapshot_path": str(store.trade_account_snapshot_path(trade_date)),
-        "order_status_path": str(store.trade_order_status_path(trade_date)),
-        "updated_at": _now_utc(now).isoformat(),
-    }
-    _json_dump(submission_path, submission)
-    status = {
-        "event": "paper-submit",
-        "status": SUBMISSION_SUBMITTED,
-        "proposal_id": proposal["proposal_id"],
-        "submission_path": str(submission_path),
-        "order_status": submission["order_status"],
-        "updated_at": _now_utc(now).isoformat(),
-    }
-    status_path = store.write_status(status)
-    _notify_paper_submission(
-        config,
-        store,
-        outcome=SUBMISSION_SUBMITTED,
-        status=status,
-        proposal=proposal,
-        submission=submission,
-        now=now,
-        transport=notification_transport,
-    )
-    return {
-        "submission_path": str(submission_path),
-        "status_path": str(status_path),
-        "status": status,
-        "submission": submission,
-    }
+    legacy = result.as_legacy_payload()
+    legacy.pop("proposal_id", None)
+    if result.submission is not None:
+        legacy["submission"] = result.submission
+    return legacy
 
 
 def get_paper_status(config: ExperimentConfig) -> dict[str, Any]:

--- a/tests/unit/test_paper_application_services.py
+++ b/tests/unit/test_paper_application_services.py
@@ -9,12 +9,24 @@ from tests._paper_fakes import (
     build_phase7_paper_config,
 )
 
-from marketlab.paper.application import ApprovalService, DecisionService
-from marketlab.paper.contracts import PaperApprovalRequest, PaperDecisionRequest
+from marketlab.paper.application import (
+    ApprovalService,
+    DecisionService,
+    ReconciliationService,
+    SubmissionService,
+)
+from marketlab.paper.contracts import (
+    PaperApprovalRequest,
+    PaperDecisionRequest,
+    PaperReconciliationRequest,
+    PaperSubmissionRequest,
+)
 from marketlab.paper.service import (
     PaperStateStore,
     decide_paper_proposal,
+    reconcile_latest_submission_status,
     run_paper_decision,
+    run_paper_submit,
 )
 from marketlab.paper.state import _json_load
 
@@ -34,11 +46,84 @@ def _normalize_status_paths(status: dict[str, object]) -> dict[str, object]:
     return normalized
 
 
+def _normalize_payload_paths(payload: dict[str, object], *keys: str) -> dict[str, object]:
+    normalized = dict(payload)
+    for key in keys:
+        value = normalized.get(key)
+        if value is not None:
+            normalized[key] = Path(str(value)).name
+    return normalized
+
+
 def _load_trade_materials(config, proposal_id: str) -> tuple[dict[str, object], dict[str, object]]:
     store = PaperStateStore(config)
     proposal = store.load_proposal(proposal_id)
     evidence = store.load_evidence(str(proposal["effective_date"]))
     return proposal, evidence
+
+
+def _load_submission_materials(
+    config,
+    trade_date: str,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object], dict[str, object]]:
+    store = PaperStateStore(config)
+    submission = _json_load(store.trade_submission_path(trade_date))
+    order_status = _json_load(store.trade_order_status_path(trade_date))
+    order_preview = _json_load(store.trade_order_preview_path(trade_date))
+    account_snapshot = _json_load(store.trade_account_snapshot_path(trade_date))
+    return submission, order_status, order_preview, account_snapshot
+
+
+def _legacy_submission_payload(result) -> dict[str, object]:
+    payload = result.as_legacy_payload()
+    payload.pop("proposal_id", None)
+    if result.submission is not None:
+        payload["submission"] = result.submission
+    return payload
+
+
+def _normalize_submission_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    if "submission_path" in normalized:
+        normalized = _normalize_payload_paths(normalized, "submission_path", "status_path")
+    status = normalized.get("status")
+    if isinstance(status, dict):
+        normalized["status"] = _normalize_payload_paths(status, "submission_path")
+    submission = normalized.get("submission")
+    if isinstance(submission, dict):
+        normalized["submission"] = _normalize_payload_paths(
+            submission,
+            "order_preview_path",
+            "account_snapshot_path",
+            "order_status_path",
+        )
+    return normalized
+
+
+def _seed_approved_long_proposal(config, *, broker: FakeAlpacaBroker) -> tuple[str, str]:
+    decision_now = datetime(2026, 4, 10, 20, 10, tzinfo=UTC)
+    approval_now = datetime(2026, 4, 10, 20, 20, tzinfo=UTC)
+    proposal_result = run_paper_decision(
+        config,
+        now=decision_now,
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    proposal_id = str(proposal_result["proposal_id"])
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_id)
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_id,
+        decision="approve",
+        actor="agent",
+        now=approval_now,
+    )
+    return proposal_id, str(proposal["effective_date"])
 
 
 def test_decision_service_matches_legacy_wrapper(tmp_path: Path) -> None:
@@ -135,3 +220,147 @@ def test_approval_service_matches_legacy_wrapper(tmp_path: Path) -> None:
     )
     assert _normalize_proposal(wrapper_proposal) == _normalize_proposal(direct_proposal)
     assert wrapper_approval == direct_approval
+
+
+def test_submission_service_matches_legacy_wrapper(tmp_path: Path) -> None:
+    submission_now = datetime(2026, 4, 10, 23, 5, tzinfo=UTC)
+    direct_config = build_phase7_paper_config(tmp_path / "direct", symbol="QQQ")
+    wrapper_config = build_phase7_paper_config(tmp_path / "wrapper", symbol="QQQ")
+    direct_broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=1000.0,
+        cash=1000.0,
+    )
+    wrapper_broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=1000.0,
+        cash=1000.0,
+    )
+
+    direct_proposal_id, direct_trade_date = _seed_approved_long_proposal(
+        direct_config,
+        broker=direct_broker,
+    )
+    wrapper_proposal_id, wrapper_trade_date = _seed_approved_long_proposal(
+        wrapper_config,
+        broker=wrapper_broker,
+    )
+
+    direct_result = SubmissionService(direct_config).run(
+        PaperSubmissionRequest(
+            now=submission_now,
+            broker=direct_broker,
+        )
+    )
+    wrapper_result = run_paper_submit(
+        wrapper_config,
+        now=submission_now,
+        broker=wrapper_broker,
+    )
+
+    direct_submission, direct_order_status, direct_order_preview, direct_account_snapshot = (
+        _load_submission_materials(direct_config, direct_trade_date)
+    )
+    wrapper_submission, wrapper_order_status, wrapper_order_preview, wrapper_account_snapshot = (
+        _load_submission_materials(wrapper_config, wrapper_trade_date)
+    )
+
+    assert direct_proposal_id == wrapper_proposal_id
+    assert direct_trade_date == wrapper_trade_date
+    assert _normalize_submission_payload(wrapper_result) == _normalize_submission_payload(
+        _legacy_submission_payload(direct_result)
+    )
+    assert _normalize_payload_paths(
+        wrapper_submission,
+        "order_preview_path",
+        "account_snapshot_path",
+        "order_status_path",
+    ) == _normalize_payload_paths(
+        direct_submission,
+        "order_preview_path",
+        "account_snapshot_path",
+        "order_status_path",
+    )
+    assert wrapper_order_status == direct_order_status
+    assert wrapper_order_preview == direct_order_preview
+    assert wrapper_account_snapshot == direct_account_snapshot
+
+
+def test_reconciliation_service_matches_legacy_wrapper(tmp_path: Path) -> None:
+    submission_now = datetime(2026, 4, 10, 23, 5, tzinfo=UTC)
+    reconciliation_now = datetime(2026, 4, 11, 14, 0, tzinfo=UTC)
+    direct_config = build_phase7_paper_config(tmp_path / "direct", symbol="QQQ")
+    wrapper_config = build_phase7_paper_config(tmp_path / "wrapper", symbol="QQQ")
+    direct_broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=1000.0,
+        cash=1000.0,
+        order_status="accepted",
+    )
+    wrapper_broker = FakeAlpacaBroker(
+        symbol="QQQ",
+        equity=1000.0,
+        buying_power=1000.0,
+        cash=1000.0,
+        order_status="accepted",
+    )
+
+    _, direct_trade_date = _seed_approved_long_proposal(direct_config, broker=direct_broker)
+    _, wrapper_trade_date = _seed_approved_long_proposal(wrapper_config, broker=wrapper_broker)
+    SubmissionService(direct_config).run(
+        PaperSubmissionRequest(
+            now=submission_now,
+            broker=direct_broker,
+        )
+    )
+    run_paper_submit(
+        wrapper_config,
+        now=submission_now,
+        broker=wrapper_broker,
+    )
+
+    direct_broker.order_status = "rejected"
+    wrapper_broker.order_status = "rejected"
+    direct_result = ReconciliationService(direct_config).run(
+        PaperReconciliationRequest(
+            now=reconciliation_now,
+            broker=direct_broker,
+        )
+    )
+    wrapper_result = reconcile_latest_submission_status(
+        wrapper_config,
+        now=reconciliation_now,
+        broker=wrapper_broker,
+    )
+
+    direct_submission = _json_load(PaperStateStore(direct_config).trade_submission_path(direct_trade_date))
+    wrapper_submission = _json_load(PaperStateStore(wrapper_config).trade_submission_path(wrapper_trade_date))
+    direct_order_status = _json_load(PaperStateStore(direct_config).trade_order_status_path(direct_trade_date))
+    wrapper_order_status = _json_load(PaperStateStore(wrapper_config).trade_order_status_path(wrapper_trade_date))
+
+    assert direct_result is not None
+    assert wrapper_result is not None
+    assert _normalize_payload_paths(
+        wrapper_result,
+        "submission_path",
+        "order_status_path",
+    ) == _normalize_payload_paths(
+        direct_result.as_legacy_payload(),
+        "submission_path",
+        "order_status_path",
+    )
+    assert _normalize_payload_paths(
+        wrapper_submission,
+        "order_preview_path",
+        "account_snapshot_path",
+        "order_status_path",
+    ) == _normalize_payload_paths(
+        direct_submission,
+        "order_preview_path",
+        "account_snapshot_path",
+        "order_status_path",
+    )
+    assert wrapper_order_status == direct_order_status


### PR DESCRIPTION
## Summary
- extract paper submission orchestration into `SubmissionService`
- extract broker submission refresh into `ReconciliationService`
- keep `paper.service` as a thin compatibility adapter and add parity coverage for wrapper behavior

## Validation
- `py -3.14 -m tox -e preflight`
