### PR TITLE
refactor: isolate paper notification and approval-provider adapters

### DIFF
--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -1,60 +1,34 @@
 from __future__ import annotations
 
 import json
-import os
 import time
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from marketlab.config import ExperimentConfig
-from marketlab.env import load_env_file
-from marketlab.paper.contracts import PaperApprovalResult, PaperBroker
+from marketlab.paper.approval_clients import build_default_paper_approval_client
+from marketlab.paper.contracts import (
+    PaperApprovalClient,
+    PaperApprovalEvaluationRequest,
+    PaperApprovalResult,
+    PaperBroker,
+    PaperNotificationSink,
+)
 from marketlab.paper.notifications import (
     PaperLoopStageError,
-    TelegramTransport,
     build_error_fingerprint,
-    build_error_message,
+    build_telegram_paper_notification_sink,
 )
 from marketlab.paper.service import (
     APPROVAL_PENDING,
-    PaperStateStore,
     _now_utc,
-    _write_notification_record,
+    _paper_broker_factory,
     decide_paper_proposal,
     read_paper_evidence,
     validate_paper_trading_config,
 )
-
-
-class AgentDecisionError(RuntimeError):
-    pass
-
-
-@dataclass(slots=True, frozen=True)
-class AgentDecision:
-    decision: str
-    rationale: str
-    provider: str
-    model: str
-    fallback_used: bool = False
-    fallback_reason: str = ""
-
-
-class AgentBackend:
-    provider_name = "base"
-
-    def evaluate(
-        self,
-        *,
-        config: ExperimentConfig,
-        proposal: dict[str, Any],
-        evidence: dict[str, Any],
-        status: dict[str, Any] | None,
-        account_context: dict[str, Any],
-    ) -> AgentDecision:
-        raise NotImplementedError
+from marketlab.paper.state import PaperStateStore
 
 
 def _json_dump(path: Path, payload: dict[str, Any]) -> Path:
@@ -91,13 +65,21 @@ def _clear_worker_error_state(state: dict[str, Any]) -> None:
         state.pop(key, None)
 
 
