### PR TITLE
refactor: add paper repositories and unit-of-work ports

### DIFF
--- a/src/marketlab/paper/application/approval.py
+++ b/src/marketlab/paper/application/approval.py
@@ -4,6 +4,7 @@ from marketlab.config import ExperimentConfig
 from marketlab.paper.contracts import (
     PaperApprovalRequest,
     PaperApprovalResult,
+    PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
     APPROVAL_APPROVED,
@@ -11,13 +12,18 @@ from marketlab.paper.core import (
     _now_utc,
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import notify_paper_approval
-from marketlab.paper.state import PaperStateStore, _json_dump
+from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 
 
 class ApprovalService:
-    def __init__(self, config: ExperimentConfig) -> None:
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        *,
+        uow_factory: PaperUnitOfWorkFactory | None = None,
+    ) -> None:
         self._config = config
+        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
 
     def run(self, request: PaperApprovalRequest) -> PaperApprovalResult:
         config = self._config
@@ -27,81 +33,79 @@ class ApprovalService:
         if request.actor not in {"agent", "manual"}:
             raise RuntimeError("paper-approve requires actor to be either agent or manual.")
 
-        store = PaperStateStore(config)
-        proposal = store.load_proposal(request.proposal_id)
-        trade_date = proposal["effective_date"]
-        submission_path = store.trade_submission_path(trade_date)
-        if submission_path.exists():
-            raise RuntimeError("Cannot change approval after paper-submit has already persisted state.")
+        with self._uow_factory() as uow:
+            proposal = uow.trades.get_proposal(request.proposal_id)
+            if proposal is None:
+                raise FileNotFoundError(f"Unknown proposal_id: {request.proposal_id}")
+            trade_date = str(proposal["effective_date"])
+            submission = uow.trades.get_submission(trade_date)
+            if submission is not None:
+                raise RuntimeError("Cannot change approval after paper-submit has already persisted state.")
 
-        required_actor = None
-        if config.paper.execution_mode == "agent_approval":
-            required_actor = "agent"
-        elif config.paper.execution_mode == "manual_approval":
-            required_actor = "manual"
-        else:
-            raise RuntimeError("paper-approve is not used when execution_mode='autonomous'.")
+            required_actor = None
+            if config.paper.execution_mode == "agent_approval":
+                required_actor = "agent"
+            elif config.paper.execution_mode == "manual_approval":
+                required_actor = "manual"
+            else:
+                raise RuntimeError("paper-approve is not used when execution_mode='autonomous'.")
 
-        if request.actor != required_actor:
-            raise RuntimeError(
-                f"paper-approve for execution_mode='{config.paper.execution_mode}' requires actor='{required_actor}'."
+            if request.actor != required_actor:
+                raise RuntimeError(
+                    f"paper-approve for execution_mode='{config.paper.execution_mode}' requires actor='{required_actor}'."
+                )
+
+            approval_status = (
+                APPROVAL_APPROVED if request.decision == "approve" else APPROVAL_REJECTED
             )
-
-        approval_status = (
-            APPROVAL_APPROVED if request.decision == "approve" else APPROVAL_REJECTED
-        )
-        approval_timestamp = _now_utc(request.now).isoformat()
-        proposal["approval_status"] = approval_status
-        proposal["approval_actor"] = request.actor
-        proposal["approval_decision"] = request.decision
-        proposal["approval_timestamp"] = approval_timestamp
-        if request.rationale is not None:
-            proposal["approval_rationale"] = request.rationale
-        if request.provider is not None:
-            proposal["approval_backend"] = request.provider
-        if request.model is not None:
-            proposal["approval_model"] = request.model
-        proposal["approval_fallback_used"] = bool(request.fallback_used)
-        if request.fallback_reason:
-            proposal["approval_fallback_reason"] = request.fallback_reason
-        proposal_path = store.update_proposal(proposal)
-        approval_record = {
-            "proposal_id": request.proposal_id,
-            "trade_date": trade_date,
-            "decision": request.decision,
-            "approval_status": approval_status,
-            "actor": request.actor,
-            "timestamp": approval_timestamp,
-            "provider": request.provider,
-            "model": request.model,
-            "fallback_used": bool(request.fallback_used),
-            "fallback_reason": request.fallback_reason,
-            "rationale": request.rationale,
-        }
-        approval_path = _json_dump(store.trade_approval_path(trade_date), approval_record)
-        status = {
-            "event": "paper-approve",
-            "status": approval_status,
-            "proposal_id": request.proposal_id,
-            "proposal_path": str(proposal_path),
-            "approval_path": str(approval_path),
-            "updated_at": approval_timestamp,
-        }
-        status_path = store.write_status(status)
-        notify_paper_approval(
-            config,
-            store,
-            proposal=proposal,
-            approval_record=approval_record,
-            now=request.now,
-            transport=request.notification_transport,
-        )
-        return PaperApprovalResult(
-            proposal_id=request.proposal_id,
-            proposal_path=str(proposal_path),
-            approval_path=str(approval_path),
-            status_path=str(status_path),
-            status=status,
-            proposal=proposal,
-            approval=approval_record,
-        )
+            approval_timestamp = _now_utc(request.now).isoformat()
+            proposal["approval_status"] = approval_status
+            proposal["approval_actor"] = request.actor
+            proposal["approval_decision"] = request.decision
+            proposal["approval_timestamp"] = approval_timestamp
+            if request.rationale is not None:
+                proposal["approval_rationale"] = request.rationale
+            if request.provider is not None:
+                proposal["approval_backend"] = request.provider
+            if request.model is not None:
+                proposal["approval_model"] = request.model
+            proposal["approval_fallback_used"] = bool(request.fallback_used)
+            if request.fallback_reason:
+                proposal["approval_fallback_reason"] = request.fallback_reason
+            proposal_path = uow.trades.save_proposal(proposal)
+            approval_record = {
+                "proposal_id": request.proposal_id,
+                "trade_date": trade_date,
+                "decision": request.decision,
+                "approval_status": approval_status,
+                "actor": request.actor,
+                "timestamp": approval_timestamp,
+                "provider": request.provider,
+                "model": request.model,
+                "fallback_used": bool(request.fallback_used),
+                "fallback_reason": request.fallback_reason,
+                "rationale": request.rationale,
+            }
+            approval_path = uow.trades.save_approval(
+                trade_date=trade_date,
+                approval=approval_record,
+            )
+            status = {
+                "event": "paper-approve",
+                "status": approval_status,
+                "proposal_id": request.proposal_id,
+                "proposal_path": str(proposal_path),
+                "approval_path": str(approval_path),
+                "updated_at": approval_timestamp,
+            }
+            status_path = uow.status.write_status(status)
+            uow.commit()
+            return PaperApprovalResult(
+                proposal_id=request.proposal_id,
+                proposal_path=str(proposal_path),
+                approval_path=str(approval_path),
+                status_path=str(status_path),
+                status=status,
+                proposal=proposal,
+                approval=approval_record,
+            )

--- a/src/marketlab/paper/application/decision.py
+++ b/src/marketlab/paper/application/decision.py
@@ -25,6 +25,7 @@ from marketlab.paper.contracts import (
     PaperDecisionRequest,
     PaperDecisionResult,
     PaperHistoryProvider,
+    PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
     APPROVAL_NOT_REQUIRED,
@@ -39,8 +40,7 @@ from marketlab.paper.core import (
     _paper_symbol,
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import notify_paper_decision
-from marketlab.paper.state import PaperStateStore
+from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 from marketlab.targets import add_forward_targets, build_rebalance_snapshots
 
 
@@ -200,14 +200,19 @@ def _reference_price_for_signal(
 
 
 class DecisionService:
-    def __init__(self, config: ExperimentConfig) -> None:
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        *,
+        uow_factory: PaperUnitOfWorkFactory | None = None,
+    ) -> None:
         self._config = config
+        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
 
     def run(self, request: PaperDecisionRequest) -> PaperDecisionResult:
         config = self._config
         validate_paper_trading_config(config)
         paper_symbol = _paper_symbol(config)
-        store = PaperStateStore(config)
         local_now = _local_now(config, request.now)
         broker_client = request.broker or AlpacaPaperBrokerClient()
         market_date = local_now.date()
@@ -220,15 +225,9 @@ class DecisionService:
                 "market_date": market_date.isoformat(),
                 "updated_at": _now_utc(request.now).isoformat(),
             }
-            status_path = store.write_status(status)
-            notify_paper_decision(
-                config,
-                store,
-                outcome="non_trading_day",
-                status=status,
-                now=request.now,
-                transport=request.notification_transport,
-            )
+            with self._uow_factory() as uow:
+                status_path = uow.status.write_status(status)
+                uow.commit()
             return PaperDecisionResult(
                 status_path=str(status_path),
                 status=status,
@@ -253,15 +252,9 @@ class DecisionService:
                 "latest_signal_date": latest_signal_date.date().isoformat(),
                 "updated_at": _now_utc(request.now).isoformat(),
             }
-            status_path = store.write_status(status)
-            notify_paper_decision(
-                config,
-                store,
-                outcome="stale_signal_date",
-                status=status,
-                now=request.now,
-                transport=request.notification_transport,
-            )
+            with self._uow_factory() as uow:
+                status_path = uow.status.write_status(status)
+                uow.commit()
             return PaperDecisionResult(
                 status_path=str(status_path),
                 status=status,
@@ -293,42 +286,30 @@ class DecisionService:
             symbol=paper_symbol,
         )
 
-        try:
-            existing = store.load_proposal(proposal_id)
-        except FileNotFoundError:
-            existing = None
-        if existing is not None:
-            evidence_path = store.trade_evidence_path(existing["effective_date"])
-            status = {
-                "event": "paper-decision",
-                "status": "existing_proposal",
-                "proposal_id": proposal_id,
-                "proposal_path": str(store.inbox_proposal_path(proposal_id)),
-                "updated_at": _now_utc(request.now).isoformat(),
-            }
-            status_path = store.write_status(status)
-            try:
-                evidence = store.load_evidence(existing["effective_date"])
-            except FileNotFoundError:
-                evidence = None
-            notify_paper_decision(
-                config,
-                store,
-                outcome="existing_proposal",
-                status=status,
-                proposal=existing,
-                now=request.now,
-                transport=request.notification_transport,
-            )
-            return PaperDecisionResult(
-                proposal_id=proposal_id,
-                proposal_path=str(store.inbox_proposal_path(proposal_id)),
-                evidence_path=str(evidence_path),
-                status_path=str(status_path),
-                status=status,
-                proposal=existing,
-                evidence=evidence,
-            )
+        with self._uow_factory() as uow:
+            existing = uow.trades.get_proposal(proposal_id)
+            if existing is not None:
+                evidence = uow.trades.get_evidence(str(existing["effective_date"]))
+                evidence_path = uow.trades.trade_evidence_path(str(existing["effective_date"]))
+                proposal_path = uow.trades.proposal_path(proposal_id)
+                status = {
+                    "event": "paper-decision",
+                    "status": "existing_proposal",
+                    "proposal_id": proposal_id,
+                    "proposal_path": str(proposal_path),
+                    "updated_at": _now_utc(request.now).isoformat(),
+                }
+                status_path = uow.status.write_status(status)
+                uow.commit()
+                return PaperDecisionResult(
+                    proposal_id=proposal_id,
+                    proposal_path=str(proposal_path),
+                    evidence_path=str(evidence_path),
+                    status_path=str(status_path),
+                    status=status,
+                    proposal=existing,
+                    evidence=evidence,
+                )
 
         train_rows = _training_rows_for_latest_signal(labeled_dataset, config, latest_signal_date)
         if len(train_rows) < max(1, config.evaluation.walk_forward.min_train_rows):
@@ -379,48 +360,40 @@ class DecisionService:
             **consensus_summary,
             "created_at": _now_utc(request.now).isoformat(),
         }
-        evidence_path = store.save_evidence(evidence)
-
-        proposal = {
-            "proposal_id": proposal_id,
-            "experiment_name": config.experiment_name,
-            "symbol": paper_symbol,
-            "signal_date": _iso_date(latest_signal_date),
-            "effective_date": effective_date,
-            "reference_price": reference_price,
-            "execution_mode": config.paper.execution_mode,
-            "approval_status": approval_status,
-            "submission_status": SUBMISSION_PENDING,
-            "min_score_threshold": float(config.portfolio.ranking.min_score_threshold),
-            "train_rows": int(len(train_rows)),
-            "train_start": evidence["train_start"],
-            "train_end": evidence["train_end"],
-            "train_positive_rate": train_positive_rate,
-            "created_at": _now_utc(request.now).isoformat(),
-            "data_provider": config.paper.data_provider,
-            "broker": config.paper.broker,
-            "evidence_path": str(evidence_path),
-            **consensus_summary,
-        }
-        proposal_path = store.save_proposal(proposal)
-        status = {
-            "event": "paper-decision",
-            "status": "proposal_created",
-            "proposal_id": proposal_id,
-            "proposal_path": str(proposal_path),
-            "evidence_path": str(evidence_path),
-            "updated_at": _now_utc(request.now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        notify_paper_decision(
-            config,
-            store,
-            outcome="proposal_created",
-            status=status,
-            proposal=proposal,
-            now=request.now,
-            transport=request.notification_transport,
-        )
+        with self._uow_factory() as uow:
+            evidence_path = uow.trades.save_evidence(evidence)
+            proposal = {
+                "proposal_id": proposal_id,
+                "experiment_name": config.experiment_name,
+                "symbol": paper_symbol,
+                "signal_date": _iso_date(latest_signal_date),
+                "effective_date": effective_date,
+                "reference_price": reference_price,
+                "execution_mode": config.paper.execution_mode,
+                "approval_status": approval_status,
+                "submission_status": SUBMISSION_PENDING,
+                "min_score_threshold": float(config.portfolio.ranking.min_score_threshold),
+                "train_rows": int(len(train_rows)),
+                "train_start": evidence["train_start"],
+                "train_end": evidence["train_end"],
+                "train_positive_rate": train_positive_rate,
+                "created_at": _now_utc(request.now).isoformat(),
+                "data_provider": config.paper.data_provider,
+                "broker": config.paper.broker,
+                "evidence_path": str(evidence_path),
+                **consensus_summary,
+            }
+            proposal_path = uow.trades.save_proposal(proposal)
+            status = {
+                "event": "paper-decision",
+                "status": "proposal_created",
+                "proposal_id": proposal_id,
+                "proposal_path": str(proposal_path),
+                "evidence_path": str(evidence_path),
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            status_path = uow.status.write_status(status)
+            uow.commit()
         return PaperDecisionResult(
             proposal_id=proposal_id,
             proposal_path=str(proposal_path),

--- a/src/marketlab/paper/application/reconciliation.py
+++ b/src/marketlab/paper/application/reconciliation.py
@@ -10,6 +10,8 @@ from marketlab.paper.contracts import (
     PaperBroker,
     PaperReconciliationRequest,
     PaperReconciliationResult,
+    PaperTradeRepository,
+    PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
     SUBMISSION_SUBMITTED,
@@ -17,7 +19,7 @@ from marketlab.paper.core import (
     _now_utc,
     validate_paper_trading_config,
 )
-from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 
 
 def _poll_order_status(
@@ -42,33 +44,31 @@ def _poll_order_status(
 
 
 def _latest_submitted_proposal_requiring_reconciliation(
-    store: PaperStateStore,
-) -> tuple[dict[str, Any], dict[str, Any], Path] | None:
-    for proposal in store.list_proposals():
+    trades: PaperTradeRepository,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    for proposal in trades.list_proposals():
         trade_date = str(proposal.get("effective_date", ""))
         if trade_date == "":
             continue
-        submission_path = store.trade_submission_path(trade_date)
-        if not submission_path.exists():
+        submission = trades.get_submission(trade_date)
+        if submission is None:
             continue
-        submission = _json_load(submission_path)
         if submission.get("status") != SUBMISSION_SUBMITTED:
             continue
         order_status = str(submission.get("order_status", "")).lower()
         if order_status in TERMINAL_ORDER_STATUSES:
             continue
-        return proposal, submission, submission_path
+        return proposal, submission
     return None
 
 
 def _refresh_submission_order_status(
-    store: PaperStateStore,
     *,
-    proposal: dict[str, Any],
     submission: dict[str, Any],
+    order_status_path: Path,
     broker_client: PaperBroker,
     now: datetime | None = None,
-) -> dict[str, Any] | None:
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
     if submission.get("status") != SUBMISSION_SUBMITTED:
         return None
 
@@ -88,8 +88,6 @@ def _refresh_submission_order_status(
     )
     refreshed_order_status = str(order_status.get("status", current_order_status or "unknown")).lower()
     current_poll_status = str(submission.get("poll_status", "")).lower()
-    trade_date = str(submission["trade_date"])
-    order_status_path = store.trade_order_status_path(trade_date)
     if (
         refreshed_order_status == current_order_status
         and poll_status == current_poll_status
@@ -97,57 +95,72 @@ def _refresh_submission_order_status(
     ):
         return None
 
-    _json_dump(order_status_path, order_status)
     refreshed_submission = dict(submission)
     refreshed_submission["order_status"] = refreshed_order_status
     refreshed_submission["poll_status"] = poll_status
     refreshed_submission["order_status_path"] = str(order_status_path)
     refreshed_submission["updated_at"] = _now_utc(now).isoformat()
-    submission_path = store.trade_submission_path(trade_date)
-    _json_dump(submission_path, refreshed_submission)
-    status = {
-        "event": "paper-submit",
-        "status": refreshed_submission["status"],
-        "proposal_id": refreshed_submission["proposal_id"],
-        "submission_path": str(submission_path),
-        "order_status": refreshed_order_status,
-        "updated_at": _now_utc(now).isoformat(),
-    }
-    store.write_status(status)
-    return refreshed_submission
+    return refreshed_submission, order_status
 
 
 class ReconciliationService:
-    def __init__(self, config: ExperimentConfig) -> None:
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        *,
+        uow_factory: PaperUnitOfWorkFactory | None = None,
+    ) -> None:
         self._config = config
+        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
 
     def run(
         self,
         request: PaperReconciliationRequest,
     ) -> PaperReconciliationResult | None:
         validate_paper_trading_config(self._config)
-        store = PaperStateStore(self._config)
-        latest_submitted = _latest_submitted_proposal_requiring_reconciliation(store)
+        with self._uow_factory() as uow:
+            latest_submitted = _latest_submitted_proposal_requiring_reconciliation(uow.trades)
         if latest_submitted is None:
             return None
 
-        proposal, submission, submission_path = latest_submitted
+        proposal, submission = latest_submitted
         trade_date = str(submission["trade_date"])
+        with self._uow_factory() as path_uow:
+            order_status_path = path_uow.trades.trade_order_status_path(trade_date)
         broker_client = request.broker or AlpacaPaperBrokerClient()
-        refreshed_submission = _refresh_submission_order_status(
-            store,
-            proposal=proposal,
+        refreshed = _refresh_submission_order_status(
             submission=submission,
+            order_status_path=order_status_path,
             broker_client=broker_client,
             now=request.now,
         )
-        if refreshed_submission is None:
+        if refreshed is None:
             return None
+        refreshed_submission, order_status = refreshed
+        with self._uow_factory() as uow:
+            order_status_path = uow.trades.save_order_status(
+                trade_date=trade_date,
+                order_status=order_status,
+            )
+            submission_path = uow.trades.save_submission(
+                trade_date=trade_date,
+                submission=refreshed_submission,
+            )
+            status = {
+                "event": "paper-submit",
+                "status": refreshed_submission["status"],
+                "proposal_id": refreshed_submission["proposal_id"],
+                "submission_path": str(submission_path),
+                "order_status": str(refreshed_submission["order_status"]),
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            uow.status.write_status(status)
+            uow.commit()
 
         return PaperReconciliationResult(
             proposal_id=str(proposal["proposal_id"]),
             submission_path=str(submission_path),
-            order_status_path=str(store.trade_order_status_path(trade_date)),
+            order_status_path=str(order_status_path),
             order_status=str(refreshed_submission["order_status"]),
             poll_status=str(refreshed_submission.get("poll_status", "")),
             submission=refreshed_submission,

--- a/src/marketlab/paper/application/submission.py
+++ b/src/marketlab/paper/application/submission.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 from marketlab.config import ExperimentConfig
 from marketlab.paper.alpaca import AlpacaPaperBrokerClient
 from marketlab.paper.contracts import (
     PaperSubmissionRequest,
     PaperSubmissionResult,
+    PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
     ALPACA_MIN_NOTIONAL_ORDER,
@@ -28,8 +27,11 @@ from marketlab.paper.core import (
     _safe_float,
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import notify_paper_submission
-from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+from marketlab.paper.persistence import (
+    build_filesystem_paper_uow_factory,
+    write_trade_account_snapshot,
+    write_trade_order_preview,
+)
 
 from .reconciliation import _poll_order_status, _refresh_submission_order_status
 
@@ -53,100 +55,91 @@ def _submission_gate_status(
     return "ready", ""
 
 
-def _backup_submission_attempt_artifacts(
-    store: PaperStateStore,
-    *,
-    trade_date: str,
-    now: datetime | None = None,
-) -> None:
-    timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
-    for path in (
-        store.trade_submission_path(trade_date),
-        store.trade_order_status_path(trade_date),
-        store.trade_order_preview_path(trade_date),
-        store.trade_account_snapshot_path(trade_date),
-    ):
-        if not path.exists():
-            continue
-        backup_path = path.with_name(f"{path.stem}.retry-backup.{timestamp}.bak")
-        path.rename(backup_path)
-
-
 class SubmissionService:
-    def __init__(self, config: ExperimentConfig) -> None:
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        *,
+        uow_factory: PaperUnitOfWorkFactory | None = None,
+    ) -> None:
         self._config = config
+        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
 
     def run(self, request: PaperSubmissionRequest) -> PaperSubmissionResult:
         config = self._config
         validate_paper_trading_config(config)
         paper_symbol = _paper_symbol(config)
-        store = PaperStateStore(config)
-        proposal = store.latest_proposal()
-        if proposal is None:
-            status = {
-                "event": "paper-submit",
-                "status": SUBMISSION_SKIPPED,
-                "reason": "no_proposal",
-                "updated_at": _now_utc(request.now).isoformat(),
-            }
-            status_path = store.write_status(status)
-            notify_paper_submission(
-                config,
-                store,
-                outcome=SUBMISSION_SKIPPED,
-                status=status,
-                now=request.now,
-                transport=request.notification_transport,
-            )
-            return PaperSubmissionResult(
-                status_path=str(status_path),
-                status=status,
-            )
+        with self._uow_factory() as uow:
+            proposal = uow.trades.get_latest_proposal()
+            if proposal is None:
+                status = {
+                    "event": "paper-submit",
+                    "status": SUBMISSION_SKIPPED,
+                    "reason": "no_proposal",
+                    "updated_at": _now_utc(request.now).isoformat(),
+                }
+                status_path = uow.status.write_status(status)
+                uow.commit()
+                return PaperSubmissionResult(
+                    status_path=str(status_path),
+                    status=status,
+                )
+            trade_date = str(proposal["effective_date"])
+            submission_path = uow.trades.trade_submission_path(trade_date)
+            order_status_path = uow.trades.trade_order_status_path(trade_date)
+            submission = uow.trades.get_submission(trade_date)
 
-        trade_date = str(proposal["effective_date"])
-        submission_path = store.trade_submission_path(trade_date)
-        if submission_path.exists():
-            submission = _json_load(submission_path)
+        if submission is not None:
             broker_client = request.broker or AlpacaPaperBrokerClient()
-            refreshed_submission = _refresh_submission_order_status(
-                store,
-                proposal=proposal,
+            refreshed = _refresh_submission_order_status(
                 submission=submission,
+                order_status_path=order_status_path,
                 broker_client=broker_client,
                 now=request.now,
             )
-            if refreshed_submission is not None:
-                submission = refreshed_submission
-            order_status = str(submission.get("order_status", "")).lower()
-            if not request.retry_failed_submission or order_status not in FAILED_ORDER_STATUSES:
-                status = {
-                    "event": "paper-submit",
-                    "status": "existing_submission",
-                    "proposal_id": proposal["proposal_id"],
-                    "submission_path": str(submission_path),
-                    "order_status": submission.get("order_status", ""),
-                    "updated_at": _now_utc(request.now).isoformat(),
-                }
-                status_path = store.write_status(status)
-                notify_paper_submission(
-                    config,
-                    store,
-                    outcome="existing_submission",
-                    status=status,
-                    proposal=proposal,
-                    submission=submission,
-                    now=request.now,
-                    transport=request.notification_transport,
-                )
+            if refreshed is not None:
+                submission, refreshed_order_status = refreshed
+                with self._uow_factory() as uow:
+                    order_status_path = uow.trades.save_order_status(
+                        trade_date=trade_date,
+                        order_status=refreshed_order_status,
+                    )
+                    submission_path = uow.trades.save_submission(
+                        trade_date=trade_date,
+                        submission=submission,
+                    )
+                    uow.commit()
+
+            existing_order_status = str(submission.get("order_status", "")).lower()
+            if (
+                not request.retry_failed_submission
+                or existing_order_status not in FAILED_ORDER_STATUSES
+            ):
+                with self._uow_factory() as uow:
+                    status = {
+                        "event": "paper-submit",
+                        "status": "existing_submission",
+                        "proposal_id": proposal["proposal_id"],
+                        "submission_path": str(submission_path),
+                        "order_status": submission.get("order_status", ""),
+                        "updated_at": _now_utc(request.now).isoformat(),
+                    }
+                    status_path = uow.status.write_status(status)
+                    uow.commit()
                 return PaperSubmissionResult(
                     proposal_id=str(proposal["proposal_id"]),
                     submission_path=str(submission_path),
                     status_path=str(status_path),
                     status=status,
                     submission=submission,
+                    proposal=proposal,
                 )
 
-            _backup_submission_attempt_artifacts(store, trade_date=trade_date, now=request.now)
+            with self._uow_factory() as uow:
+                uow.trades.backup_submission_attempt_artifacts(
+                    trade_date=trade_date,
+                    now=request.now,
+                )
             retry_suffix = _now_utc(request.now).strftime("retry%H%M%S")
         else:
             local_now = _local_now(config, request.now)
@@ -168,36 +161,36 @@ class SubmissionService:
                 "reason": gate_reason,
                 "updated_at": _now_utc(request.now).isoformat(),
             }
-            _json_dump(submission_path, submission)
-            status = {
-                "event": "paper-submit",
-                "status": gate_status,
-                "reason": gate_reason,
-                "proposal_id": proposal["proposal_id"],
-                "submission_path": str(submission_path),
-                "updated_at": _now_utc(request.now).isoformat(),
-            }
-            status_path = store.write_status(status)
-            notify_paper_submission(
-                config,
-                store,
-                outcome=gate_status,
-                status=status,
-                proposal=proposal,
-                submission=submission,
-                now=request.now,
-                transport=request.notification_transport,
-            )
+            with self._uow_factory() as uow:
+                submission_path = uow.trades.save_submission(
+                    trade_date=trade_date,
+                    submission=submission,
+                )
+                status = {
+                    "event": "paper-submit",
+                    "status": gate_status,
+                    "reason": gate_reason,
+                    "proposal_id": proposal["proposal_id"],
+                    "submission_path": str(submission_path),
+                    "updated_at": _now_utc(request.now).isoformat(),
+                }
+                status_path = uow.status.write_status(status)
+                uow.commit()
             return PaperSubmissionResult(
                 proposal_id=str(proposal["proposal_id"]),
                 submission_path=str(submission_path),
                 status_path=str(status_path),
                 status=status,
                 submission=submission,
+                proposal=proposal,
             )
 
         account = broker_client.get_account()
-        _json_dump(store.trade_account_snapshot_path(trade_date), account)
+        account_snapshot_path = write_trade_account_snapshot(
+            config,
+            trade_date=trade_date,
+            payload=account,
+        )
         position = broker_client.get_position(paper_symbol)
         current_qty = _safe_float((position or {}).get("qty"))
         current_market_value = _position_market_value(
@@ -258,7 +251,11 @@ class SubmissionService:
             "side": side,
             "updated_at": _now_utc(request.now).isoformat(),
         }
-        _json_dump(store.trade_order_preview_path(trade_date), order_preview)
+        order_preview_path = write_trade_order_preview(
+            config,
+            trade_date=trade_date,
+            payload=order_preview,
+        )
 
         if side == "none" or (side == "buy" and order_notional < ALPACA_MIN_NOTIONAL_ORDER):
             buy_reason = "already_at_target"
@@ -269,34 +266,30 @@ class SubmissionService:
                 "trade_date": trade_date,
                 "status": SUBMISSION_NOOP,
                 "reason": "already_at_target" if side == "none" else buy_reason,
-                "order_preview_path": str(store.trade_order_preview_path(trade_date)),
+                "order_preview_path": str(order_preview_path),
                 "updated_at": _now_utc(request.now).isoformat(),
             }
-            _json_dump(submission_path, submission)
-            status = {
-                "event": "paper-submit",
-                "status": SUBMISSION_NOOP,
-                "proposal_id": proposal["proposal_id"],
-                "submission_path": str(submission_path),
-                "updated_at": _now_utc(request.now).isoformat(),
-            }
-            status_path = store.write_status(status)
-            notify_paper_submission(
-                config,
-                store,
-                outcome=SUBMISSION_NOOP,
-                status=status,
-                proposal=proposal,
-                submission=submission,
-                now=request.now,
-                transport=request.notification_transport,
-            )
+            with self._uow_factory() as uow:
+                submission_path = uow.trades.save_submission(
+                    trade_date=trade_date,
+                    submission=submission,
+                )
+                status = {
+                    "event": "paper-submit",
+                    "status": SUBMISSION_NOOP,
+                    "proposal_id": proposal["proposal_id"],
+                    "submission_path": str(submission_path),
+                    "updated_at": _now_utc(request.now).isoformat(),
+                }
+                status_path = uow.status.write_status(status)
+                uow.commit()
             return PaperSubmissionResult(
                 proposal_id=str(proposal["proposal_id"]),
                 submission_path=str(submission_path),
                 status_path=str(status_path),
                 status=status,
                 submission=submission,
+                proposal=proposal,
             )
 
         client_order_id = _client_order_id(str(proposal["proposal_id"]), retry_suffix=retry_suffix)
@@ -320,7 +313,6 @@ class SubmissionService:
             fallback_status=str(order.get("status", "unknown")),
             client_order_id=str(order.get("client_order_id", client_order_id)),
         )
-        _json_dump(store.trade_order_status_path(trade_date), order_status)
 
         submission = {
             "proposal_id": proposal["proposal_id"],
@@ -333,35 +325,36 @@ class SubmissionService:
             "client_order_id": order.get("client_order_id", client_order_id),
             "order_status": str(order_status.get("status", order.get("status", "unknown"))).lower(),
             "poll_status": poll_status,
-            "order_preview_path": str(store.trade_order_preview_path(trade_date)),
-            "account_snapshot_path": str(store.trade_account_snapshot_path(trade_date)),
-            "order_status_path": str(store.trade_order_status_path(trade_date)),
+            "order_preview_path": str(order_preview_path),
+            "account_snapshot_path": str(account_snapshot_path),
+            "order_status_path": str(order_status_path),
             "updated_at": _now_utc(request.now).isoformat(),
         }
-        _json_dump(submission_path, submission)
-        status = {
-            "event": "paper-submit",
-            "status": SUBMISSION_SUBMITTED,
-            "proposal_id": proposal["proposal_id"],
-            "submission_path": str(submission_path),
-            "order_status": submission["order_status"],
-            "updated_at": _now_utc(request.now).isoformat(),
-        }
-        status_path = store.write_status(status)
-        notify_paper_submission(
-            config,
-            store,
-            outcome=SUBMISSION_SUBMITTED,
-            status=status,
-            proposal=proposal,
-            submission=submission,
-            now=request.now,
-            transport=request.notification_transport,
-        )
+        with self._uow_factory() as uow:
+            order_status_path = uow.trades.save_order_status(
+                trade_date=trade_date,
+                order_status=order_status,
+            )
+            submission["order_status_path"] = str(order_status_path)
+            submission_path = uow.trades.save_submission(
+                trade_date=trade_date,
+                submission=submission,
+            )
+            status = {
+                "event": "paper-submit",
+                "status": SUBMISSION_SUBMITTED,
+                "proposal_id": proposal["proposal_id"],
+                "submission_path": str(submission_path),
+                "order_status": submission["order_status"],
+                "updated_at": _now_utc(request.now).isoformat(),
+            }
+            status_path = uow.status.write_status(status)
+            uow.commit()
         return PaperSubmissionResult(
             proposal_id=str(proposal["proposal_id"]),
             submission_path=str(submission_path),
             status_path=str(status_path),
             status=status,
             submission=submission,
+            proposal=proposal,
         )

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
+from pathlib import Path
 from typing import Any, runtime_checkable
 
 import pandas as pd
@@ -74,6 +75,76 @@ class PaperBroker(Protocol):
     ) -> dict[str, Any]: ...
 
     def get_order(self, order_id: str) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class PaperTradeRepository(Protocol):
+    def list_proposals(self) -> list[dict[str, Any]]: ...
+
+    def get_latest_proposal(self) -> dict[str, Any] | None: ...
+
+    def get_proposal(self, proposal_id: str) -> dict[str, Any] | None: ...
+
+    def get_evidence(self, trade_date: str) -> dict[str, Any] | None: ...
+
+    def get_submission(self, trade_date: str) -> dict[str, Any] | None: ...
+
+    def save_evidence(self, evidence: dict[str, Any]) -> Path: ...
+
+    def save_proposal(self, proposal: dict[str, Any]) -> Path: ...
+
+    def save_approval(self, *, trade_date: str, approval: dict[str, Any]) -> Path: ...
+
+    def save_submission(self, *, trade_date: str, submission: dict[str, Any]) -> Path: ...
+
+    def save_order_status(self, *, trade_date: str, order_status: dict[str, Any]) -> Path: ...
+
+    def proposal_path(self, proposal_id: str) -> Path: ...
+
+    def trade_evidence_path(self, trade_date: str) -> Path: ...
+
+    def trade_submission_path(self, trade_date: str) -> Path: ...
+
+    def trade_order_status_path(self, trade_date: str) -> Path: ...
+
+    def backup_submission_attempt_artifacts(
+        self,
+        *,
+        trade_date: str,
+        now: datetime | None = None,
+    ) -> None: ...
+
+
+@runtime_checkable
+class PaperStatusRepository(Protocol):
+    @property
+    def status_path(self) -> Path: ...
+
+    def read_status(self) -> dict[str, Any] | None: ...
+
+    def write_status(self, payload: dict[str, Any]) -> Path: ...
+
+
+@runtime_checkable
+class PaperUnitOfWork(Protocol):
+    @property
+    def trades(self) -> PaperTradeRepository: ...
+
+    @property
+    def status(self) -> PaperStatusRepository: ...
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+    def __enter__(self) -> PaperUnitOfWork: ...
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
+
+
+@runtime_checkable
+class PaperUnitOfWorkFactory(Protocol):
+    def __call__(self) -> PaperUnitOfWork: ...
 
 
 @dataclass(slots=True, frozen=True)
@@ -191,6 +262,7 @@ class PaperSubmissionResult:
     status_path: str = ""
     status: dict[str, Any] = field(default_factory=dict)
     submission: dict[str, Any] | None = None
+    proposal: dict[str, Any] | None = None
 
     @classmethod
     def from_legacy(cls, payload: dict[str, Any]) -> PaperSubmissionResult:
@@ -200,6 +272,7 @@ class PaperSubmissionResult:
             status_path=_string_field(payload, "status_path"),
             status=_status_field(payload),
             submission=_mapping_field(payload, "submission"),
+            proposal=_mapping_field(payload, "proposal"),
         )
 
     def as_legacy_payload(self) -> dict[str, Any]:

--- a/src/marketlab/paper/persistence/__init__.py
+++ b/src/marketlab/paper/persistence/__init__.py
@@ -1,0 +1,15 @@
+from .filesystem import (
+    FilesystemPaperUnitOfWork,
+    FilesystemPaperUnitOfWorkFactory,
+    build_filesystem_paper_uow_factory,
+    write_trade_account_snapshot,
+    write_trade_order_preview,
+)
+
+__all__ = [
+    "FilesystemPaperUnitOfWork",
+    "FilesystemPaperUnitOfWorkFactory",
+    "build_filesystem_paper_uow_factory",
+    "write_trade_account_snapshot",
+    "write_trade_order_preview",
+]

--- a/src/marketlab/paper/persistence/filesystem.py
+++ b/src/marketlab/paper/persistence/filesystem.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from marketlab.config import ExperimentConfig
+from marketlab.paper.contracts import (
+    PaperStatusRepository,
+    PaperTradeRepository,
+    PaperUnitOfWork,
+    PaperUnitOfWorkFactory,
+)
+from marketlab.paper.core import _now_utc
+from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+
+
+class FilesystemPaperTradeRepository(PaperTradeRepository):
+    def __init__(
+        self,
+        store: PaperStateStore,
+        pending_writes: dict[Path, dict[str, Any]],
+    ) -> None:
+        self._store = store
+        self._pending_writes = pending_writes
+
+    def _load_path(self, path: Path) -> dict[str, Any] | None:
+        payload = self._pending_writes.get(path)
+        if payload is not None:
+            return dict(payload)
+        if not path.exists():
+            return None
+        return _json_load(path)
+
+    def _stage(self, path: Path, payload: dict[str, Any]) -> Path:
+        self._pending_writes[path] = dict(payload)
+        return path
+
+    def list_proposals(self) -> list[dict[str, Any]]:
+        proposal_paths = {
+            *sorted(self._store.inbox_root.glob("*.json")),
+            *(
+                path
+                for path in self._pending_writes
+                if path.parent == self._store.inbox_root and path.suffix == ".json"
+            ),
+        }
+        proposals = [
+            proposal
+            for path in sorted(proposal_paths)
+            if (proposal := self._load_path(path)) is not None
+        ]
+        return sorted(
+            proposals,
+            key=lambda proposal: (
+                proposal.get("effective_date", ""),
+                proposal.get("created_at", ""),
+                proposal.get("proposal_id", ""),
+            ),
+            reverse=True,
+        )
+
+    def get_latest_proposal(self) -> dict[str, Any] | None:
+        proposals = self.list_proposals()
+        if not proposals:
+            return None
+        return proposals[0]
+
+    def get_proposal(self, proposal_id: str) -> dict[str, Any] | None:
+        return self._load_path(self._store.inbox_proposal_path(proposal_id))
+
+    def get_evidence(self, trade_date: str) -> dict[str, Any] | None:
+        return self._load_path(self._store.trade_evidence_path(trade_date))
+
+    def get_submission(self, trade_date: str) -> dict[str, Any] | None:
+        return self._load_path(self._store.trade_submission_path(trade_date))
+
+    def save_evidence(self, evidence: dict[str, Any]) -> Path:
+        return self._stage(self._store.trade_evidence_path(str(evidence["effective_date"])), evidence)
+
+    def save_proposal(self, proposal: dict[str, Any]) -> Path:
+        trade_date = str(proposal["effective_date"])
+        proposal_id = str(proposal["proposal_id"])
+        proposal_path = self._store.trade_proposal_path(trade_date)
+        inbox_path = self._store.inbox_proposal_path(proposal_id)
+        self._stage(proposal_path, proposal)
+        self._stage(inbox_path, proposal)
+        return proposal_path
+
+    def save_approval(self, *, trade_date: str, approval: dict[str, Any]) -> Path:
+        return self._stage(self._store.trade_approval_path(trade_date), approval)
+
+    def save_submission(self, *, trade_date: str, submission: dict[str, Any]) -> Path:
+        return self._stage(self._store.trade_submission_path(trade_date), submission)
+
+    def save_order_status(self, *, trade_date: str, order_status: dict[str, Any]) -> Path:
+        return self._stage(self._store.trade_order_status_path(trade_date), order_status)
+
+    def proposal_path(self, proposal_id: str) -> Path:
+        return self._store.inbox_proposal_path(proposal_id)
+
+    def trade_evidence_path(self, trade_date: str) -> Path:
+        return self._store.trade_evidence_path(trade_date)
+
+    def trade_submission_path(self, trade_date: str) -> Path:
+        return self._store.trade_submission_path(trade_date)
+
+    def trade_order_status_path(self, trade_date: str) -> Path:
+        return self._store.trade_order_status_path(trade_date)
+
+    def backup_submission_attempt_artifacts(
+        self,
+        *,
+        trade_date: str,
+        now: datetime | None = None,
+    ) -> None:
+        timestamp = _now_utc(now).strftime("%Y%m%dT%H%M%S%fZ")
+        for path in (
+            self._store.trade_submission_path(trade_date),
+            self._store.trade_order_status_path(trade_date),
+            self._store.trade_order_preview_path(trade_date),
+            self._store.trade_account_snapshot_path(trade_date),
+        ):
+            if not path.exists():
+                continue
+            backup_path = path.with_name(f"{path.stem}.retry-backup.{timestamp}.bak")
+            path.rename(backup_path)
+
+
+class FilesystemPaperStatusRepository(PaperStatusRepository):
+    def __init__(
+        self,
+        store: PaperStateStore,
+        pending_writes: dict[Path, dict[str, Any]],
+    ) -> None:
+        self._store = store
+        self._pending_writes = pending_writes
+
+    @property
+    def status_path(self) -> Path:
+        return self._store.status_path
+
+    def read_status(self) -> dict[str, Any] | None:
+        payload = self._pending_writes.get(self.status_path)
+        if payload is not None:
+            return dict(payload)
+        if not self.status_path.exists():
+            return None
+        return _json_load(self.status_path)
+
+    def write_status(self, payload: dict[str, Any]) -> Path:
+        self._pending_writes[self.status_path] = dict(payload)
+        return self.status_path
+
+
+class FilesystemPaperUnitOfWork(PaperUnitOfWork):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._store = PaperStateStore(config)
+        self._pending_writes: dict[Path, dict[str, Any]] = {}
+        self._trades = FilesystemPaperTradeRepository(self._store, self._pending_writes)
+        self._status = FilesystemPaperStatusRepository(self._store, self._pending_writes)
+        self._committed = False
+
+    @property
+    def trades(self) -> PaperTradeRepository:
+        return self._trades
+
+    @property
+    def status(self) -> PaperStatusRepository:
+        return self._status
+
+    def commit(self) -> None:
+        for path, payload in self._pending_writes.items():
+            _json_dump(path, payload)
+        self._pending_writes.clear()
+        self._committed = True
+
+    def rollback(self) -> None:
+        self._pending_writes.clear()
+
+    def __enter__(self) -> FilesystemPaperUnitOfWork:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if exc_type is not None or not self._committed:
+            self.rollback()
+
+
+class FilesystemPaperUnitOfWorkFactory(PaperUnitOfWorkFactory):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._config = config
+
+    def __call__(self) -> PaperUnitOfWork:
+        return FilesystemPaperUnitOfWork(self._config)
+
+
+def build_filesystem_paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
+    return FilesystemPaperUnitOfWorkFactory(config)
+
+
+def write_trade_account_snapshot(
+    config: ExperimentConfig,
+    *,
+    trade_date: str,
+    payload: dict[str, Any],
+) -> Path:
+    return _json_dump(PaperStateStore(config).trade_account_snapshot_path(trade_date), payload)
+
+
+def write_trade_order_preview(
+    config: ExperimentConfig,
+    *,
+    trade_date: str,
+    payload: dict[str, Any],
+) -> Path:
+    return _json_dump(PaperStateStore(config).trade_order_preview_path(trade_date), payload)

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -22,6 +22,9 @@ from marketlab.paper.core import (
     APPROVAL_PENDING as _APPROVAL_PENDING,
 )
 from marketlab.paper.core import (
+    SUBMISSION_SKIPPED as _SUBMISSION_SKIPPED,
+)
+from marketlab.paper.core import (
     _clock_value as _core_clock_value,
 )
 from marketlab.paper.core import (
@@ -36,15 +39,36 @@ from marketlab.paper.core import (
 from marketlab.paper.core import (
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import TelegramTransport, write_notification_record
+from marketlab.paper.notifications import (
+    TelegramTransport,
+    notify_paper_approval,
+    notify_paper_decision,
+    notify_paper_submission,
+    write_notification_record,
+)
+from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 from marketlab.paper.state import PaperStateStore
 
 APPROVAL_PENDING = _APPROVAL_PENDING
+SUBMISSION_SKIPPED = _SUBMISSION_SKIPPED
 _clock_value = _core_clock_value
 _local_now = _core_local_now
 _now_utc = _core_now_utc
 _paper_symbol = _core_paper_symbol
 _write_notification_record = write_notification_record
+
+
+def _paper_uow_factory(config: ExperimentConfig):
+    return build_filesystem_paper_uow_factory(config)
+
+
+def _decision_notification_outcome(status: dict[str, Any]) -> str:
+    outcome = str(status.get("status", ""))
+    if outcome == SUBMISSION_SKIPPED:
+        reason = str(status.get("reason", "")).strip()
+        if reason != "":
+            return reason
+    return outcome
 
 
 def run_paper_decision(
@@ -55,7 +79,7 @@ def run_paper_decision(
     broker: PaperBroker | None = None,
     notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
-    result = DecisionService(config).run(
+    result = DecisionService(config, uow_factory=_paper_uow_factory(config)).run(
         PaperDecisionRequest(
             now=now,
             provider=provider,
@@ -63,12 +87,22 @@ def run_paper_decision(
             notification_transport=notification_transport,
         )
     )
+    notify_paper_decision(
+        config,
+        PaperStateStore(config),
+        outcome=_decision_notification_outcome(result.status),
+        status=result.status,
+        proposal=result.proposal,
+        now=now,
+        transport=notification_transport,
+    )
     return result.as_legacy_payload()
 
 
 def list_paper_proposals(config: ExperimentConfig) -> list[dict[str, Any]]:
     validate_paper_trading_config(config)
-    return PaperStateStore(config).list_proposals()
+    with _paper_uow_factory(config)() as uow:
+        return uow.trades.list_proposals()
 
 
 def read_paper_proposal(
@@ -77,7 +111,11 @@ def read_paper_proposal(
     proposal_id: str,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
-    return PaperStateStore(config).load_proposal(proposal_id)
+    with _paper_uow_factory(config)() as uow:
+        proposal = uow.trades.get_proposal(proposal_id)
+    if proposal is None:
+        raise FileNotFoundError(f"Unknown proposal_id: {proposal_id}")
+    return proposal
 
 
 def read_paper_evidence(
@@ -86,9 +124,14 @@ def read_paper_evidence(
     proposal_id: str,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
-    store = PaperStateStore(config)
-    proposal = store.load_proposal(proposal_id)
-    return store.load_evidence(proposal["effective_date"])
+    with _paper_uow_factory(config)() as uow:
+        proposal = uow.trades.get_proposal(proposal_id)
+        if proposal is None:
+            raise FileNotFoundError(f"Unknown proposal_id: {proposal_id}")
+        evidence = uow.trades.get_evidence(str(proposal["effective_date"]))
+    if evidence is None:
+        raise FileNotFoundError(f"Missing evidence for proposal_id: {proposal_id}")
+    return evidence
 
 
 def decide_paper_proposal(
@@ -105,7 +148,7 @@ def decide_paper_proposal(
     now: datetime | None = None,
     notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
-    result = ApprovalService(config).run(
+    result = ApprovalService(config, uow_factory=_paper_uow_factory(config)).run(
         PaperApprovalRequest(
             proposal_id=proposal_id,
             decision=decision,
@@ -119,6 +162,15 @@ def decide_paper_proposal(
             notification_transport=notification_transport,
         )
     )
+    if result.proposal is not None and result.approval is not None:
+        notify_paper_approval(
+            config,
+            PaperStateStore(config),
+            proposal=result.proposal,
+            approval_record=result.approval,
+            now=now,
+            transport=notification_transport,
+        )
     return result.as_legacy_payload()
 
 
@@ -128,7 +180,7 @@ def reconcile_latest_submission_status(
     now: datetime | None = None,
     broker: PaperBroker | None = None,
 ) -> dict[str, Any] | None:
-    result = ReconciliationService(config).run(
+    result = ReconciliationService(config, uow_factory=_paper_uow_factory(config)).run(
         PaperReconciliationRequest(
             now=now,
             broker=broker,
@@ -147,13 +199,23 @@ def run_paper_submit(
     notification_transport: TelegramTransport | None = None,
     retry_failed_submission: bool = False,
 ) -> dict[str, Any]:
-    result = SubmissionService(config).run(
+    result = SubmissionService(config, uow_factory=_paper_uow_factory(config)).run(
         PaperSubmissionRequest(
             now=now,
             broker=broker,
             notification_transport=notification_transport,
             retry_failed_submission=retry_failed_submission,
         )
+    )
+    notify_paper_submission(
+        config,
+        PaperStateStore(config),
+        outcome=str(result.status.get("status", "")),
+        status=result.status,
+        proposal=result.proposal,
+        submission=result.submission,
+        now=now,
+        transport=notification_transport,
     )
     legacy = result.as_legacy_payload()
     legacy.pop("proposal_id", None)
@@ -164,17 +226,19 @@ def run_paper_submit(
 
 def get_paper_status(config: ExperimentConfig) -> dict[str, Any]:
     validate_paper_trading_config(config)
-    store = PaperStateStore(config)
-    latest_proposal = store.latest_proposal()
-    proposals = store.list_proposals()
+    with _paper_uow_factory(config)() as uow:
+        latest_proposal = uow.trades.get_latest_proposal()
+        proposals = uow.trades.list_proposals()
+        status = uow.status.read_status()
+        status_path = uow.status.status_path
     pending_proposals = [
         proposal
         for proposal in proposals
         if proposal.get("approval_status", APPROVAL_PENDING) == APPROVAL_PENDING
     ]
     return {
-        "status_path": str(store.status_path),
-        "status": store.read_status(),
+        "status_path": str(status_path),
+        "status": status,
         "latest_proposal": latest_proposal,
         "pending_proposal_count": len(pending_proposals),
     }

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -1,0 +1,640 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests._paper_fakes import FakeAlpacaBroker, build_phase7_paper_config
+
+import marketlab.paper.service as service_module
+from marketlab.paper.application import ReconciliationService
+from marketlab.paper.contracts import (
+    PaperReconciliationRequest,
+    PaperStatusRepository,
+    PaperTradeRepository,
+    PaperUnitOfWork,
+    PaperUnitOfWorkFactory,
+)
+from marketlab.paper.persistence import (
+    build_filesystem_paper_uow_factory,
+    write_trade_account_snapshot,
+    write_trade_order_preview,
+)
+from marketlab.paper.state import PaperStateStore
+
+
+@dataclass
+class _InMemoryStoreState:
+    status: dict[str, Any] | None = None
+    proposals_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    evidence_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    approvals_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    submissions_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    order_status_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    backup_calls: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class _PendingState:
+    status: dict[str, Any] | None = None
+    proposals_by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    evidence_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    approvals_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    submissions_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+    order_status_by_trade_date: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+class InMemoryPaperTradeRepository(PaperTradeRepository):
+    def __init__(self, root: Path, state: _InMemoryStoreState, pending: _PendingState) -> None:
+        self._root = root
+        self._state = state
+        self._pending = pending
+
+    def _proposal_payload(self, proposal_id: str) -> dict[str, Any] | None:
+        if proposal_id in self._pending.proposals_by_id:
+            return copy.deepcopy(self._pending.proposals_by_id[proposal_id])
+        payload = self._state.proposals_by_id.get(proposal_id)
+        if payload is None:
+            return None
+        return copy.deepcopy(payload)
+
+    def _trade_payload(
+        self,
+        *,
+        trade_date: str,
+        pending_map: dict[str, dict[str, Any]],
+        state_map: dict[str, dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        if trade_date in pending_map:
+            return copy.deepcopy(pending_map[trade_date])
+        payload = state_map.get(trade_date)
+        if payload is None:
+            return None
+        return copy.deepcopy(payload)
+
+    def list_proposals(self) -> list[dict[str, Any]]:
+        proposal_ids = set(self._state.proposals_by_id) | set(self._pending.proposals_by_id)
+        proposals = [
+            proposal
+            for proposal_id in proposal_ids
+            if (proposal := self._proposal_payload(proposal_id)) is not None
+        ]
+        return sorted(
+            proposals,
+            key=lambda proposal: (
+                proposal.get("effective_date", ""),
+                proposal.get("created_at", ""),
+                proposal.get("proposal_id", ""),
+            ),
+            reverse=True,
+        )
+
+    def get_latest_proposal(self) -> dict[str, Any] | None:
+        proposals = self.list_proposals()
+        if not proposals:
+            return None
+        return proposals[0]
+
+    def get_proposal(self, proposal_id: str) -> dict[str, Any] | None:
+        return self._proposal_payload(proposal_id)
+
+    def get_evidence(self, trade_date: str) -> dict[str, Any] | None:
+        return self._trade_payload(
+            trade_date=trade_date,
+            pending_map=self._pending.evidence_by_trade_date,
+            state_map=self._state.evidence_by_trade_date,
+        )
+
+    def get_submission(self, trade_date: str) -> dict[str, Any] | None:
+        return self._trade_payload(
+            trade_date=trade_date,
+            pending_map=self._pending.submissions_by_trade_date,
+            state_map=self._state.submissions_by_trade_date,
+        )
+
+    def save_evidence(self, evidence: dict[str, Any]) -> Path:
+        trade_date = str(evidence["effective_date"])
+        self._pending.evidence_by_trade_date[trade_date] = copy.deepcopy(evidence)
+        return self.trade_evidence_path(trade_date)
+
+    def save_proposal(self, proposal: dict[str, Any]) -> Path:
+        proposal_id = str(proposal["proposal_id"])
+        self._pending.proposals_by_id[proposal_id] = copy.deepcopy(proposal)
+        return self._trade_path(str(proposal["effective_date"])) / "proposal.json"
+
+    def save_approval(self, *, trade_date: str, approval: dict[str, Any]) -> Path:
+        self._pending.approvals_by_trade_date[trade_date] = copy.deepcopy(approval)
+        return self._trade_path(trade_date) / "approval.json"
+
+    def save_submission(self, *, trade_date: str, submission: dict[str, Any]) -> Path:
+        self._pending.submissions_by_trade_date[trade_date] = copy.deepcopy(submission)
+        return self.trade_submission_path(trade_date)
+
+    def save_order_status(self, *, trade_date: str, order_status: dict[str, Any]) -> Path:
+        self._pending.order_status_by_trade_date[trade_date] = copy.deepcopy(order_status)
+        return self.trade_order_status_path(trade_date)
+
+    def proposal_path(self, proposal_id: str) -> Path:
+        return self._root / "artifacts" / "paper" / "inbox" / f"{proposal_id}.json"
+
+    def trade_evidence_path(self, trade_date: str) -> Path:
+        return self._trade_path(trade_date) / "evidence.json"
+
+    def trade_submission_path(self, trade_date: str) -> Path:
+        return self._trade_path(trade_date) / "submission.json"
+
+    def trade_order_status_path(self, trade_date: str) -> Path:
+        return self._trade_path(trade_date) / "order_status.json"
+
+    def backup_submission_attempt_artifacts(
+        self,
+        *,
+        trade_date: str,
+        now: datetime | None = None,
+    ) -> None:
+        self._state.backup_calls.append(
+            {
+                "trade_date": trade_date,
+                "timestamp": datetime.now(UTC).isoformat() if now is None else now.isoformat(),
+            }
+        )
+
+    def _trade_path(self, trade_date: str) -> Path:
+        return self._root / "artifacts" / "paper" / "state" / "trades" / trade_date
+
+
+class InMemoryPaperStatusRepository(PaperStatusRepository):
+    def __init__(self, root: Path, state: _InMemoryStoreState, pending: _PendingState) -> None:
+        self._root = root
+        self._state = state
+        self._pending = pending
+
+    @property
+    def status_path(self) -> Path:
+        return self._root / "artifacts" / "paper" / "state" / "status.json"
+
+    def read_status(self) -> dict[str, Any] | None:
+        if self._pending.status is not None:
+            return copy.deepcopy(self._pending.status)
+        if self._state.status is None:
+            return None
+        return copy.deepcopy(self._state.status)
+
+    def write_status(self, payload: dict[str, Any]) -> Path:
+        self._pending.status = copy.deepcopy(payload)
+        return self.status_path
+
+
+class InMemoryPaperUnitOfWork(PaperUnitOfWork):
+    def __init__(self, factory: InMemoryPaperUnitOfWorkFactory) -> None:
+        self._factory = factory
+        self._pending = _PendingState()
+        self._trades = InMemoryPaperTradeRepository(factory.root, factory.state, self._pending)
+        self._status = InMemoryPaperStatusRepository(factory.root, factory.state, self._pending)
+        self._committed = False
+
+    @property
+    def trades(self) -> PaperTradeRepository:
+        return self._trades
+
+    @property
+    def status(self) -> PaperStatusRepository:
+        return self._status
+
+    def commit(self) -> None:
+        self._factory.state.proposals_by_id.update(copy.deepcopy(self._pending.proposals_by_id))
+        self._factory.state.evidence_by_trade_date.update(copy.deepcopy(self._pending.evidence_by_trade_date))
+        self._factory.state.approvals_by_trade_date.update(copy.deepcopy(self._pending.approvals_by_trade_date))
+        self._factory.state.submissions_by_trade_date.update(copy.deepcopy(self._pending.submissions_by_trade_date))
+        self._factory.state.order_status_by_trade_date.update(copy.deepcopy(self._pending.order_status_by_trade_date))
+        if self._pending.status is not None:
+            self._factory.state.status = copy.deepcopy(self._pending.status)
+        self._pending = _PendingState()
+        self._factory.commit_count += 1
+        self._committed = True
+
+    def rollback(self) -> None:
+        self._pending = _PendingState()
+
+    def __enter__(self) -> InMemoryPaperUnitOfWork:
+        self._factory.active_count += 1
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if exc_type is not None or not self._committed:
+            self.rollback()
+        self._factory.active_count -= 1
+
+
+class InMemoryPaperUnitOfWorkFactory(PaperUnitOfWorkFactory):
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.state = _InMemoryStoreState()
+        self.active_count = 0
+        self.commit_count = 0
+
+    def __call__(self) -> PaperUnitOfWork:
+        return InMemoryPaperUnitOfWork(self)
+
+
+def _proposal_payload(
+    *,
+    proposal_id: str,
+    trade_date: str,
+    created_at: str,
+    approval_status: str = "approved",
+    approval_actor: str = "agent",
+) -> dict[str, Any]:
+    return {
+        "proposal_id": proposal_id,
+        "experiment_name": "phase7_paper_fixture",
+        "symbol": "QQQ",
+        "signal_date": "2026-04-10",
+        "effective_date": trade_date,
+        "reference_price": 640.41,
+        "execution_mode": "agent_approval",
+        "approval_status": approval_status,
+        "approval_actor": approval_actor,
+        "submission_status": "pending",
+        "min_score_threshold": 0.55,
+        "train_rows": 250,
+        "train_start": "2023-04-10",
+        "train_end": "2026-04-09",
+        "train_positive_rate": 0.55,
+        "created_at": created_at,
+        "data_provider": "alpaca",
+        "broker": "alpaca",
+        "evidence_path": f"/memory/{trade_date}/evidence.json",
+        "decision_policy": "consensus_vote",
+        "consensus_rule": {
+            "type": "consensus_vote",
+            "min_long_votes": 4,
+            "model_count": 6,
+        },
+        "long_vote_count": 4,
+        "cash_vote_count": 2,
+        "decision": "long",
+        "target_weight": 1.0,
+    }
+
+
+def _evidence_payload(*, proposal_id: str, trade_date: str) -> dict[str, Any]:
+    return {
+        "proposal_id": proposal_id,
+        "symbol": "QQQ",
+        "signal_date": "2026-04-10",
+        "effective_date": trade_date,
+        "feature_columns": ["feature_1"],
+        "train_rows": 250,
+        "train_start": "2023-04-10",
+        "train_end": "2026-04-09",
+        "train_positive_rate": 0.55,
+        "min_score_threshold": 0.55,
+        "reference_price": 640.41,
+        "models": [
+            {
+                "model_name": "logistic_regression",
+                "estimator_label": "logreg",
+                "score": 0.61,
+                "vote": "long",
+                "target_weight": 1.0,
+            }
+        ],
+        "decision_policy": "consensus_vote",
+        "consensus_rule": {
+            "type": "consensus_vote",
+            "min_long_votes": 4,
+            "model_count": 6,
+        },
+        "long_vote_count": 4,
+        "cash_vote_count": 2,
+        "decision": "long",
+        "target_weight": 1.0,
+        "created_at": "2026-04-10T20:10:00+00:00",
+    }
+
+
+def _build_factory(
+    *,
+    adapter_kind: str,
+    tmp_path: Path,
+    config,
+) -> PaperUnitOfWorkFactory:
+    if adapter_kind == "filesystem":
+        return build_filesystem_paper_uow_factory(config)
+    if adapter_kind == "memory":
+        return InMemoryPaperUnitOfWorkFactory(tmp_path / "memory-root")
+    raise ValueError(f"Unknown adapter kind: {adapter_kind}")
+
+
+@pytest.mark.parametrize("adapter_kind", ["filesystem", "memory"])
+def test_paper_repository_contract_stages_until_commit(adapter_kind: str, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path / adapter_kind, symbol="QQQ")
+    factory = _build_factory(adapter_kind=adapter_kind, tmp_path=tmp_path, config=config)
+    proposal = _proposal_payload(
+        proposal_id="proposal-1",
+        trade_date="2026-04-13",
+        created_at="2026-04-10T20:10:00+00:00",
+    )
+    evidence = _evidence_payload(
+        proposal_id=proposal["proposal_id"],
+        trade_date="2026-04-13",
+    )
+    status = {
+        "event": "paper-decision",
+        "status": "proposal_created",
+        "proposal_id": proposal["proposal_id"],
+    }
+
+    with factory() as uow:
+        uow.trades.save_evidence(evidence)
+        uow.trades.save_proposal(proposal)
+        uow.status.write_status(status)
+        assert uow.trades.get_proposal(proposal["proposal_id"]) == proposal
+        assert uow.trades.get_evidence("2026-04-13") == evidence
+        assert uow.status.read_status() == status
+
+    with factory() as uow:
+        assert uow.trades.get_proposal(proposal["proposal_id"]) is None
+        assert uow.trades.get_evidence("2026-04-13") is None
+        assert uow.status.read_status() is None
+
+
+@pytest.mark.parametrize("adapter_kind", ["filesystem", "memory"])
+def test_paper_repository_contract_persists_and_orders_records(adapter_kind: str, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path / f"{adapter_kind}-persist", symbol="QQQ")
+    factory = _build_factory(adapter_kind=adapter_kind, tmp_path=tmp_path, config=config)
+    older = _proposal_payload(
+        proposal_id="proposal-older",
+        trade_date="2026-04-13",
+        created_at="2026-04-10T20:10:00+00:00",
+    )
+    newer = _proposal_payload(
+        proposal_id="proposal-newer",
+        trade_date="2026-04-14",
+        created_at="2026-04-11T20:10:00+00:00",
+    )
+    submission = {
+        "proposal_id": newer["proposal_id"],
+        "trade_date": "2026-04-14",
+        "status": "submitted",
+        "order_status": "accepted",
+    }
+    order_status = {
+        "id": "order-1",
+        "status": "accepted",
+    }
+    status = {
+        "event": "paper-submit",
+        "status": "submitted",
+        "proposal_id": newer["proposal_id"],
+    }
+
+    with factory() as uow:
+        uow.trades.save_proposal(older)
+        uow.trades.save_evidence(_evidence_payload(proposal_id=older["proposal_id"], trade_date="2026-04-13"))
+        uow.commit()
+
+    with factory() as uow:
+        uow.trades.save_proposal(newer)
+        uow.trades.save_evidence(_evidence_payload(proposal_id=newer["proposal_id"], trade_date="2026-04-14"))
+        uow.trades.save_submission(trade_date="2026-04-14", submission=submission)
+        uow.trades.save_order_status(trade_date="2026-04-14", order_status=order_status)
+        uow.status.write_status(status)
+        uow.commit()
+
+    with factory() as uow:
+        proposals = uow.trades.list_proposals()
+        assert [proposal["proposal_id"] for proposal in proposals] == [
+            newer["proposal_id"],
+            older["proposal_id"],
+        ]
+        assert uow.trades.get_latest_proposal()["proposal_id"] == newer["proposal_id"]
+        assert uow.trades.get_submission("2026-04-14") == submission
+        assert uow.status.read_status() == status
+
+
+def test_filesystem_trade_repository_retry_backup_preserves_attempt_artifacts(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, symbol="QQQ")
+    factory = build_filesystem_paper_uow_factory(config)
+    trade_date = "2026-04-13"
+    store = PaperStateStore(config)
+
+    with factory() as uow:
+        uow.trades.save_submission(
+            trade_date=trade_date,
+            submission={"proposal_id": "proposal-1", "trade_date": trade_date, "status": "submitted"},
+        )
+        uow.trades.save_order_status(
+            trade_date=trade_date,
+            order_status={"id": "order-1", "status": "accepted"},
+        )
+        uow.commit()
+    write_trade_order_preview(
+        config,
+        trade_date=trade_date,
+        payload={"proposal_id": "proposal-1", "trade_date": trade_date, "side": "buy"},
+    )
+    write_trade_account_snapshot(
+        config,
+        trade_date=trade_date,
+        payload={"equity": "1000.00"},
+    )
+
+    with factory() as uow:
+        uow.trades.backup_submission_attempt_artifacts(
+            trade_date=trade_date,
+            now=datetime(2026, 4, 10, 23, 10, tzinfo=UTC),
+        )
+
+    trade_dir = store.trade_dir(trade_date)
+    backup_files = sorted(path.name for path in trade_dir.glob("*.retry-backup.*.bak"))
+    assert len(backup_files) == 4
+    assert not store.trade_submission_path(trade_date).exists()
+    assert not store.trade_order_status_path(trade_date).exists()
+    assert not store.trade_order_preview_path(trade_date).exists()
+    assert not store.trade_account_snapshot_path(trade_date).exists()
+
+
+def test_read_helpers_use_repository_boundary(monkeypatch, tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, symbol="QQQ")
+    factory = InMemoryPaperUnitOfWorkFactory(tmp_path / "memory-read")
+    proposal = _proposal_payload(
+        proposal_id="proposal-read",
+        trade_date="2026-04-13",
+        created_at="2026-04-10T20:10:00+00:00",
+        approval_status="pending",
+        approval_actor="",
+    )
+    evidence = _evidence_payload(proposal_id=proposal["proposal_id"], trade_date="2026-04-13")
+    status = {"event": "paper-decision", "status": "proposal_created", "proposal_id": proposal["proposal_id"]}
+
+    with factory() as uow:
+        uow.trades.save_proposal(proposal)
+        uow.trades.save_evidence(evidence)
+        uow.status.write_status(status)
+        uow.commit()
+
+    monkeypatch.setattr(service_module, "_paper_uow_factory", lambda _config: factory)
+
+    proposals = service_module.list_paper_proposals(config)
+    loaded_proposal = service_module.read_paper_proposal(config, proposal_id=proposal["proposal_id"])
+    loaded_evidence = service_module.read_paper_evidence(config, proposal_id=proposal["proposal_id"])
+    summary = service_module.get_paper_status(config)
+
+    assert [item["proposal_id"] for item in proposals] == [proposal["proposal_id"]]
+    assert loaded_proposal == proposal
+    assert loaded_evidence == evidence
+    assert summary["latest_proposal"]["proposal_id"] == proposal["proposal_id"]
+    assert summary["pending_proposal_count"] == 1
+    assert summary["status"] == status
+
+
+def _seed_submission_ready_proposal(factory: InMemoryPaperUnitOfWorkFactory) -> dict[str, Any]:
+    proposal = _proposal_payload(
+        proposal_id="proposal-submit",
+        trade_date="2026-04-13",
+        created_at="2026-04-10T20:10:00+00:00",
+        approval_status="approved",
+        approval_actor="agent",
+    )
+    with factory() as uow:
+        uow.trades.save_proposal(proposal)
+        uow.commit()
+    return proposal
+
+
+class _BoundaryBroker(FakeAlpacaBroker):
+    def __init__(self, *, factory: InMemoryPaperUnitOfWorkFactory) -> None:
+        super().__init__(
+            symbol="QQQ",
+            equity=1000.0,
+            buying_power=1000.0,
+            cash=1000.0,
+        )
+        self._factory = factory
+        self.calls: list[str] = []
+
+    def get_account(self) -> dict[str, object]:
+        assert self._factory.active_count == 0
+        self.calls.append("get_account")
+        return super().get_account()
+
+    def get_position(self, symbol: str) -> dict[str, object] | None:
+        assert self._factory.active_count == 0
+        self.calls.append("get_position")
+        return super().get_position(symbol)
+
+    def submit_notional_day_market_order(
+        self,
+        *,
+        symbol: str,
+        notional: float,
+        side: str,
+        client_order_id: str,
+    ) -> dict[str, object]:
+        assert self._factory.active_count == 0
+        self.calls.append("submit_notional_day_market_order")
+        return super().submit_notional_day_market_order(
+            symbol=symbol,
+            notional=notional,
+            side=side,
+            client_order_id=client_order_id,
+        )
+
+    def get_order(self, order_id: str) -> dict[str, object]:
+        assert self._factory.active_count == 0
+        self.calls.append("get_order")
+        return super().get_order(order_id)
+
+
+def test_submission_service_and_wrapper_keep_broker_and_notifications_outside_uow(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, symbol="QQQ")
+    factory = InMemoryPaperUnitOfWorkFactory(tmp_path / "memory-submit")
+    _seed_submission_ready_proposal(factory)
+    broker = _BoundaryBroker(factory=factory)
+    notification_events: list[str] = []
+
+    monkeypatch.setattr(service_module, "_paper_uow_factory", lambda _config: factory)
+
+    def _notify_submission(*args, **kwargs) -> None:
+        assert factory.active_count == 0
+        assert factory.commit_count >= 1
+        notification_events.append("notified")
+
+    monkeypatch.setattr(service_module, "notify_paper_submission", _notify_submission)
+
+    result = service_module.run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    assert result["status"]["status"] == "submitted"
+    assert broker.calls == [
+        "get_account",
+        "get_position",
+        "submit_notional_day_market_order",
+        "get_order",
+    ]
+    assert notification_events == ["notified"]
+
+
+class _ReconciliationBroker(FakeAlpacaBroker):
+    def __init__(self, *, factory: InMemoryPaperUnitOfWorkFactory) -> None:
+        super().__init__(
+            symbol="QQQ",
+            equity=1000.0,
+            buying_power=1000.0,
+            cash=1000.0,
+            order_status="rejected",
+        )
+        self._factory = factory
+        self.calls: list[str] = []
+
+    def get_order(self, order_id: str) -> dict[str, object]:
+        assert self._factory.active_count == 0
+        self.calls.append("get_order")
+        return {
+            "id": order_id,
+            "status": self.order_status,
+            "client_order_id": "client-order-1",
+        }
+
+
+def test_reconciliation_service_polls_broker_outside_uow(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, symbol="QQQ")
+    factory = InMemoryPaperUnitOfWorkFactory(tmp_path / "memory-reconcile")
+    proposal = _seed_submission_ready_proposal(factory)
+    with factory() as uow:
+        uow.trades.save_submission(
+            trade_date=str(proposal["effective_date"]),
+            submission={
+                "proposal_id": proposal["proposal_id"],
+                "trade_date": str(proposal["effective_date"]),
+                "status": "submitted",
+                "order_id": "order-1",
+                "client_order_id": "client-order-1",
+                "order_status": "accepted",
+                "poll_status": "observed",
+            },
+        )
+        uow.commit()
+
+    broker = _ReconciliationBroker(factory=factory)
+    result = ReconciliationService(config, uow_factory=factory).run(
+        PaperReconciliationRequest(
+            now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),
+            broker=broker,
+        )
+    )
+
+    assert result is not None
+    assert result.order_status == "rejected"
+    assert broker.calls == ["get_order"]

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -111,7 +111,10 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
     assert parser["testenv:typecheck"]["commands"].strip() == (
         "{envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py "
         "src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py "
-        "src/marketlab/paper/contracts.py src/marketlab/paper/agent.py "
+        "src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py "
+        "src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py "
+        "src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py "
+        "src/marketlab/paper/service.py src/marketlab/paper/agent.py "
         "src/marketlab/paper/scheduler.py"
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
## Summary
- add DB-agnostic paper persistence ports and a staged filesystem unit-of-work adapter
- move the paper decision, approval, submission, reconciliation, and read helpers onto the new persistence boundary
- add repository contract coverage and extend the paper typecheck surface

## Validation
- `py -3.14 -m pytest -q tests/unit/test_paper_persistence.py tests/unit/test_paper_application_services.py tests/unit/test_paper_service.py tests/unit/test_paper_agent.py tests/unit/test_paper_scheduler.py --basetemp .pytest_tmp_phase3_pr1`
- `py -3.14 -m tox -e typecheck`
- `py -3.14 -m tox -e lint`
- `py -3.14 -m tox -e docs`
- `py -3.14 -m tox -e py312`
- `py -3.14 -m tox -e package`
- `py -3.12 -m pytest -q tests/integration -m "not real_data and not network" --basetemp .pytest_tmp_integration`

## Notes
- local `tox -e integration` is environment-blocked on this Windows host because the recreated `.tox/integration` interpreter is missing `pip`; the equivalent offline integration pytest command above passed.
- local `tox -e preflight` did not return before the 10 minute tool timeout, but all of its relevant component envs above were run directly.
