### PR TITLE
refactor: isolate paper broker and artifact store adapters

### DIFF
--- a/src/marketlab/paper/application/approval.py
+++ b/src/marketlab/paper/application/approval.py
@@ -12,7 +12,6 @@ from marketlab.paper.core import (
     _now_utc,
     validate_paper_trading_config,
 )
-from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 
 
 class ApprovalService:
@@ -20,10 +19,10 @@ class ApprovalService:
         self,
         config: ExperimentConfig,
         *,
-        uow_factory: PaperUnitOfWorkFactory | None = None,
+        uow_factory: PaperUnitOfWorkFactory,
     ) -> None:
         self._config = config
-        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
+        self._uow_factory = uow_factory
 
     def run(self, request: PaperApprovalRequest) -> PaperApprovalResult:
         config = self._config

--- a/src/marketlab/paper/application/decision.py
+++ b/src/marketlab/paper/application/decision.py
@@ -16,15 +16,13 @@ from marketlab.models import (
     predict_direction_scores,
 )
 from marketlab.models.training import modeling_feature_columns
-from marketlab.paper.alpaca import (
-    AlpacaMarketDataProvider,
-    AlpacaPaperBrokerClient,
-)
 from marketlab.paper.contracts import (
     PaperBroker,
+    PaperBrokerFactory,
     PaperDecisionRequest,
     PaperDecisionResult,
     PaperHistoryProvider,
+    PaperHistoryProviderFactory,
     PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
@@ -40,17 +38,17 @@ from marketlab.paper.core import (
     _paper_symbol,
     validate_paper_trading_config,
 )
-from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 from marketlab.targets import add_forward_targets, build_rebalance_snapshots
 
 
-def _build_alpaca_panel(
+def _build_market_panel(
     config: ExperimentConfig,
-    provider: PaperHistoryProvider | None = None,
+    *,
+    provider: PaperHistoryProvider,
 ) -> pd.DataFrame:
     frames = load_symbol_frames(
         config,
-        provider=provider or AlpacaMarketDataProvider(),
+        provider=provider,
         force_refresh=True,
     )
     return build_market_panel(frames)
@@ -82,7 +80,7 @@ def _next_trading_date(
     for candidate in future_dates:
         if candidate > market_date:
             return candidate
-    raise RuntimeError("The Alpaca calendar did not provide a future trading date for the paper decision.")
+    raise RuntimeError("The broker calendar did not provide a future trading date for the paper decision.")
 
 
 def _proposal_id(signal_date: str, effective_date: str, symbol: str) -> str:
@@ -204,17 +202,37 @@ class DecisionService:
         self,
         config: ExperimentConfig,
         *,
-        uow_factory: PaperUnitOfWorkFactory | None = None,
+        uow_factory: PaperUnitOfWorkFactory,
+        history_provider_factory: PaperHistoryProviderFactory | None = None,
+        broker_factory: PaperBrokerFactory | None = None,
     ) -> None:
         self._config = config
-        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
+        self._uow_factory = uow_factory
+        self._history_provider_factory = history_provider_factory
+        self._broker_factory = broker_factory
+
+    def _provider(self, request: PaperDecisionRequest) -> PaperHistoryProvider:
+        if request.provider is not None:
+            return request.provider
+        if self._history_provider_factory is None:
+            raise RuntimeError(
+                "DecisionService requires a history provider or history_provider_factory."
+            )
+        return self._history_provider_factory()
+
+    def _broker(self, request: PaperDecisionRequest) -> PaperBroker:
+        if request.broker is not None:
+            return request.broker
+        if self._broker_factory is None:
+            raise RuntimeError("DecisionService requires a broker or broker_factory.")
+        return self._broker_factory()
 
     def run(self, request: PaperDecisionRequest) -> PaperDecisionResult:
         config = self._config
         validate_paper_trading_config(config)
         paper_symbol = _paper_symbol(config)
         local_now = _local_now(config, request.now)
-        broker_client = request.broker or AlpacaPaperBrokerClient()
+        broker_client = self._broker(request)
         market_date = local_now.date()
 
         if not _is_trading_day(broker_client, market_date=market_date):
@@ -233,7 +251,7 @@ class DecisionService:
                 status=status,
             )
 
-        panel = _build_alpaca_panel(config, provider=request.provider)
+        panel = _build_market_panel(config, provider=self._provider(request))
         featured_panel = add_feature_set(panel=panel, **asdict(config.features))
         historical_snapshots = build_rebalance_snapshots(
             featured_panel,

--- a/src/marketlab/paper/application/reconciliation.py
+++ b/src/marketlab/paper/application/reconciliation.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Any
 
 from marketlab.config import ExperimentConfig
-from marketlab.paper.alpaca import AlpacaPaperBrokerClient
 from marketlab.paper.contracts import (
     PaperBroker,
+    PaperBrokerFactory,
     PaperReconciliationRequest,
     PaperReconciliationResult,
     PaperTradeRepository,
@@ -19,7 +19,6 @@ from marketlab.paper.core import (
     _now_utc,
     validate_paper_trading_config,
 )
-from marketlab.paper.persistence import build_filesystem_paper_uow_factory
 
 
 def _poll_order_status(
@@ -66,6 +65,7 @@ def _refresh_submission_order_status(
     *,
     submission: dict[str, Any],
     order_status_path: Path,
+    has_order_status_path: bool,
     broker_client: PaperBroker,
     now: datetime | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]] | None:
@@ -91,7 +91,7 @@ def _refresh_submission_order_status(
     if (
         refreshed_order_status == current_order_status
         and poll_status == current_poll_status
-        and order_status_path.exists()
+        and has_order_status_path
     ):
         return None
 
@@ -108,10 +108,19 @@ class ReconciliationService:
         self,
         config: ExperimentConfig,
         *,
-        uow_factory: PaperUnitOfWorkFactory | None = None,
+        uow_factory: PaperUnitOfWorkFactory,
+        broker_factory: PaperBrokerFactory | None = None,
     ) -> None:
         self._config = config
-        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
+        self._uow_factory = uow_factory
+        self._broker_factory = broker_factory
+
+    def _broker(self, request: PaperReconciliationRequest) -> PaperBroker:
+        if request.broker is not None:
+            return request.broker
+        if self._broker_factory is None:
+            raise RuntimeError("ReconciliationService requires a broker or broker_factory.")
+        return self._broker_factory()
 
     def run(
         self,
@@ -127,10 +136,11 @@ class ReconciliationService:
         trade_date = str(submission["trade_date"])
         with self._uow_factory() as path_uow:
             order_status_path = path_uow.trades.trade_order_status_path(trade_date)
-        broker_client = request.broker or AlpacaPaperBrokerClient()
+        broker_client = self._broker(request)
         refreshed = _refresh_submission_order_status(
             submission=submission,
             order_status_path=order_status_path,
+            has_order_status_path=str(submission.get("order_status_path", "")).strip() != "",
             broker_client=broker_client,
             now=request.now,
         )

--- a/src/marketlab/paper/application/reconciliation.py
+++ b/src/marketlab/paper/application/reconciliation.py
@@ -136,11 +136,12 @@ class ReconciliationService:
         trade_date = str(submission["trade_date"])
         with self._uow_factory() as path_uow:
             order_status_path = path_uow.trades.trade_order_status_path(trade_date)
+            has_order_status_path = path_uow.trades.order_status_path_exists(trade_date)
         broker_client = self._broker(request)
         refreshed = _refresh_submission_order_status(
             submission=submission,
             order_status_path=order_status_path,
-            has_order_status_path=str(submission.get("order_status_path", "")).strip() != "",
+            has_order_status_path=has_order_status_path,
             broker_client=broker_client,
             now=request.now,
         )

--- a/src/marketlab/paper/application/submission.py
+++ b/src/marketlab/paper/application/submission.py
@@ -95,6 +95,7 @@ class SubmissionService:
             trade_date = str(proposal["effective_date"])
             submission_path = uow.trades.trade_submission_path(trade_date)
             order_status_path = uow.trades.trade_order_status_path(trade_date)
+            has_order_status_path = uow.trades.order_status_path_exists(trade_date)
             submission = uow.trades.get_submission(trade_date)
 
         if submission is not None:
@@ -102,7 +103,7 @@ class SubmissionService:
             refreshed = _refresh_submission_order_status(
                 submission=submission,
                 order_status_path=order_status_path,
-                has_order_status_path=str(submission.get("order_status_path", "")).strip() != "",
+                has_order_status_path=has_order_status_path,
                 broker_client=broker_client,
                 now=request.now,
             )

--- a/src/marketlab/paper/application/submission.py
+++ b/src/marketlab/paper/application/submission.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from marketlab.config import ExperimentConfig
-from marketlab.paper.alpaca import AlpacaPaperBrokerClient
 from marketlab.paper.contracts import (
+    PaperArtifactStore,
+    PaperBroker,
+    PaperBrokerFactory,
     PaperSubmissionRequest,
     PaperSubmissionResult,
     PaperUnitOfWorkFactory,
@@ -26,11 +28,6 @@ from marketlab.paper.core import (
     _rounded_notional,
     _safe_float,
     validate_paper_trading_config,
-)
-from marketlab.paper.persistence import (
-    build_filesystem_paper_uow_factory,
-    write_trade_account_snapshot,
-    write_trade_order_preview,
 )
 
 from .reconciliation import _poll_order_status, _refresh_submission_order_status
@@ -60,10 +57,21 @@ class SubmissionService:
         self,
         config: ExperimentConfig,
         *,
-        uow_factory: PaperUnitOfWorkFactory | None = None,
+        uow_factory: PaperUnitOfWorkFactory,
+        artifact_store: PaperArtifactStore,
+        broker_factory: PaperBrokerFactory | None = None,
     ) -> None:
         self._config = config
-        self._uow_factory = uow_factory or build_filesystem_paper_uow_factory(config)
+        self._uow_factory = uow_factory
+        self._artifact_store = artifact_store
+        self._broker_factory = broker_factory
+
+    def _broker(self, request: PaperSubmissionRequest) -> PaperBroker:
+        if request.broker is not None:
+            return request.broker
+        if self._broker_factory is None:
+            raise RuntimeError("SubmissionService requires a broker or broker_factory.")
+        return self._broker_factory()
 
     def run(self, request: PaperSubmissionRequest) -> PaperSubmissionResult:
         config = self._config
@@ -90,10 +98,11 @@ class SubmissionService:
             submission = uow.trades.get_submission(trade_date)
 
         if submission is not None:
-            broker_client = request.broker or AlpacaPaperBrokerClient()
+            broker_client = self._broker(request)
             refreshed = _refresh_submission_order_status(
                 submission=submission,
                 order_status_path=order_status_path,
+                has_order_status_path=str(submission.get("order_status_path", "")).strip() != "",
                 broker_client=broker_client,
                 now=request.now,
             )
@@ -149,7 +158,7 @@ class SubmissionService:
                     "paper-submit is only allowed at or after "
                     f"{config.paper.submission_time} {config.paper.schedule_timezone}."
                 )
-            broker_client = request.broker or AlpacaPaperBrokerClient()
+            broker_client = self._broker(request)
             retry_suffix = ""
 
         gate_status, gate_reason = _submission_gate_status(config, proposal)
@@ -186,8 +195,7 @@ class SubmissionService:
             )
 
         account = broker_client.get_account()
-        account_snapshot_path = write_trade_account_snapshot(
-            config,
+        account_snapshot_path = self._artifact_store.write_trade_account_snapshot(
             trade_date=trade_date,
             payload=account,
         )
@@ -251,8 +259,7 @@ class SubmissionService:
             "side": side,
             "updated_at": _now_utc(request.now).isoformat(),
         }
-        order_preview_path = write_trade_order_preview(
-            config,
+        order_preview_path = self._artifact_store.write_trade_order_preview(
             trade_date=trade_date,
             payload=order_preview,
         )

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -117,6 +117,8 @@ class PaperTradeRepository(Protocol):
 
     def trade_order_status_path(self, trade_date: str) -> Path: ...
 
+    def order_status_path_exists(self, trade_date: str) -> bool: ...
+
     def backup_submission_attempt_artifacts(
         self,
         *,

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -78,6 +78,16 @@ class PaperBroker(Protocol):
 
 
 @runtime_checkable
+class PaperHistoryProviderFactory(Protocol):
+    def __call__(self) -> PaperHistoryProvider: ...
+
+
+@runtime_checkable
+class PaperBrokerFactory(Protocol):
+    def __call__(self) -> PaperBroker: ...
+
+
+@runtime_checkable
 class PaperTradeRepository(Protocol):
     def list_proposals(self) -> list[dict[str, Any]]: ...
 
@@ -145,6 +155,23 @@ class PaperUnitOfWork(Protocol):
 @runtime_checkable
 class PaperUnitOfWorkFactory(Protocol):
     def __call__(self) -> PaperUnitOfWork: ...
+
+
+@runtime_checkable
+class PaperArtifactStore(Protocol):
+    def write_trade_account_snapshot(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path: ...
+
+    def write_trade_order_preview(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path: ...
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/marketlab/paper/persistence/__init__.py
+++ b/src/marketlab/paper/persistence/__init__.py
@@ -1,15 +1,15 @@
 from .filesystem import (
+    FilesystemPaperArtifactStore,
     FilesystemPaperUnitOfWork,
     FilesystemPaperUnitOfWorkFactory,
+    build_filesystem_paper_artifact_store,
     build_filesystem_paper_uow_factory,
-    write_trade_account_snapshot,
-    write_trade_order_preview,
 )
 
 __all__ = [
+    "FilesystemPaperArtifactStore",
     "FilesystemPaperUnitOfWork",
     "FilesystemPaperUnitOfWorkFactory",
+    "build_filesystem_paper_artifact_store",
     "build_filesystem_paper_uow_factory",
-    "write_trade_account_snapshot",
-    "write_trade_order_preview",
 ]

--- a/src/marketlab/paper/persistence/filesystem.py
+++ b/src/marketlab/paper/persistence/filesystem.py
@@ -109,6 +109,10 @@ class FilesystemPaperTradeRepository(PaperTradeRepository):
     def trade_order_status_path(self, trade_date: str) -> Path:
         return self._store.trade_order_status_path(trade_date)
 
+    def order_status_path_exists(self, trade_date: str) -> bool:
+        path = self._store.trade_order_status_path(trade_date)
+        return path in self._pending_writes or path.exists()
+
     def backup_submission_attempt_artifacts(
         self,
         *,

--- a/src/marketlab/paper/persistence/filesystem.py
+++ b/src/marketlab/paper/persistence/filesystem.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from marketlab.config import ExperimentConfig
 from marketlab.paper.contracts import (
+    PaperArtifactStore,
     PaperStatusRepository,
     PaperTradeRepository,
     PaperUnitOfWork,
@@ -198,19 +199,26 @@ def build_filesystem_paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfW
     return FilesystemPaperUnitOfWorkFactory(config)
 
 
-def write_trade_account_snapshot(
-    config: ExperimentConfig,
-    *,
-    trade_date: str,
-    payload: dict[str, Any],
-) -> Path:
-    return _json_dump(PaperStateStore(config).trade_account_snapshot_path(trade_date), payload)
+class FilesystemPaperArtifactStore(PaperArtifactStore):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._store = PaperStateStore(config)
+
+    def write_trade_account_snapshot(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        return _json_dump(self._store.trade_account_snapshot_path(trade_date), payload)
+
+    def write_trade_order_preview(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        return _json_dump(self._store.trade_order_preview_path(trade_date), payload)
 
 
-def write_trade_order_preview(
-    config: ExperimentConfig,
-    *,
-    trade_date: str,
-    payload: dict[str, Any],
-) -> Path:
-    return _json_dump(PaperStateStore(config).trade_order_preview_path(trade_date), payload)
+def build_filesystem_paper_artifact_store(config: ExperimentConfig) -> PaperArtifactStore:
+    return FilesystemPaperArtifactStore(config)

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.paper.alpaca import AlpacaMarketDataProvider, AlpacaPaperBrokerClient
 from marketlab.paper.application import (
     ApprovalService,
     DecisionService,
@@ -12,11 +13,15 @@ from marketlab.paper.application import (
 )
 from marketlab.paper.contracts import (
     PaperApprovalRequest,
+    PaperArtifactStore,
     PaperBroker,
+    PaperBrokerFactory,
     PaperDecisionRequest,
     PaperHistoryProvider,
+    PaperHistoryProviderFactory,
     PaperReconciliationRequest,
     PaperSubmissionRequest,
+    PaperUnitOfWorkFactory,
 )
 from marketlab.paper.core import (
     APPROVAL_PENDING as _APPROVAL_PENDING,
@@ -46,7 +51,10 @@ from marketlab.paper.notifications import (
     notify_paper_submission,
     write_notification_record,
 )
-from marketlab.paper.persistence import build_filesystem_paper_uow_factory
+from marketlab.paper.persistence import (
+    build_filesystem_paper_artifact_store,
+    build_filesystem_paper_uow_factory,
+)
 from marketlab.paper.state import PaperStateStore
 
 APPROVAL_PENDING = _APPROVAL_PENDING
@@ -58,8 +66,24 @@ _paper_symbol = _core_paper_symbol
 _write_notification_record = write_notification_record
 
 
-def _paper_uow_factory(config: ExperimentConfig):
+def _paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
     return build_filesystem_paper_uow_factory(config)
+
+
+def _paper_history_provider_factory(config: ExperimentConfig) -> PaperHistoryProviderFactory:
+    if config.paper.data_provider != "alpaca":
+        raise ValueError(f"Unsupported paper data provider: {config.paper.data_provider}")
+    return AlpacaMarketDataProvider
+
+
+def _paper_broker_factory(config: ExperimentConfig) -> PaperBrokerFactory:
+    if config.paper.broker != "alpaca":
+        raise ValueError(f"Unsupported paper broker: {config.paper.broker}")
+    return AlpacaPaperBrokerClient
+
+
+def _paper_artifact_store(config: ExperimentConfig) -> PaperArtifactStore:
+    return build_filesystem_paper_artifact_store(config)
 
 
 def _decision_notification_outcome(status: dict[str, Any]) -> str:
@@ -79,7 +103,12 @@ def run_paper_decision(
     broker: PaperBroker | None = None,
     notification_transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
-    result = DecisionService(config, uow_factory=_paper_uow_factory(config)).run(
+    result = DecisionService(
+        config,
+        uow_factory=_paper_uow_factory(config),
+        history_provider_factory=_paper_history_provider_factory(config),
+        broker_factory=_paper_broker_factory(config),
+    ).run(
         PaperDecisionRequest(
             now=now,
             provider=provider,
@@ -180,7 +209,11 @@ def reconcile_latest_submission_status(
     now: datetime | None = None,
     broker: PaperBroker | None = None,
 ) -> dict[str, Any] | None:
-    result = ReconciliationService(config, uow_factory=_paper_uow_factory(config)).run(
+    result = ReconciliationService(
+        config,
+        uow_factory=_paper_uow_factory(config),
+        broker_factory=_paper_broker_factory(config),
+    ).run(
         PaperReconciliationRequest(
             now=now,
             broker=broker,
@@ -199,7 +232,12 @@ def run_paper_submit(
     notification_transport: TelegramTransport | None = None,
     retry_failed_submission: bool = False,
 ) -> dict[str, Any]:
-    result = SubmissionService(config, uow_factory=_paper_uow_factory(config)).run(
+    result = SubmissionService(
+        config,
+        uow_factory=_paper_uow_factory(config),
+        artifact_store=_paper_artifact_store(config),
+        broker_factory=_paper_broker_factory(config),
+    ).run(
         PaperSubmissionRequest(
             now=now,
             broker=broker,

--- a/tests/unit/test_paper_application_services.py
+++ b/tests/unit/test_paper_application_services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from tests._paper_fakes import (
     FakeAlpacaBroker,
@@ -17,9 +18,14 @@ from marketlab.paper.application import (
 )
 from marketlab.paper.contracts import (
     PaperApprovalRequest,
+    PaperArtifactStore,
     PaperDecisionRequest,
     PaperReconciliationRequest,
     PaperSubmissionRequest,
+)
+from marketlab.paper.persistence import (
+    build_filesystem_paper_artifact_store,
+    build_filesystem_paper_uow_factory,
 )
 from marketlab.paper.service import (
     PaperStateStore,
@@ -29,6 +35,37 @@ from marketlab.paper.service import (
     run_paper_submit,
 )
 from marketlab.paper.state import _json_load
+
+
+class _RecordingArtifactStore(PaperArtifactStore):
+    def __init__(self, delegate: PaperArtifactStore) -> None:
+        self._delegate = delegate
+        self.account_snapshot_writes: list[tuple[str, dict[str, Any]]] = []
+        self.order_preview_writes: list[tuple[str, dict[str, Any]]] = []
+
+    def write_trade_account_snapshot(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        self.account_snapshot_writes.append((trade_date, dict(payload)))
+        return self._delegate.write_trade_account_snapshot(
+            trade_date=trade_date,
+            payload=payload,
+        )
+
+    def write_trade_order_preview(
+        self,
+        *,
+        trade_date: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        self.order_preview_writes.append((trade_date, dict(payload)))
+        return self._delegate.write_trade_order_preview(
+            trade_date=trade_date,
+            payload=payload,
+        )
 
 
 def _normalize_proposal(proposal: dict[str, object]) -> dict[str, object]:
@@ -131,7 +168,10 @@ def test_decision_service_matches_legacy_wrapper(tmp_path: Path) -> None:
     direct_config = build_phase7_paper_config(tmp_path / "direct")
     wrapper_config = build_phase7_paper_config(tmp_path / "wrapper")
 
-    direct_result = DecisionService(direct_config).run(
+    direct_result = DecisionService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+    ).run(
         PaperDecisionRequest(
             now=decision_now,
             provider=FakeAlpacaProvider(symbol="VOO"),
@@ -164,13 +204,46 @@ def test_decision_service_matches_legacy_wrapper(tmp_path: Path) -> None:
     assert wrapped_evidence == direct_evidence
 
 
+def test_decision_service_supports_injected_broker_and_provider_factories(tmp_path: Path) -> None:
+    decision_now = datetime(2026, 4, 10, 20, 10, tzinfo=UTC)
+    config = build_phase7_paper_config(tmp_path, symbol="QQQ")
+    provider = FakeAlpacaProvider(symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ")
+    provider_calls = 0
+    broker_calls = 0
+
+    def _provider_factory() -> FakeAlpacaProvider:
+        nonlocal provider_calls
+        provider_calls += 1
+        return provider
+
+    def _broker_factory() -> FakeAlpacaBroker:
+        nonlocal broker_calls
+        broker_calls += 1
+        return broker
+
+    result = DecisionService(
+        config,
+        uow_factory=build_filesystem_paper_uow_factory(config),
+        history_provider_factory=_provider_factory,
+        broker_factory=_broker_factory,
+    ).run(PaperDecisionRequest(now=decision_now))
+
+    assert result.proposal_id != ""
+    assert provider_calls == 1
+    assert broker_calls == 1
+
+
 def test_approval_service_matches_legacy_wrapper(tmp_path: Path) -> None:
     decision_now = datetime(2026, 4, 10, 20, 10, tzinfo=UTC)
     approval_now = datetime(2026, 4, 10, 20, 20, tzinfo=UTC)
     direct_config = build_phase7_paper_config(tmp_path / "direct")
     wrapper_config = build_phase7_paper_config(tmp_path / "wrapper")
 
-    direct_decision = DecisionService(direct_config).run(
+    direct_decision = DecisionService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+    ).run(
         PaperDecisionRequest(
             now=decision_now,
             provider=FakeAlpacaProvider(symbol="VOO"),
@@ -184,7 +257,10 @@ def test_approval_service_matches_legacy_wrapper(tmp_path: Path) -> None:
         broker=FakeAlpacaBroker(symbol="VOO"),
     )
 
-    direct_result = ApprovalService(direct_config).run(
+    direct_result = ApprovalService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+    ).run(
         PaperApprovalRequest(
             proposal_id=direct_decision.proposal_id,
             decision="approve",
@@ -248,7 +324,12 @@ def test_submission_service_matches_legacy_wrapper(tmp_path: Path) -> None:
         broker=wrapper_broker,
     )
 
-    direct_result = SubmissionService(direct_config).run(
+    recording_store = _RecordingArtifactStore(build_filesystem_paper_artifact_store(direct_config))
+    direct_result = SubmissionService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+        artifact_store=recording_store,
+    ).run(
         PaperSubmissionRequest(
             now=submission_now,
             broker=direct_broker,
@@ -286,6 +367,18 @@ def test_submission_service_matches_legacy_wrapper(tmp_path: Path) -> None:
     assert wrapper_order_status == direct_order_status
     assert wrapper_order_preview == direct_order_preview
     assert wrapper_account_snapshot == direct_account_snapshot
+    assert recording_store.account_snapshot_writes == [
+        (
+            direct_trade_date,
+            direct_account_snapshot,
+        )
+    ]
+    assert recording_store.order_preview_writes == [
+        (
+            direct_trade_date,
+            direct_order_preview,
+        )
+    ]
 
 
 def test_reconciliation_service_matches_legacy_wrapper(tmp_path: Path) -> None:
@@ -310,7 +403,11 @@ def test_reconciliation_service_matches_legacy_wrapper(tmp_path: Path) -> None:
 
     _, direct_trade_date = _seed_approved_long_proposal(direct_config, broker=direct_broker)
     _, wrapper_trade_date = _seed_approved_long_proposal(wrapper_config, broker=wrapper_broker)
-    SubmissionService(direct_config).run(
+    SubmissionService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+        artifact_store=build_filesystem_paper_artifact_store(direct_config),
+    ).run(
         PaperSubmissionRequest(
             now=submission_now,
             broker=direct_broker,
@@ -324,7 +421,10 @@ def test_reconciliation_service_matches_legacy_wrapper(tmp_path: Path) -> None:
 
     direct_broker.order_status = "rejected"
     wrapper_broker.order_status = "rejected"
-    direct_result = ReconciliationService(direct_config).run(
+    direct_result = ReconciliationService(
+        direct_config,
+        uow_factory=build_filesystem_paper_uow_factory(direct_config),
+    ).run(
         PaperReconciliationRequest(
             now=reconciliation_now,
             broker=direct_broker,

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -148,6 +148,12 @@ class InMemoryPaperTradeRepository(PaperTradeRepository):
     def trade_order_status_path(self, trade_date: str) -> Path:
         return self._trade_path(trade_date) / "order_status.json"
 
+    def order_status_path_exists(self, trade_date: str) -> bool:
+        return (
+            trade_date in self._pending.order_status_by_trade_date
+            or trade_date in self._state.order_status_by_trade_date
+        )
+
     def backup_submission_attempt_artifacts(
         self,
         *,

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -19,9 +19,8 @@ from marketlab.paper.contracts import (
     PaperUnitOfWorkFactory,
 )
 from marketlab.paper.persistence import (
+    build_filesystem_paper_artifact_store,
     build_filesystem_paper_uow_factory,
-    write_trade_account_snapshot,
-    write_trade_order_preview,
 )
 from marketlab.paper.state import PaperStateStore
 
@@ -420,6 +419,7 @@ def test_paper_repository_contract_persists_and_orders_records(adapter_kind: str
 def test_filesystem_trade_repository_retry_backup_preserves_attempt_artifacts(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, symbol="QQQ")
     factory = build_filesystem_paper_uow_factory(config)
+    artifact_store = build_filesystem_paper_artifact_store(config)
     trade_date = "2026-04-13"
     store = PaperStateStore(config)
 
@@ -433,13 +433,11 @@ def test_filesystem_trade_repository_retry_backup_preserves_attempt_artifacts(tm
             order_status={"id": "order-1", "status": "accepted"},
         )
         uow.commit()
-    write_trade_order_preview(
-        config,
+    artifact_store.write_trade_order_preview(
         trade_date=trade_date,
         payload={"proposal_id": "proposal-1", "trade_date": trade_date, "side": "buy"},
     )
-    write_trade_account_snapshot(
-        config,
+    artifact_store.write_trade_account_snapshot(
         trade_date=trade_date,
         payload={"equity": "1000.00"},
     )

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -498,6 +498,53 @@ def test_reconcile_latest_submission_status_refreshes_broker_rejection(tmp_path:
     assert submission["order_status"] == "rejected"
 
 
+def test_reconcile_latest_submission_status_recreates_missing_order_status_artifact(
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=broker,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(proposal_result["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+    )
+
+    order_status_path = store.trade_order_status_path("2026-04-13")
+    order_status = json.loads(order_status_path.read_text(encoding="utf-8"))
+    order_status_path.unlink()
+    assert not order_status_path.exists()
+
+    broker.order_status = str(order_status["status"])
+    reconciliation = reconcile_latest_submission_status(
+        config,
+        now=datetime(2026, 4, 11, 14, 0, tzinfo=UTC),
+        broker=broker,
+    )
+
+    recreated_order_status = json.loads(order_status_path.read_text(encoding="utf-8"))
+    assert reconciliation is not None
+    assert recreated_order_status == order_status
+
+
 def test_reconcile_latest_submission_status_uses_latest_submitted_trade(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
     broker = FakeAlpacaBroker(symbol="QQQ", order_status="accepted")


### PR DESCRIPTION
## Summary
- add explicit paper broker, history-provider, and artifact-store ports plus the filesystem artifact-store adapter
- move Alpaca and filesystem default wiring into the paper service composition root
- cover adapter substitution and artifact-store behavior in the paper service and persistence tests

## Validation
- py -3.14 -m tox -e preflight