+def _paper_notification_sink(config: ExperimentConfig) -> PaperNotificationSink:
+    return build_telegram_paper_notification_sink(config)
+
+
+def _paper_approval_client(config: ExperimentConfig) -> PaperApprovalClient:
+    return build_default_paper_approval_client(config)
+
+
 def _notify_worker_error(
     config: ExperimentConfig,
     *,
     state: dict[str, Any],
     exc: Exception,
     now: datetime | None = None,
-    transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> Path | None:
     if isinstance(exc, PaperLoopStageError):
         stage = exc.stage
@@ -129,405 +111,15 @@ def _notify_worker_error(
     state["last_error_proposal_id"] = proposal_id
     state["last_error_trade_date"] = trade_date
     state["last_error_alert_at"] = _now_utc(now).isoformat()
-    store = PaperStateStore(config)
-    return _write_notification_record(
-        config,
-        store,
-        stage="paper-error",
-        outcome="error",
-        message=build_error_message(
-            config,
-            loop_name="agent",
-            stage=stage,
-            exc=root_error,
-            proposal_id=proposal_id,
-            trade_date=trade_date,
-        ),
-        details={
-            "experiment_name": config.experiment_name,
-            "loop": "agent",
-            "failed_stage": stage,
-            "proposal_id": proposal_id,
-            "trade_date": trade_date,
-            "exception_type": type(root_error).__name__,
-            "exception_message": str(root_error),
-        },
+    sink = notification_sink or _paper_notification_sink(config)
+    return sink.notify_error(
+        loop_name="agent",
+        stage=stage,
+        exc=root_error,
         proposal_id=proposal_id,
         trade_date=trade_date,
         now=now,
-        transport=transport,
     )
-
-
-def _decision_schema() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "properties": {
-            "decision": {
-                "type": "string",
-                "enum": ["approve", "reject"],
-            },
-            "rationale": {
-                "type": "string",
-            },
-        },
-        "required": ["decision", "rationale"],
-        "additionalProperties": False,
-    }
-
-
-def _approval_policy_prompt() -> str:
-    return (
-        "Review the attached paper-trading proposal evidence and decide whether to "
-        "approve or reject the existing proposal. You may only approve or reject the "
-        "proposal as written. The consensus rule has already been applied by the system. "
-        "If the persisted proposal and evidence are internally consistent for the same "
-        "trade, approve it. Reject only when the persisted proposal or evidence is "
-        "malformed, inconsistent, or refers to a different trade. Do not invent a "
-        "different trade, symbol, quantity, side, target weight, threshold, or date. "
-        "Return only the required structured output."
-    )
-
-
-def _coerce_agent_decision(payload: Any, *, provider: str, model: str) -> AgentDecision:
-    if not isinstance(payload, dict):
-        raise AgentDecisionError(f"{provider} returned a non-object structured response.")
-    decision = str(payload.get("decision", "")).strip().lower()
-    rationale = str(payload.get("rationale", "")).strip()
-    if decision not in {"approve", "reject"}:
-        raise AgentDecisionError(f"{provider} returned an invalid decision: {decision!r}")
-    if rationale == "":
-        raise AgentDecisionError(f"{provider} returned an empty rationale.")
-    return AgentDecision(
-        decision=decision,
-        rationale=rationale,
-        provider=provider,
-        model=model,
-    )
-
-
-def _proposal_is_consistent(proposal: dict[str, Any], evidence: dict[str, Any]) -> tuple[bool, str]:
-    if proposal.get("proposal_id") != evidence.get("proposal_id"):
-        return False, "proposal_id mismatch"
-    if proposal.get("symbol") != evidence.get("symbol"):
-        return False, "symbol mismatch"
-    if proposal.get("effective_date") != evidence.get("effective_date"):
-        return False, "effective_date mismatch"
-    if proposal.get("decision_policy") != "consensus_vote":
-        return False, "unsupported decision policy"
-    models = evidence.get("models", [])
-    if not isinstance(models, list) or len(models) == 0:
-        return False, "missing model evidence"
-    consensus_rule = evidence.get("consensus_rule")
-    if not isinstance(consensus_rule, dict):
-        return False, "missing consensus rule"
-    try:
-        proposal_target_weight = float(proposal.get("target_weight", 0.0))
-        evidence_target_weight = float(evidence.get("target_weight", 0.0))
-        proposal_long_vote_count = int(proposal.get("long_vote_count", -1))
-        evidence_long_vote_count = int(evidence.get("long_vote_count", -2))
-        proposal_cash_vote_count = int(proposal.get("cash_vote_count", -1))
-        evidence_cash_vote_count = int(evidence.get("cash_vote_count", -2))
-        threshold = int(consensus_rule.get("min_long_votes", -1))
-        model_count = int(consensus_rule.get("model_count", len(models)))
-    except (TypeError, ValueError):
-        return False, "invalid numeric proposal or evidence fields"
-    if proposal.get("decision") != evidence.get("decision"):
-        return False, "decision mismatch"
-    if proposal_target_weight != evidence_target_weight:
-        return False, "target_weight mismatch"
-    if proposal_long_vote_count != evidence_long_vote_count:
-        return False, "long_vote_count mismatch"
-    if proposal_cash_vote_count != evidence_cash_vote_count:
-        return False, "cash_vote_count mismatch"
-    long_votes = sum(1 for row in models if row.get("vote") == "long")
-    if long_votes != evidence_long_vote_count:
-        return False, "model vote tally mismatch"
-    cash_votes = len(models) - long_votes
-    if cash_votes != evidence_cash_vote_count:
-        return False, "cash vote tally mismatch"
-    if model_count != len(models):
-        return False, "consensus model_count mismatch"
-    expected_target_weight = 1.0 if long_votes >= threshold else 0.0
-    expected_decision = "long" if expected_target_weight > 0.0 else "cash"
-    if proposal.get("decision") != expected_decision:
-        return False, "consensus decision mismatch"
-    if proposal_target_weight != expected_target_weight:
-        return False, "consensus target_weight mismatch"
-    return True, ""
-
-
-class DeterministicConsensusBackend(AgentBackend):
-    provider_name = "deterministic_consensus"
-
-    def evaluate(
-        self,
-        *,
-        config: ExperimentConfig,
-        proposal: dict[str, Any],
-        evidence: dict[str, Any],
-        status: dict[str, Any] | None,
-        account_context: dict[str, Any],
-    ) -> AgentDecision:
-        is_consistent, reason = _proposal_is_consistent(proposal, evidence)
-        if not is_consistent:
-            return AgentDecision(
-                decision="reject",
-                rationale=f"Rejected because the proposal evidence is inconsistent: {reason}.",
-                provider=self.provider_name,
-                model=self.provider_name,
-            )
-
-        long_vote_count = int(evidence["long_vote_count"])
-        model_count = len(evidence["models"])
-        threshold = int(evidence["consensus_rule"]["min_long_votes"])
-        decision = str(proposal["decision"])
-        return AgentDecision(
-            decision="approve",
-            rationale=(
-                f"Approved because the proposal is internally consistent and the "
-                f"{long_vote_count}/{model_count} consensus vote satisfies the "
-                f"minimum-long-vote threshold of {threshold} for a {decision} action."
-            ),
-            provider=self.provider_name,
-            model=self.provider_name,
-        )
-
-
-def _guardrail_primary_decision(
-    *,
-    config: ExperimentConfig,
-    requested_backend: str,
-    proposal: dict[str, Any],
-    evidence: dict[str, Any],
-    status: dict[str, Any] | None,
-    account_context: dict[str, Any],
-    primary_result: AgentDecision,
-) -> AgentDecision:
-    if requested_backend == "deterministic_consensus" or primary_result.decision != "reject":
-        return primary_result
-
-    deterministic_result = DeterministicConsensusBackend().evaluate(
-        config=config,
-        proposal=proposal,
-        evidence=evidence,
-        status=status,
-        account_context=account_context,
-    )
-    if deterministic_result.decision != "approve":
-        return primary_result
-
-    return AgentDecision(
-        decision=deterministic_result.decision,
-        rationale=deterministic_result.rationale,
-        provider=deterministic_result.provider,
-        model=deterministic_result.model,
-        fallback_used=True,
-        fallback_reason=(
-            f"{requested_backend} backend returned {primary_result.decision!r}, but "
-            f"deterministic_consensus requires {deterministic_result.decision!r} for "
-            "the persisted proposal evidence."
-        ),
-    )
-
-
-def _extract_openai_text(response: Any) -> str:
-    output_text = getattr(response, "output_text", None)
-    if isinstance(output_text, str) and output_text.strip():
-        return output_text
-
-    parts: list[str] = []
-    for output in getattr(response, "output", []) or []:
-        if getattr(output, "type", None) != "message":
-            continue
-        for item in getattr(output, "content", []) or []:
-            item_type = getattr(item, "type", None)
-            if item_type == "refusal":
-                raise AgentDecisionError(f"OpenAI refusal: {getattr(item, 'refusal', '')}")
-            text_value = getattr(item, "text", None)
-            if isinstance(text_value, str) and text_value.strip():
-                parts.append(text_value)
-    if parts:
-        return "".join(parts)
-    raise AgentDecisionError("OpenAI returned no parseable text output.")
-
-
-class OpenAIAgentBackend(AgentBackend):
-    provider_name = "openai"
-
-    def evaluate(
-        self,
-        *,
-        config: ExperimentConfig,
-        proposal: dict[str, Any],
-        evidence: dict[str, Any],
-        status: dict[str, Any] | None,
-        account_context: dict[str, Any],
-    ) -> AgentDecision:
-        load_env_file()
-        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-        if api_key == "":
-            raise AgentDecisionError("OPENAI_API_KEY is not configured.")
-
-        try:
-            from openai import OpenAI
-        except ImportError as exc:
-            raise AgentDecisionError("The openai package is required for paper.agent_backend='openai'.") from exc
-
-        client = OpenAI(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
-        response = client.responses.create(
-            model=config.paper.agent_model,
-            input=[
-                {"role": "system", "content": _approval_policy_prompt()},
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        {
-                            "proposal": proposal,
-                            "evidence": evidence,
-                            "latest_status": status,
-                            "account_context": account_context,
-                        },
-                        sort_keys=True,
-                    ),
-                },
-            ],
-            text={
-                "format": {
-                    "type": "json_schema",
-                    "name": "paper_agent_decision",
-                    "strict": True,
-                    "schema": _decision_schema(),
-                }
-            },
-        )
-        output_text = _extract_openai_text(response)
-        return _coerce_agent_decision(
-            json.loads(output_text),
-            provider=self.provider_name,
-            model=config.paper.agent_model,
-        )
-
-
-class ClaudeAgentBackend(AgentBackend):
-    provider_name = "claude"
-
-    def evaluate(
-        self,
-        *,
-        config: ExperimentConfig,
-        proposal: dict[str, Any],
-        evidence: dict[str, Any],
-        status: dict[str, Any] | None,
-        account_context: dict[str, Any],
-    ) -> AgentDecision:
-        load_env_file()
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-        if api_key == "":
-            raise AgentDecisionError("ANTHROPIC_API_KEY is not configured.")
-
-        try:
-            from anthropic import Anthropic
-        except ImportError as exc:
-            raise AgentDecisionError("The anthropic package is required for paper.agent_backend='claude'.") from exc
-
-        client = Anthropic(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
-        response = client.messages.create(
-            model=config.paper.agent_model,
-            max_tokens=256,
-            system=_approval_policy_prompt(),
-            messages=[
-                {
-                    "role": "user",
-                    "content": json.dumps(
-                        {
-                            "proposal": proposal,
-                            "evidence": evidence,
-                            "latest_status": status,
-                            "account_context": account_context,
-                        },
-                        sort_keys=True,
-                    ),
-                }
-            ],
-            output_config={
-                "format": {
-                    "type": "json_schema",
-                    "schema": _decision_schema(),
-                }
-            },
-        )
-        content = getattr(response, "content", []) or []
-        if not content:
-            raise AgentDecisionError("Claude returned no content.")
-        first_item = content[0]
-        text = getattr(first_item, "text", None)
-        if not isinstance(text, str) or not text.strip():
-            raise AgentDecisionError("Claude returned no structured JSON text.")
-        return _coerce_agent_decision(
-            json.loads(text),
-            provider=self.provider_name,
-            model=config.paper.agent_model,
-        )
-
-
-def _build_backend(config: ExperimentConfig, backend_name: str) -> AgentBackend:
-    if backend_name == "deterministic_consensus":
-        return DeterministicConsensusBackend()
-    if backend_name == "openai":
-        return OpenAIAgentBackend()
-    if backend_name == "claude":
-        return ClaudeAgentBackend()
-    raise AgentDecisionError(f"Unsupported paper agent backend: {backend_name}")
-
-
-def _evaluate_with_fallback(
-    config: ExperimentConfig,
-    *,
-    proposal: dict[str, Any],
-    evidence: dict[str, Any],
-    status: dict[str, Any] | None,
-    account_context: dict[str, Any],
-) -> AgentDecision:
-    requested_backend = config.paper.agent_backend
-    primary = _build_backend(config, requested_backend)
-    try:
-        primary_result = primary.evaluate(
-            config=config,
-            proposal=proposal,
-            evidence=evidence,
-            status=status,
-            account_context=account_context,
-        )
-        return _guardrail_primary_decision(
-            config=config,
-            requested_backend=requested_backend,
-            proposal=proposal,
-            evidence=evidence,
-            status=status,
-            account_context=account_context,
-            primary_result=primary_result,
-        )
-    except Exception as exc:
-        fallback_backend_name = config.paper.agent_fallback_backend
-        if fallback_backend_name == requested_backend:
-            raise
-        fallback = _build_backend(config, fallback_backend_name)
-        fallback_result = fallback.evaluate(
-            config=config,
-            proposal=proposal,
-            evidence=evidence,
-            status=status,
-            account_context=account_context,
-        )
-        return AgentDecision(
-            decision=fallback_result.decision,
-            rationale=fallback_result.rationale,
-            provider=fallback_result.provider,
-            model=fallback_result.model,
-            fallback_used=True,
-            fallback_reason=f"{requested_backend} backend failed: {exc}",
-        )
 
 
 def _current_account_context(
@@ -536,12 +128,7 @@ def _current_account_context(
     broker: PaperBroker | None = None,
 ) -> dict[str, Any]:
     symbol = str(config.data.symbols[0])
-    if broker is None:
-        from marketlab.paper.alpaca import AlpacaPaperBrokerClient
-
-        client: PaperBroker = AlpacaPaperBrokerClient()
-    else:
-        client = broker
+    client = broker if broker is not None else _paper_broker_factory(config)()
     account = client.get_account()
     position = client.get_position(symbol)
     return {
@@ -555,7 +142,8 @@ def run_agent_approval_iteration(
     *,
     now: datetime | None = None,
     broker: PaperBroker | None = None,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
+    approval_client: PaperApprovalClient | None = None,
 ) -> dict[str, Any]:
     validate_paper_trading_config(config)
     state = _load_worker_state(config)
@@ -586,11 +174,8 @@ def run_agent_approval_iteration(
         ),
     )
     current_status = store.read_status()
-    account_context = (
-        _current_account_context(config, broker=broker)
-        if proposals
-        else {}
-    )
+    account_context = _current_account_context(config, broker=broker) if proposals else {}
+    client = approval_client or _paper_approval_client(config)
 
     for proposal in proposals:
         try:
@@ -607,7 +192,7 @@ def run_agent_approval_iteration(
                 ),
                 fallback_reason=str(exc),
                 now=now,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
             )
             approval_result = PaperApprovalResult.from_legacy(result)
             events.append(
@@ -623,12 +208,13 @@ def run_agent_approval_iteration(
             )
             continue
         try:
-            decision = _evaluate_with_fallback(
-                config,
-                proposal=proposal,
-                evidence=evidence,
-                status=current_status,
-                account_context=account_context,
+            decision = client.evaluate(
+                PaperApprovalEvaluationRequest(
+                    proposal=proposal,
+                    evidence=evidence,
+                    status=current_status,
+                    account_context=account_context,
+                )
             )
             result = decide_paper_proposal(
                 config,
@@ -641,7 +227,7 @@ def run_agent_approval_iteration(
                 fallback_used=decision.fallback_used,
                 fallback_reason=decision.fallback_reason,
                 now=now,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
             )
             approval_result = PaperApprovalResult.from_legacy(result)
         except Exception as exc:
@@ -680,14 +266,16 @@ def run_agent_approval_loop(
     config: ExperimentConfig,
     *,
     once: bool = False,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
+    approval_client: PaperApprovalClient | None = None,
 ) -> None:
     while True:
         loop_error: Exception | None = None
         try:
             summary = run_agent_approval_iteration(
                 config,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
+                approval_client=approval_client,
             )
         except Exception as exc:
             loop_error = exc
@@ -696,7 +284,7 @@ def run_agent_approval_loop(
                 config,
                 state=state,
                 exc=exc,
-                transport=notification_transport,
+                notification_sink=notification_sink,
             )
             state_path = _save_worker_state(config, state)
             summary = {

--- a/src/marketlab/paper/approval_clients.py
+++ b/src/marketlab/paper/approval_clients.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from marketlab.config import ExperimentConfig
+from marketlab.env import load_env_file
+from marketlab.paper.contracts import (
+    PaperApprovalClient,
+    PaperApprovalClientDecision,
+    PaperApprovalEvaluationRequest,
+)
+
+
+class PaperApprovalClientError(RuntimeError):
+    pass
+
+
+class _Backend:
+    provider_name = "base"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision:
+        raise NotImplementedError
+
+
+def _decision_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "decision": {
+                "type": "string",
+                "enum": ["approve", "reject"],
+            },
+            "rationale": {
+                "type": "string",
+            },
+        },
+        "required": ["decision", "rationale"],
+        "additionalProperties": False,
+    }
+
+
+def _approval_policy_prompt() -> str:
+    return (
+        "Review the attached paper-trading proposal evidence and decide whether to "
+        "approve or reject the existing proposal. You may only approve or reject the "
+        "proposal as written. The consensus rule has already been applied by the system. "
+        "If the persisted proposal and evidence are internally consistent for the same "
+        "trade, approve it. Reject only when the persisted proposal or evidence is "
+        "malformed, inconsistent, or refers to a different trade. Do not invent a "
+        "different trade, symbol, quantity, side, target weight, threshold, or date. "
+        "Return only the required structured output."
+    )
+
+
+def _coerce_agent_decision(
+    payload: Any,
+    *,
+    provider: str,
+    model: str,
+) -> PaperApprovalClientDecision:
+    if not isinstance(payload, dict):
+        raise PaperApprovalClientError(f"{provider} returned a non-object structured response.")
+    decision = str(payload.get("decision", "")).strip().lower()
+    rationale = str(payload.get("rationale", "")).strip()
+    if decision not in {"approve", "reject"}:
+        raise PaperApprovalClientError(f"{provider} returned an invalid decision: {decision!r}")
+    if rationale == "":
+        raise PaperApprovalClientError(f"{provider} returned an empty rationale.")
+    return PaperApprovalClientDecision(
+        decision=decision,
+        rationale=rationale,
+        provider=provider,
+        model=model,
+    )
+
+
+def _proposal_is_consistent(
+    proposal: Mapping[str, Any],
+    evidence: Mapping[str, Any],
+) -> tuple[bool, str]:
+    if proposal.get("proposal_id") != evidence.get("proposal_id"):
+        return False, "proposal_id mismatch"
+    if proposal.get("symbol") != evidence.get("symbol"):
+        return False, "symbol mismatch"
+    if proposal.get("effective_date") != evidence.get("effective_date"):
+        return False, "effective_date mismatch"
+    if proposal.get("decision_policy") != "consensus_vote":
+        return False, "unsupported decision policy"
+    models = evidence.get("models", [])
+    if not isinstance(models, list) or len(models) == 0:
+        return False, "missing model evidence"
+    consensus_rule = evidence.get("consensus_rule")
+    if not isinstance(consensus_rule, dict):
+        return False, "missing consensus rule"
+    try:
+        proposal_target_weight = float(proposal.get("target_weight", 0.0))
+        evidence_target_weight = float(evidence.get("target_weight", 0.0))
+        proposal_long_vote_count = int(proposal.get("long_vote_count", -1))
+        evidence_long_vote_count = int(evidence.get("long_vote_count", -2))
+        proposal_cash_vote_count = int(proposal.get("cash_vote_count", -1))
+        evidence_cash_vote_count = int(evidence.get("cash_vote_count", -2))
+        threshold = int(consensus_rule.get("min_long_votes", -1))
+        model_count = int(consensus_rule.get("model_count", len(models)))
+    except (TypeError, ValueError):
+        return False, "invalid numeric proposal or evidence fields"
+    if proposal.get("decision") != evidence.get("decision"):
+        return False, "decision mismatch"
+    if proposal_target_weight != evidence_target_weight:
+        return False, "target_weight mismatch"
+    if proposal_long_vote_count != evidence_long_vote_count:
+        return False, "long_vote_count mismatch"
+    if proposal_cash_vote_count != evidence_cash_vote_count:
+        return False, "cash_vote_count mismatch"
+    long_votes = sum(1 for row in models if row.get("vote") == "long")
+    if long_votes != evidence_long_vote_count:
+        return False, "model vote tally mismatch"
+    cash_votes = len(models) - long_votes
+    if cash_votes != evidence_cash_vote_count:
+        return False, "cash vote tally mismatch"
+    if model_count != len(models):
+        return False, "consensus model_count mismatch"
+    expected_target_weight = 1.0 if long_votes >= threshold else 0.0
+    expected_decision = "long" if expected_target_weight > 0.0 else "cash"
+    if proposal.get("decision") != expected_decision:
+        return False, "consensus decision mismatch"
+    if proposal_target_weight != expected_target_weight:
+        return False, "consensus target_weight mismatch"
+    return True, ""
+
+
+class _DeterministicConsensusBackend(_Backend):
+    provider_name = "deterministic_consensus"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision:
+        is_consistent, reason = _proposal_is_consistent(request.proposal, request.evidence)
+        if not is_consistent:
+            return PaperApprovalClientDecision(
+                decision="reject",
+                rationale=f"Rejected because the proposal evidence is inconsistent: {reason}.",
+                provider=self.provider_name,
+                model=self.provider_name,
+            )
+
+        long_vote_count = int(request.evidence["long_vote_count"])
+        model_count = len(request.evidence["models"])
+        threshold = int(request.evidence["consensus_rule"]["min_long_votes"])
+        decision = str(request.proposal["decision"])
+        return PaperApprovalClientDecision(
+            decision="approve",
+            rationale=(
+                f"Approved because the proposal is internally consistent and the "
+                f"{long_vote_count}/{model_count} consensus vote satisfies the "
+                f"minimum-long-vote threshold of {threshold} for a {decision} action."
+            ),
+            provider=self.provider_name,
+            model=self.provider_name,
+        )
+
+
+def _guardrail_primary_decision(
+    *,
+    config: ExperimentConfig,
+    requested_backend: str,
+    request: PaperApprovalEvaluationRequest,
+    primary_result: PaperApprovalClientDecision,
+) -> PaperApprovalClientDecision:
+    if requested_backend == "deterministic_consensus" or primary_result.decision != "reject":
+        return primary_result
+
+    deterministic_result = _DeterministicConsensusBackend().evaluate(
+        config=config,
+        request=request,
+    )
+    if deterministic_result.decision != "approve":
+        return primary_result
+
+    return PaperApprovalClientDecision(
+        decision=deterministic_result.decision,
+        rationale=deterministic_result.rationale,
+        provider=deterministic_result.provider,
+        model=deterministic_result.model,
+        fallback_used=True,
+        fallback_reason=(
+            f"{requested_backend} backend returned {primary_result.decision!r}, but "
+            f"deterministic_consensus requires {deterministic_result.decision!r} for "
+            "the persisted proposal evidence."
+        ),
+    )
+
+
+def _extract_openai_text(response: Any) -> str:
+    output_text = getattr(response, "output_text", None)
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+
+    parts: list[str] = []
+    for output in getattr(response, "output", []) or []:
+        if getattr(output, "type", None) != "message":
+            continue
+        for item in getattr(output, "content", []) or []:
+            item_type = getattr(item, "type", None)
+            if item_type == "refusal":
+                raise PaperApprovalClientError(f"OpenAI refusal: {getattr(item, 'refusal', '')}")
+            text_value = getattr(item, "text", None)
+            if isinstance(text_value, str) and text_value.strip():
+                parts.append(text_value)
+    if parts:
+        return "".join(parts)
+    raise PaperApprovalClientError("OpenAI returned no parseable text output.")
+
+
+class _OpenAIAgentBackend(_Backend):
+    provider_name = "openai"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision:
+        load_env_file()
+        api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if api_key == "":
+            raise PaperApprovalClientError("OPENAI_API_KEY is not configured.")
+
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise PaperApprovalClientError(
+                "The openai package is required for paper.agent_backend='openai'."
+            ) from exc
+
+        client = OpenAI(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
+        response = client.responses.create(
+            model=config.paper.agent_model,
+            input=[
+                {"role": "system", "content": _approval_policy_prompt()},
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "proposal": dict(request.proposal),
+                            "evidence": dict(request.evidence),
+                            "latest_status": dict(request.status or {}),
+                            "account_context": dict(request.account_context),
+                        },
+                        sort_keys=True,
+                    ),
+                },
+            ],
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "paper_agent_decision",
+                    "strict": True,
+                    "schema": _decision_schema(),
+                }
+            },
+        )
+        output_text = _extract_openai_text(response)
+        return _coerce_agent_decision(
+            json.loads(output_text),
+            provider=self.provider_name,
+            model=config.paper.agent_model,
+        )
+
+
+class _ClaudeAgentBackend(_Backend):
+    provider_name = "claude"
+
+    def evaluate(
+        self,
+        *,
+        config: ExperimentConfig,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision:
+        load_env_file()
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+        if api_key == "":
+            raise PaperApprovalClientError("ANTHROPIC_API_KEY is not configured.")
+
+        try:
+            from anthropic import Anthropic
+        except ImportError as exc:
+            raise PaperApprovalClientError(
+                "The anthropic package is required for paper.agent_backend='claude'."
+            ) from exc
+
+        client = Anthropic(api_key=api_key, timeout=config.paper.agent_timeout_seconds)
+        response = client.messages.create(
+            model=config.paper.agent_model,
+            max_tokens=256,
+            system=_approval_policy_prompt(),
+            messages=[
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "proposal": dict(request.proposal),
+                            "evidence": dict(request.evidence),
+                            "latest_status": dict(request.status or {}),
+                            "account_context": dict(request.account_context),
+                        },
+                        sort_keys=True,
+                    ),
+                }
+            ],
+            output_config={
+                "format": {
+                    "type": "json_schema",
+                    "schema": _decision_schema(),
+                }
+            },
+        )
+        content = getattr(response, "content", []) or []
+        if not content:
+            raise PaperApprovalClientError("Claude returned no content.")
+        first_item = content[0]
+        text = getattr(first_item, "text", None)
+        if not isinstance(text, str) or not text.strip():
+            raise PaperApprovalClientError("Claude returned no structured JSON text.")
+        return _coerce_agent_decision(
+            json.loads(text),
+            provider=self.provider_name,
+            model=config.paper.agent_model,
+        )
+
+
+def _build_backend(backend_name: str) -> _Backend:
+    if backend_name == "deterministic_consensus":
+        return _DeterministicConsensusBackend()
+    if backend_name == "openai":
+        return _OpenAIAgentBackend()
+    if backend_name == "claude":
+        return _ClaudeAgentBackend()
+    raise PaperApprovalClientError(f"Unsupported paper agent backend: {backend_name}")
+
+
+class _ConfiguredPaperApprovalClient(PaperApprovalClient):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._config = config
+
+    def evaluate(self, request: PaperApprovalEvaluationRequest) -> PaperApprovalClientDecision:
+        requested_backend = self._config.paper.agent_backend
+        primary = _build_backend(requested_backend)
+        try:
+            primary_result = primary.evaluate(config=self._config, request=request)
+            return _guardrail_primary_decision(
+                config=self._config,
+                requested_backend=requested_backend,
+                request=request,
+                primary_result=primary_result,
+            )
+        except Exception as exc:
+            fallback_backend_name = self._config.paper.agent_fallback_backend
+            if fallback_backend_name == requested_backend:
+                raise
+            fallback = _build_backend(fallback_backend_name)
+            fallback_result = fallback.evaluate(config=self._config, request=request)
+            return PaperApprovalClientDecision(
+                decision=fallback_result.decision,
+                rationale=fallback_result.rationale,
+                provider=fallback_result.provider,
+                model=fallback_result.model,
+                fallback_used=True,
+                fallback_reason=f"{requested_backend} backend failed: {exc}",
+            )
+
+
+def build_default_paper_approval_client(
+    config: ExperimentConfig,
+) -> PaperApprovalClient:
+    return _ConfiguredPaperApprovalClient(config)

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
@@ -7,8 +8,6 @@ from typing import Any, runtime_checkable
 
 import pandas as pd
 from typing_extensions import Protocol
-
-from marketlab.paper.notifications import TelegramTransport
 
 
 def _string_field(payload: dict[str, Any], key: str) -> str:
@@ -181,7 +180,6 @@ class PaperDecisionRequest:
     now: datetime | None = None
     provider: PaperHistoryProvider | None = None
     broker: PaperBroker | None = None
-    notification_transport: TelegramTransport | None = None
 
 
 @dataclass(slots=True, frozen=True)
@@ -195,14 +193,12 @@ class PaperApprovalRequest:
     fallback_used: bool = False
     fallback_reason: str | None = None
     now: datetime | None = None
-    notification_transport: TelegramTransport | None = None
 
 
 @dataclass(slots=True, frozen=True)
 class PaperSubmissionRequest:
     now: datetime | None = None
     broker: PaperBroker | None = None
-    notification_transport: TelegramTransport | None = None
     retry_failed_submission: bool = False
 
 
@@ -210,6 +206,83 @@ class PaperSubmissionRequest:
 class PaperReconciliationRequest:
     now: datetime | None = None
     broker: PaperBroker | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class PaperApprovalEvaluationRequest:
+    proposal: Mapping[str, Any]
+    evidence: Mapping[str, Any]
+    status: Mapping[str, Any] | None = None
+    account_context: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True, frozen=True)
+class PaperApprovalClientDecision:
+    decision: str
+    rationale: str
+    provider: str
+    model: str
+    fallback_used: bool = False
+    fallback_reason: str = ""
+
+
+@runtime_checkable
+class PaperApprovalClient(Protocol):
+    def evaluate(
+        self,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision: ...
+
+
+@runtime_checkable
+class PaperApprovalClientFactory(Protocol):
+    def __call__(self) -> PaperApprovalClient: ...
+
+
+@runtime_checkable
+class PaperNotificationSink(Protocol):
+    def notify_decision(
+        self,
+        *,
+        outcome: str,
+        status: Mapping[str, Any],
+        proposal: Mapping[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> Path: ...
+
+    def notify_approval(
+        self,
+        *,
+        proposal: Mapping[str, Any],
+        approval_record: Mapping[str, Any],
+        now: datetime | None = None,
+    ) -> Path: ...
+
+    def notify_submission(
+        self,
+        *,
+        outcome: str,
+        status: Mapping[str, Any],
+        proposal: Mapping[str, Any] | None = None,
+        submission: Mapping[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> Path: ...
+
+    def notify_error(
+        self,
+        *,
+        loop_name: str,
+        stage: str,
+        exc: Exception,
+        proposal_id: str = "",
+        trade_date: str = "",
+        now: datetime | None = None,
+    ) -> Path: ...
+
+
+@runtime_checkable
+class PaperNotificationSinkFactory(Protocol):
+    def __call__(self) -> PaperNotificationSink: ...
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -11,6 +11,7 @@ from urllib import error, request
 
 from marketlab.config import ExperimentConfig
 from marketlab.env import load_env_file
+from marketlab.paper.contracts import PaperNotificationSink
 from marketlab.paper.state import PaperStateStore
 
 TELEGRAM_API_BASE_URL_ENV = "MARKETLAB_TELEGRAM_API_BASE_URL"
@@ -337,6 +338,120 @@ def write_notification_record(
         payload=record,
         now=now,
     )
+
+
+class TelegramPaperNotificationSink(PaperNotificationSink):
+    def __init__(
+        self,
+        config: ExperimentConfig,
+        *,
+        transport: TelegramTransport | None = None,
+    ) -> None:
+        self._config = config
+        self._transport = transport
+
+    def _store(self) -> PaperStateStore:
+        return PaperStateStore(self._config)
+
+    def notify_decision(
+        self,
+        *,
+        outcome: str,
+        status: Mapping[str, Any],
+        proposal: Mapping[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> Path:
+        return notify_paper_decision(
+            self._config,
+            self._store(),
+            outcome=outcome,
+            status=status,
+            proposal=proposal,
+            now=now,
+            transport=self._transport,
+        )
+
+    def notify_approval(
+        self,
+        *,
+        proposal: Mapping[str, Any],
+        approval_record: Mapping[str, Any],
+        now: datetime | None = None,
+    ) -> Path:
+        return notify_paper_approval(
+            self._config,
+            self._store(),
+            proposal=proposal,
+            approval_record=approval_record,
+            now=now,
+            transport=self._transport,
+        )
+
+    def notify_submission(
+        self,
+        *,
+        outcome: str,
+        status: Mapping[str, Any],
+        proposal: Mapping[str, Any] | None = None,
+        submission: Mapping[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> Path:
+        return notify_paper_submission(
+            self._config,
+            self._store(),
+            outcome=outcome,
+            status=status,
+            proposal=proposal,
+            submission=submission,
+            now=now,
+            transport=self._transport,
+        )
+
+    def notify_error(
+        self,
+        *,
+        loop_name: str,
+        stage: str,
+        exc: Exception,
+        proposal_id: str = "",
+        trade_date: str = "",
+        now: datetime | None = None,
+    ) -> Path:
+        return write_notification_record(
+            self._config,
+            self._store(),
+            stage="paper-error",
+            outcome="error",
+            message=build_error_message(
+                self._config,
+                loop_name=loop_name,
+                stage=stage,
+                exc=exc,
+                proposal_id=proposal_id,
+                trade_date=trade_date,
+            ),
+            details={
+                "experiment_name": self._config.experiment_name,
+                "loop": loop_name,
+                "failed_stage": stage,
+                "proposal_id": proposal_id,
+                "trade_date": trade_date,
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+            },
+            proposal_id=proposal_id,
+            trade_date=trade_date,
+            now=now,
+            transport=self._transport,
+        )
+
+
+def build_telegram_paper_notification_sink(
+    config: ExperimentConfig,
+    *,
+    transport: TelegramTransport | None = None,
+) -> PaperNotificationSink:
+    return TelegramPaperNotificationSink(config, transport=transport)
 
 
 def notify_paper_decision(

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -9,21 +9,20 @@ from typing import Any
 from marketlab.config import ExperimentConfig
 from marketlab.paper.contracts import (
     PaperDecisionResult,
+    PaperNotificationSink,
     PaperReconciliationResult,
     PaperSubmissionResult,
 )
 from marketlab.paper.notifications import (
     PaperLoopStageError,
-    TelegramTransport,
     build_error_fingerprint,
-    build_error_message,
+    build_telegram_paper_notification_sink,
 )
 from marketlab.paper.service import (
     PaperStateStore,
     _clock_value,
     _local_now,
     _now_utc,
-    _write_notification_record,
     reconcile_latest_submission_status,
     run_paper_decision,
     run_paper_submit,
@@ -61,13 +60,17 @@ def _clear_scheduler_error_state(state: dict[str, Any]) -> None:
         state.pop(key, None)
 
 
+def _paper_notification_sink(config: ExperimentConfig) -> PaperNotificationSink:
+    return build_telegram_paper_notification_sink(config)
+
+
 def _notify_scheduler_error(
     config: ExperimentConfig,
     *,
     state: dict[str, Any],
     exc: Exception,
     now: datetime | None = None,
-    transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> Path | None:
     if isinstance(exc, PaperLoopStageError):
         stage = exc.stage
@@ -98,33 +101,14 @@ def _notify_scheduler_error(
     state["last_error_proposal_id"] = proposal_id
     state["last_error_trade_date"] = trade_date
     state["last_error_alert_at"] = _now_utc(now).isoformat()
-    store = PaperStateStore(config)
-    return _write_notification_record(
-        config,
-        store,
-        stage="paper-error",
-        outcome="error",
-        message=build_error_message(
-            config,
-            loop_name="scheduler",
-            stage=stage,
-            exc=root_error,
-            proposal_id=proposal_id,
-            trade_date=trade_date,
-        ),
-        details={
-            "experiment_name": config.experiment_name,
-            "loop": "scheduler",
-            "failed_stage": stage,
-            "proposal_id": proposal_id,
-            "trade_date": trade_date,
-            "exception_type": type(root_error).__name__,
-            "exception_message": str(root_error),
-        },
+    sink = notification_sink or _paper_notification_sink(config)
+    return sink.notify_error(
+        loop_name="scheduler",
+        stage=stage,
+        exc=root_error,
         proposal_id=proposal_id,
         trade_date=trade_date,
         now=now,
-        transport=transport,
     )
 
 
@@ -132,7 +116,7 @@ def run_scheduler_iteration(
     config: ExperimentConfig,
     *,
     now: datetime | None = None,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> dict[str, Any]:
     local_now = _local_now(config, now)
     market_date = local_now.date().isoformat()
@@ -146,7 +130,7 @@ def run_scheduler_iteration(
             result = run_paper_decision(
                 config,
                 now=now,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
             )
             decision_result = PaperDecisionResult.from_legacy(result)
         except Exception as exc:
@@ -164,7 +148,7 @@ def run_scheduler_iteration(
             result = run_paper_submit(
                 config,
                 now=now,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
             )
             submission_result = PaperSubmissionResult.from_legacy(result)
         except Exception as exc:
@@ -210,14 +194,14 @@ def run_scheduler_loop(
     config: ExperimentConfig,
     *,
     once: bool = False,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> None:
     while True:
         loop_error: Exception | None = None
         try:
             summary = run_scheduler_iteration(
                 config,
-                notification_transport=notification_transport,
+                notification_sink=notification_sink,
             )
         except Exception as exc:
             loop_error = exc
@@ -226,7 +210,7 @@ def run_scheduler_loop(
                 config,
                 state=state,
                 exc=exc,
-                transport=notification_transport,
+                notification_sink=notification_sink,
             )
             state_path = _save_scheduler_state(config, state)
             summary = {

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -19,6 +19,7 @@ from marketlab.paper.contracts import (
     PaperDecisionRequest,
     PaperHistoryProvider,
     PaperHistoryProviderFactory,
+    PaperNotificationSink,
     PaperReconciliationRequest,
     PaperSubmissionRequest,
     PaperUnitOfWorkFactory,
@@ -44,13 +45,7 @@ from marketlab.paper.core import (
 from marketlab.paper.core import (
     validate_paper_trading_config,
 )
-from marketlab.paper.notifications import (
-    TelegramTransport,
-    notify_paper_approval,
-    notify_paper_decision,
-    notify_paper_submission,
-    write_notification_record,
-)
+from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.persistence import (
     build_filesystem_paper_artifact_store,
     build_filesystem_paper_uow_factory,
@@ -63,7 +58,6 @@ _clock_value = _core_clock_value
 _local_now = _core_local_now
 _now_utc = _core_now_utc
 _paper_symbol = _core_paper_symbol
-_write_notification_record = write_notification_record
 
 
 def _paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
@@ -86,6 +80,14 @@ def _paper_artifact_store(config: ExperimentConfig) -> PaperArtifactStore:
     return build_filesystem_paper_artifact_store(config)
 
 
+def _paper_notification_sink(config: ExperimentConfig) -> PaperNotificationSink:
+    return build_telegram_paper_notification_sink(config)
+
+
+def _paper_state_store(config: ExperimentConfig) -> PaperStateStore:
+    return PaperStateStore(config)
+
+
 def _decision_notification_outcome(status: dict[str, Any]) -> str:
     outcome = str(status.get("status", ""))
     if outcome == SUBMISSION_SKIPPED:
@@ -101,7 +103,7 @@ def run_paper_decision(
     now: datetime | None = None,
     provider: PaperHistoryProvider | None = None,
     broker: PaperBroker | None = None,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> dict[str, Any]:
     result = DecisionService(
         config,
@@ -113,17 +115,14 @@ def run_paper_decision(
             now=now,
             provider=provider,
             broker=broker,
-            notification_transport=notification_transport,
         )
     )
-    notify_paper_decision(
-        config,
-        PaperStateStore(config),
+    sink = notification_sink or _paper_notification_sink(config)
+    sink.notify_decision(
         outcome=_decision_notification_outcome(result.status),
         status=result.status,
         proposal=result.proposal,
         now=now,
-        transport=notification_transport,
     )
     return result.as_legacy_payload()
 
@@ -175,7 +174,7 @@ def decide_paper_proposal(
     fallback_used: bool = False,
     fallback_reason: str | None = None,
     now: datetime | None = None,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
 ) -> dict[str, Any]:
     result = ApprovalService(config, uow_factory=_paper_uow_factory(config)).run(
         PaperApprovalRequest(
@@ -188,17 +187,14 @@ def decide_paper_proposal(
             fallback_used=fallback_used,
             fallback_reason=fallback_reason,
             now=now,
-            notification_transport=notification_transport,
         )
     )
     if result.proposal is not None and result.approval is not None:
-        notify_paper_approval(
-            config,
-            PaperStateStore(config),
+        sink = notification_sink or _paper_notification_sink(config)
+        sink.notify_approval(
             proposal=result.proposal,
             approval_record=result.approval,
             now=now,
-            transport=notification_transport,
         )
     return result.as_legacy_payload()
 
@@ -229,7 +225,7 @@ def run_paper_submit(
     *,
     now: datetime | None = None,
     broker: PaperBroker | None = None,
-    notification_transport: TelegramTransport | None = None,
+    notification_sink: PaperNotificationSink | None = None,
     retry_failed_submission: bool = False,
 ) -> dict[str, Any]:
     result = SubmissionService(
@@ -241,19 +237,16 @@ def run_paper_submit(
         PaperSubmissionRequest(
             now=now,
             broker=broker,
-            notification_transport=notification_transport,
             retry_failed_submission=retry_failed_submission,
         )
     )
-    notify_paper_submission(
-        config,
-        PaperStateStore(config),
+    sink = notification_sink or _paper_notification_sink(config)
+    sink.notify_submission(
         outcome=str(result.status.get("status", "")),
         status=result.status,
         proposal=result.proposal,
         submission=result.submission,
         now=now,
-        transport=notification_transport,
     )
     legacy = result.as_legacy_payload()
     legacy.pop("proposal_id", None)

--- a/tests/_paper_fakes.py
+++ b/tests/_paper_fakes.py
@@ -21,6 +21,10 @@ from marketlab.config import (
     TelegramNotificationsConfig,
     WalkForwardConfig,
 )
+from marketlab.paper.contracts import (
+    PaperApprovalClientDecision,
+    PaperApprovalEvaluationRequest,
+)
 
 
 def build_paper_history_frame(
@@ -250,6 +254,116 @@ class FakeAlpacaBroker:
             "status": self.order_status,
             "client_order_id": self.submitted_orders[-1]["client_order_id"],
         }
+
+
+class FakePaperNotificationSink:
+    def __init__(self) -> None:
+        self.decision_calls: list[dict[str, object]] = []
+        self.approval_calls: list[dict[str, object]] = []
+        self.submission_calls: list[dict[str, object]] = []
+        self.error_calls: list[dict[str, object]] = []
+
+    def notify_decision(
+        self,
+        *,
+        outcome: str,
+        status: dict[str, object],
+        proposal: dict[str, object] | None = None,
+        now=None,
+    ) -> Path:
+        self.decision_calls.append(
+            {
+                "outcome": outcome,
+                "status": dict(status),
+                "proposal": dict(proposal) if proposal is not None else None,
+                "now": now,
+            }
+        )
+        return Path("fake-paper-decision.json")
+
+    def notify_approval(
+        self,
+        *,
+        proposal: dict[str, object],
+        approval_record: dict[str, object],
+        now=None,
+    ) -> Path:
+        self.approval_calls.append(
+            {
+                "proposal": dict(proposal),
+                "approval_record": dict(approval_record),
+                "now": now,
+            }
+        )
+        return Path("fake-paper-approval.json")
+
+    def notify_submission(
+        self,
+        *,
+        outcome: str,
+        status: dict[str, object],
+        proposal: dict[str, object] | None = None,
+        submission: dict[str, object] | None = None,
+        now=None,
+    ) -> Path:
+        self.submission_calls.append(
+            {
+                "outcome": outcome,
+                "status": dict(status),
+                "proposal": dict(proposal) if proposal is not None else None,
+                "submission": dict(submission) if submission is not None else None,
+                "now": now,
+            }
+        )
+        return Path("fake-paper-submission.json")
+
+    def notify_error(
+        self,
+        *,
+        loop_name: str,
+        stage: str,
+        exc: Exception,
+        proposal_id: str = "",
+        trade_date: str = "",
+        now=None,
+    ) -> Path:
+        self.error_calls.append(
+            {
+                "loop_name": loop_name,
+                "stage": stage,
+                "exc": exc,
+                "proposal_id": proposal_id,
+                "trade_date": trade_date,
+                "now": now,
+            }
+        )
+        return Path("fake-paper-error.json")
+
+
+class FakePaperApprovalClient:
+    def __init__(
+        self,
+        *,
+        decision: PaperApprovalClientDecision | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._decision = decision or PaperApprovalClientDecision(
+            decision="approve",
+            rationale="Approved by fake client.",
+            provider="fake",
+            model="fake-model",
+        )
+        self._error = error
+        self.requests: list[PaperApprovalEvaluationRequest] = []
+
+    def evaluate(
+        self,
+        request: PaperApprovalEvaluationRequest,
+    ) -> PaperApprovalClientDecision:
+        self.requests.append(request)
+        if self._error is not None:
+            raise self._error
+        return self._decision
 
 
 def write_phase7_paper_config(

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -10,11 +10,15 @@ import pytest
 from tests._paper_fakes import (
     FakeAlpacaBroker,
     FakeAlpacaProvider,
+    FakePaperApprovalClient,
+    FakePaperNotificationSink,
     build_phase7_paper_config,
 )
 
 import marketlab.paper.agent as agent_module
 from marketlab.paper.agent import run_agent_approval_iteration, run_agent_approval_loop
+from marketlab.paper.contracts import PaperApprovalClientDecision
+from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.service import PaperStateStore, run_paper_decision
 
 
@@ -161,7 +165,10 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
         config,
         now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
         broker=FakeAlpacaBroker(symbol="VOO"),
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     proposal = PaperStateStore(config).latest_proposal()
@@ -174,6 +181,46 @@ def test_agent_worker_falls_back_to_deterministic_consensus(monkeypatch, tmp_pat
     assert "provider: deterministic_consensus" in calls[0]["payload"]["text"]
     assert "fallback_used: true" in calls[0]["payload"]["text"]
     assert "fallback_reason: openai backend failed" in calls[0]["payload"]["text"]
+
+
+def test_agent_worker_supports_injected_approval_client_and_notification_sink(
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=FakeAlpacaBroker(symbol="QQQ"),
+    )
+    approval_client = FakePaperApprovalClient(
+        decision=PaperApprovalClientDecision(
+            decision="approve",
+            rationale="Approved by injected fake client.",
+            provider="fake",
+            model="fake-model",
+            fallback_used=True,
+            fallback_reason="fake backend requested fallback metadata",
+        )
+    )
+    sink = FakePaperNotificationSink()
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="QQQ"),
+        notification_sink=sink,
+        approval_client=approval_client,
+    )
+
+    proposal = PaperStateStore(config).latest_proposal()
+    assert result["processed_count"] == 1
+    assert len(approval_client.requests) == 1
+    assert len(sink.approval_calls) == 1
+    assert proposal is not None
+    assert proposal["approval_backend"] == "fake"
+    assert proposal["approval_model"] == "fake-model"
+    assert proposal["approval_fallback_used"] is True
 
 
 def test_agent_worker_overrides_primary_rejection_when_evidence_requires_approval(
@@ -501,20 +548,29 @@ def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
         run_agent_approval_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
     with pytest.raises(RuntimeError, match="approval backend exploded"):
         run_agent_approval_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _successful_iteration)
     run_agent_approval_loop(
         config,
         once=True,
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
@@ -522,7 +578,10 @@ def test_agent_worker_loop_deduplicates_repeated_error_alerts_until_recovery(
         run_agent_approval_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     records = [
@@ -551,7 +610,10 @@ def test_agent_worker_loop_once_propagates_iteration_failures_after_notifying(
         run_agent_approval_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     records = [

--- a/tests/unit/test_paper_contracts.py
+++ b/tests/unit/test_paper_contracts.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
-from tests._paper_fakes import FakeAlpacaBroker, FakeAlpacaProvider
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    FakePaperApprovalClient,
+    FakePaperNotificationSink,
+)
 
 from marketlab.paper.contracts import (
+    PaperApprovalClient,
+    PaperApprovalClientDecision,
     PaperApprovalRequest,
     PaperApprovalResult,
     PaperBroker,
     PaperDecisionRequest,
     PaperDecisionResult,
     PaperHistoryProvider,
+    PaperNotificationSink,
     PaperReconciliationRequest,
     PaperReconciliationResult,
     PaperSubmissionRequest,
@@ -19,6 +27,8 @@ from marketlab.paper.contracts import (
 def test_paper_protocols_match_existing_fake_adapters() -> None:
     assert isinstance(FakeAlpacaProvider(), PaperHistoryProvider)
     assert isinstance(FakeAlpacaBroker(), PaperBroker)
+    assert isinstance(FakePaperNotificationSink(), PaperNotificationSink)
+    assert isinstance(FakePaperApprovalClient(), PaperApprovalClient)
 
 
 def test_paper_decision_result_round_trips_legacy_payload() -> None:
@@ -53,6 +63,23 @@ def test_paper_request_objects_preserve_phase_inputs() -> None:
     assert approval_request.fallback_used is True
     assert submission_request.retry_failed_submission is True
     assert reconciliation_request.broker is None
+
+
+def test_paper_approval_client_decision_preserves_fallback_fields() -> None:
+    decision = PaperApprovalClientDecision(
+        decision="approve",
+        rationale="Approved by contract test.",
+        provider="openai",
+        model="gpt-4o-mini",
+        fallback_used=True,
+        fallback_reason="openai backend failed: timeout",
+    )
+
+    assert decision.decision == "approve"
+    assert decision.provider == "openai"
+    assert decision.model == "gpt-4o-mini"
+    assert decision.fallback_used is True
+    assert decision.fallback_reason == "openai backend failed: timeout"
 
 
 def test_paper_approval_result_round_trips_legacy_payload() -> None:

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from tests._paper_fakes import FakeAlpacaBroker, build_phase7_paper_config
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakePaperNotificationSink,
+    build_phase7_paper_config,
+)
 
 import marketlab.paper.service as service_module
 from marketlab.paper.application import ReconciliationService
@@ -564,21 +568,21 @@ def test_submission_service_and_wrapper_keep_broker_and_notifications_outside_uo
     _seed_submission_ready_proposal(factory)
     broker = _BoundaryBroker(factory=factory)
     notification_events: list[str] = []
+    notification_sink = FakePaperNotificationSink()
 
     monkeypatch.setattr(service_module, "_paper_uow_factory", lambda _config: factory)
-
-    def _notify_submission(*args, **kwargs) -> None:
-        assert factory.active_count == 0
-        assert factory.commit_count >= 1
-        notification_events.append("notified")
-
-    monkeypatch.setattr(service_module, "notify_paper_submission", _notify_submission)
+    monkeypatch.setattr(service_module, "_paper_notification_sink", lambda _config: notification_sink)
 
     result = service_module.run_paper_submit(
         config,
         now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
         broker=broker,
     )
+
+    assert len(notification_sink.submission_calls) == 1
+    assert factory.active_count == 0
+    assert factory.commit_count >= 1
+    notification_events.append("notified")
 
     assert result["status"]["status"] == "submitted"
     assert broker.calls == [

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -5,9 +5,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-from tests._paper_fakes import build_phase7_paper_config
+from tests._paper_fakes import FakePaperNotificationSink, build_phase7_paper_config
 
 from marketlab.paper import scheduler
+from marketlab.paper.notifications import build_telegram_paper_notification_sink
 
 
 def _capture_transport(calls: list[dict[str, object]]):
@@ -65,6 +66,35 @@ def test_scheduler_iteration_runs_each_phase_once_per_market_date(
     assert events == ["decision", "submission"]
 
 
+def test_scheduler_iteration_forwards_injected_notification_sink(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path)
+    sink = FakePaperNotificationSink()
+    forwarded_sinks: list[object] = []
+
+    def _fake_decision(*args, **kwargs):
+        forwarded_sinks.append(kwargs["notification_sink"])
+        return {"proposal_path": "proposal.json", "status_path": "status.json", "status": {}}
+
+    def _fake_submit(*args, **kwargs):
+        forwarded_sinks.append(kwargs["notification_sink"])
+        return {"submission_path": "submission.json", "status_path": "status.json", "status": {}}
+
+    monkeypatch.setattr(scheduler, "run_paper_decision", _fake_decision)
+    monkeypatch.setattr(scheduler, "run_paper_submit", _fake_submit)
+    monkeypatch.setattr(scheduler, "reconcile_latest_submission_status", lambda *args, **kwargs: None)
+
+    scheduler.run_scheduler_iteration(
+        config,
+        now=datetime(2026, 4, 10, 23, 10, tzinfo=UTC),
+        notification_sink=sink,
+    )
+
+    assert forwarded_sinks == [sink, sink]
+
+
 def test_scheduler_iteration_appends_submission_reconciliation_events(
     monkeypatch,
     tmp_path: Path,
@@ -118,20 +148,29 @@ def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
         scheduler.run_scheduler_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
     with pytest.raises(RuntimeError, match="decision phase failed"):
         scheduler.run_scheduler_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     monkeypatch.setattr(scheduler, "run_scheduler_iteration", _successful_iteration)
     scheduler.run_scheduler_loop(
         config,
         once=True,
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     monkeypatch.setattr(scheduler, "run_scheduler_iteration", _failing_iteration)
@@ -139,7 +178,10 @@ def test_scheduler_loop_deduplicates_repeated_error_alerts_until_recovery(
         scheduler.run_scheduler_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     records = [
@@ -168,7 +210,10 @@ def test_scheduler_loop_once_propagates_iteration_failures_after_notifying(
         scheduler.run_scheduler_loop(
             config,
             once=True,
-            notification_transport=_capture_transport(calls),
+            notification_sink=build_telegram_paper_notification_sink(
+                config,
+                transport=_capture_transport(calls),
+            ),
         )
 
     records = [

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -8,9 +8,11 @@ import pytest
 from tests._paper_fakes import (
     FakeAlpacaBroker,
     FakeAlpacaProvider,
+    FakePaperNotificationSink,
     build_phase7_paper_config,
 )
 
+from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.service import (
     PaperStateStore,
     decide_paper_proposal,
@@ -65,7 +67,10 @@ def test_run_paper_decision_writes_latest_daily_proposal(monkeypatch, tmp_path: 
         now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
         provider=provider,
         broker=broker,
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     proposal_path = Path(result["proposal_path"])
@@ -157,7 +162,10 @@ def test_decide_paper_proposal_records_agent_approval(monkeypatch, tmp_path: Pat
         decision="approve",
         actor="agent",
         now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     approval_path = Path(decision_result["approval_path"])
@@ -194,7 +202,10 @@ def test_run_paper_submit_skips_missing_agent_approval(monkeypatch, tmp_path: Pa
         config,
         now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
         broker=FakeAlpacaBroker(symbol="VOO"),
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     submission = submission_result["submission"]
@@ -237,7 +248,10 @@ def test_run_paper_submit_places_fractional_order_after_agent_approval(monkeypat
         config,
         now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
         broker=broker,
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     submission = submission_result["submission"]
@@ -663,7 +677,10 @@ def test_run_paper_decision_notifies_existing_proposal(monkeypatch, tmp_path: Pa
         now=datetime(2026, 4, 10, 20, 11, tzinfo=UTC),
         provider=provider,
         broker=broker,
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     assert result["status"]["status"] == "existing_proposal"
@@ -721,7 +738,10 @@ def test_decide_paper_proposal_notifies_manual_rejection(monkeypatch, tmp_path: 
         actor="manual",
         rationale="Manual hold for review.",
         now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
-        notification_transport=_capture_transport(calls),
+        notification_sink=build_telegram_paper_notification_sink(
+            config,
+            transport=_capture_transport(calls),
+        ),
     )
 
     approval = json.loads(Path(decision_result["approval_path"]).read_text(encoding="utf-8"))
@@ -729,6 +749,42 @@ def test_decide_paper_proposal_notifies_manual_rejection(monkeypatch, tmp_path: 
     assert len(calls) == 1
     assert "actor: manual" in calls[0]["payload"]["text"]
     assert "outcome: rejected" in calls[0]["payload"]["text"]
+
+
+def test_service_wrappers_support_injected_notification_sink(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    provider = FakeAlpacaProvider(symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ")
+    sink = FakePaperNotificationSink()
+
+    proposal_result = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+        notification_sink=sink,
+    )
+    decide_paper_proposal(
+        config,
+        proposal_id=proposal_result["proposal_id"],
+        decision="approve",
+        actor="agent",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+        notification_sink=sink,
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+        notification_sink=sink,
+    )
+
+    assert len(sink.decision_calls) == 1
+    assert sink.decision_calls[0]["outcome"] == "proposal_created"
+    assert len(sink.approval_calls) == 1
+    assert sink.approval_calls[0]["approval_record"]["approval_status"] == "approved"
+    assert len(sink.submission_calls) == 1
+    assert sink.submission_calls[0]["outcome"] in {"submitted", "no_trade_required"}
 
 
 def test_get_paper_status_returns_latest_proposal_summary(tmp_path: Path) -> None:

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -110,12 +110,12 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
         assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
     assert parser["testenv:typecheck"]["commands"].strip() == (
         "{envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py "
-        "src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py "
-        "src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py "
-        "src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py "
-        "src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py "
-        "src/marketlab/paper/service.py src/marketlab/paper/agent.py "
-        "src/marketlab/paper/scheduler.py"
+        "src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py "
+        "src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py "
+        "src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/application/decision.py "
+        "src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py "
+        "src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py "
+        "src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py"
     )
 
     assert parser["testenv:preflight-fast"]["basepython"] == "py312"

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
## Summary
- isolate paper notifications behind a notification sink port
- isolate approval-provider logic behind a paper approval client port
- add adapter substitution coverage and include the new approval client module in the mypy gate

## Validation
- py -3.14 -m tox -e preflight
- py -3.14 -m pytest tests/unit/test_paper_contracts.py tests/unit/test_paper_application_services.py tests/unit/test_paper_service.py tests/unit/test_paper_agent.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_notifications.py tests/unit/test_paper_persistence.py tests/integration/test_paper_notification_flow.py tests/integration/test_mcp_server.py -q --basetemp .pytest_tmp
- py -3.14 -m ruff check src/marketlab/paper tests/unit/test_paper_contracts.py tests/unit/test_paper_application_services.py tests/unit/test_paper_service.py tests/unit/test_paper_agent.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_notifications.py tests/unit/test_paper_persistence.py