### PR TITLE
refactor: add structured paper observability

### DIFF
--- a/IMPLEMENTATION_ROADMAP_PHASES_1_6.md
+++ b/IMPLEMENTATION_ROADMAP_PHASES_1_6.md
@@ -149,7 +149,7 @@ Do not parallelize:
 | 2 | Extract phase-oriented paper services | typed contracts, current paper modules, artifact semantics | shared application service layer, thin adapters | 2 | Mostly no | all adapters call the same services and artifacts are unchanged |
 | 3 | Add DB-agnostic persistence ports | extracted services, current `PaperStateStore`, current paper artifacts | repositories, `UnitOfWork`, filesystem adapter, optional SQLite adapter, contract tests | 2 | Yes, after port contracts are fixed | default local behavior still works and adapter contract tests pass |
 | 4 | Isolate external IO behind ports | services, persistence ports, Alpaca/Telegram/provider/artifact modules | `BrokerClient`, `NotificationSink`, `ApprovalClient`, `ArtifactStore` | 2 | Yes, after outbound interfaces are fixed | application services stop importing concrete IO adapters |
-| 5 | Add structured observability | `log.py`, paper services, entry adapters | structured log envelope, execution context propagation | 1 | Usually no | structured logs exist and behavior remains unchanged |
+| 5 | Add structured observability | `log.py`, paper services, entry adapters | structured log envelope, execution context propagation | 2 | Usually no | structured logs exist and behavior remains unchanged |
 | 6 | Define extraction readiness and add boundary guardrails | completed seams from phases 1-5, architecture docs | readiness criteria, boundary tests, explicit keep-package-first rules | 2 | Yes, after criteria are fixed | boundary rules are automated and the repo is still a modular monolith |
 
 ## Detailed Phase Plans
@@ -440,16 +440,21 @@ Expected outputs:
 
 PR sequence:
 
-1. Branch: `refactor/structured-paper-logging`
-   PR title: `refactor: add structured execution logging for paper control plane`
-   Goal: add transport-agnostic structured execution logging
+1. Branch: `refactor/structured-paper-logging-foundation`
+   PR title: `refactor: add structured execution logging foundation for paper workflows`
+   Goal: add the shared structured log envelope and root execution-context wiring
+
+2. Branch: `refactor/structured-paper-logging-rollout`
+   PR title: `refactor: instrument paper control plane with structured execution context`
+   Goal: propagate shared execution context through paper services and loop adapters
 
 Worker packet plan:
 
-- recommended single-owner change because logging touches shared execution paths
+- recommended single-owner implementation per PR because logging touches shared execution paths
 - `/qa`:
   - verify logs do not replace artifact-based debugging
   - verify current debugging surfaces remain usable
+  - verify scheduler and agent stdout summaries do not drift
 - `/critic`:
   - block logging changes that become hidden control flow
   - block cloud-vendor assumptions in the log shape
@@ -571,7 +576,8 @@ Exit criteria:
 
 ### Phase 5
 
-- [ ] PR: `refactor: add structured execution logging for paper control plane`
+- [ ] PR: `refactor: add structured execution logging foundation for paper workflows`
+- [ ] PR: `refactor: instrument paper control plane with structured execution context`
 - [ ] Confirm current local debugging still works
 
 ### Phase 6

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -168,6 +168,14 @@ Every notification attempt is also persisted under:
 
 These audit records include the stage, outcome, message body, delivery result, and any delivery error. They do not replace the proposal, approval, or submission state files.
 
+## Structured Observability
+
+The paper entrypoints now emit structured JSON logs to `stderr`. This keeps the existing CLI and loop `stdout` contracts unchanged for path outputs, JSON summaries, and MCP protocol traffic.
+
+The persisted paper artifacts remain the canonical audit and debugging surface. Proposal, approval, submission, notification, and status files are still the source of truth for paper state.
+
+For the long-running local stack, `docker logs` remains the operational tail path for scheduler, agent, and MCP execution traces because those structured records are written to container `stderr`.
+
 ## Docker Compose Loop
 
 The checked-in local stack is:

--- a/scripts/run-paper-launch-checks.ps1
+++ b/scripts/run-paper-launch-checks.ps1
@@ -6,6 +6,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = Split-Path -Parent $PSScriptRoot
+$DotEnvPath = Join-Path $RepoRoot ".env"
 
 function Get-GitPorcelainStatus {
     $status = & git status --porcelain=v1
@@ -14,6 +15,37 @@ function Get-GitPorcelainStatus {
     }
 
     return @($status | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Get-DotEnvValue {
+    param(
+        [string]$Path,
+        [string]$Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq "" -or $trimmed.StartsWith("#")) {
+            continue
+        }
+
+        $parts = $trimmed -split "=", 2
+        if ($parts.Count -ne 2) {
+            continue
+        }
+
+        if ($parts[0].Trim() -ne $Name) {
+            continue
+        }
+
+        return $parts[1].Trim().Trim('"').Trim("'")
+    }
+
+    return $null
 }
 
 Push-Location $RepoRoot
@@ -37,9 +69,23 @@ try {
         }
     }
 
-    Write-Host "Running real Telegram smoke test..."
-    $env:MARKETLAB_RUN_REAL_TELEGRAM = "1"
-    .tox\py312\Scripts\python.exe -m pytest -q tests/integration/test_real_telegram_smoke.py --basetemp $PytestBaseTemp
+    $runRealTelegram = $env:MARKETLAB_RUN_REAL_TELEGRAM
+    if ([string]::IsNullOrWhiteSpace($runRealTelegram)) {
+        $runRealTelegram = Get-DotEnvValue -Path $DotEnvPath -Name "MARKETLAB_RUN_REAL_TELEGRAM"
+    }
+    if ([string]::IsNullOrWhiteSpace($runRealTelegram)) {
+        $runRealTelegram = "0"
+    }
+
+    if ($runRealTelegram -eq "1") {
+        Write-Host "Running real Telegram smoke test..."
+        $env:MARKETLAB_RUN_REAL_TELEGRAM = "1"
+        .tox\py312\Scripts\python.exe -m pytest -q tests/integration/test_real_telegram_smoke.py --basetemp $PytestBaseTemp
+    }
+    else {
+        Write-Host "Skipping real Telegram smoke test because MARKETLAB_RUN_REAL_TELEGRAM is not '1'."
+        Remove-Item Env:MARKETLAB_RUN_REAL_TELEGRAM -ErrorAction SilentlyContinue
+    }
 
     Write-Host "Restarting paper Docker services..."
     docker compose --env-file .env -f docker/compose.paper.yml up -d --build

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -2,10 +2,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+from collections.abc import Callable
+from time import perf_counter
 
 from marketlab._version import get_version
 from marketlab.config import load_config
-from marketlab.log import configure_logging
+from marketlab.log import (
+    ExecutionContext,
+    bind_execution_context,
+    configure_logging,
+    duration_ms_since,
+    emit_structured_log,
+)
 from marketlab.paper import (
     decide_paper_proposal,
     get_paper_status,
@@ -15,8 +24,14 @@ from marketlab.paper import (
     run_paper_submit,
     run_scheduler_loop,
 )
+from marketlab.paper.observability import (
+    paper_execution_context,
+    root_execution_context,
+)
 from marketlab.pipeline import backtest, prepare_data, run_experiment, train_models
 from marketlab.resources.templates import CONFIG_TEMPLATE_NAMES, write_config_template
+
+LOGGER = logging.getLogger(__name__)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -66,6 +81,145 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _run_logged_paper_command(
+    command_name: str,
+    *,
+    action: Callable[[ExecutionContext], tuple[int, str | None]],
+    proposal_id: str | None = None,
+) -> int:
+    root_context = root_execution_context(
+        deployment="local_cli",
+        phase=command_name,
+        proposal_id=proposal_id,
+        details={"command": command_name},
+    )
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        f"Starting {command_name} command.",
+        event="paper.command.start",
+        execution_context=root_context,
+    )
+    start_time = perf_counter()
+    try:
+        with bind_execution_context(root_context):
+            exit_code, outcome = action(root_context)
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            f"{command_name} command failed.",
+            event="paper.command.error",
+            execution_context=paper_execution_context(
+                root_context,
+                phase=command_name,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"command": command_name},
+            ),
+            exc_info=exc,
+        )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        f"Finished {command_name} command.",
+        event="paper.command.finish",
+        execution_context=paper_execution_context(
+            root_context,
+            phase=command_name,
+            outcome=outcome or "success",
+            duration_ms=duration_ms_since(start_time),
+            details={"command": command_name},
+        ),
+    )
+    return exit_code
+
+
+def _run_paper_decision_command(
+    config,
+    *,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    result = run_paper_decision(config, execution_context=execution_context)
+    print(result.get("proposal_path", result["status_path"]))
+    return 0, str(result.get("status", {}).get("status", "success"))
+
+
+def _run_paper_submit_command(
+    config,
+    *,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    result = run_paper_submit(config, execution_context=execution_context)
+    print(result.get("submission_path", result["status_path"]))
+    return 0, str(result.get("status", {}).get("status", "success"))
+
+
+def _run_paper_approve_command(
+    config,
+    *,
+    proposal_id: str,
+    decision: str,
+    actor: str,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    result = decide_paper_proposal(
+        config,
+        proposal_id=proposal_id,
+        decision=decision,
+        actor=actor,
+        execution_context=execution_context,
+    )
+    print(result["approval_path"])
+    return 0, str(result.get("status", {}).get("status", "success"))
+
+
+def _run_paper_status_command(
+    config,
+    *,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    del execution_context
+    print(json.dumps(get_paper_status(config), indent=2, sort_keys=True))
+    return 0, "success"
+
+
+def _run_paper_agent_approve_command(
+    config,
+    *,
+    once: bool,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    del execution_context
+    run_agent_approval_loop(config, once=once)
+    return 0, "success"
+
+
+def _run_paper_scheduler_command(
+    config,
+    *,
+    once: bool,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    del execution_context
+    run_scheduler_loop(config, once=once)
+    return 0, "success"
+
+
+def _run_paper_report_command(
+    config,
+    *,
+    start_date: str,
+    end_date: str,
+    execution_context: ExecutionContext,
+) -> tuple[int, str | None]:
+    del execution_context
+    result = run_paper_report(config, start_date=start_date, end_date=end_date)
+    print(result["report_path"])
+    return 0, "success"
+
+
 def main(argv: list[str] | None = None) -> int:
     configure_logging()
     parser = build_parser()
@@ -87,41 +241,75 @@ def main(argv: list[str] | None = None) -> int:
     config = load_config(args.config)
 
     if args.command == "paper-decision":
-        result = run_paper_decision(config)
-        print(result.get("proposal_path", result["status_path"]))
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_decision_command(
+                config,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "paper-submit":
-        result = run_paper_submit(config)
-        print(result.get("submission_path", result["status_path"]))
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_submit_command(
+                config,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "paper-approve":
-        result = decide_paper_proposal(
-            config,
+        return _run_logged_paper_command(
+            args.command,
             proposal_id=args.proposal_id,
-            decision=args.decision,
-            actor=args.actor,
+            action=lambda execution_context: _run_paper_approve_command(
+                config,
+                proposal_id=args.proposal_id,
+                decision=args.decision,
+                actor=args.actor,
+                execution_context=execution_context,
+            ),
         )
-        print(result["approval_path"])
-        return 0
 
     if args.command == "paper-status":
-        print(json.dumps(get_paper_status(config), indent=2, sort_keys=True))
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_status_command(
+                config,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "paper-agent-approve":
-        run_agent_approval_loop(config, once=args.once)
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_agent_approve_command(
+                config,
+                once=args.once,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "paper-scheduler":
-        run_scheduler_loop(config, once=args.once)
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_scheduler_command(
+                config,
+                once=args.once,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "paper-report":
-        result = run_paper_report(config, start_date=args.start, end_date=args.end)
-        print(result["report_path"])
-        return 0
+        return _run_logged_paper_command(
+            args.command,
+            action=lambda execution_context: _run_paper_report_command(
+                config,
+                start_date=args.start,
+                end_date=args.end,
+                execution_context=execution_context,
+            ),
+        )
 
     if args.command == "prepare-data":
         _, panel_path = prepare_data(config)

--- a/src/marketlab/log.py
+++ b/src/marketlab/log.py
@@ -72,9 +72,25 @@ class StructuredLogFormatter(logging.Formatter):
             "provider": getattr(record, "provider", None),
             "outcome": getattr(record, "outcome", None),
             "duration_ms": getattr(record, "duration_ms", None),
-            "details": _json_mapping(getattr(record, "details", None)),
+            "details": self._details(record),
         }
         return json.dumps(payload, default=_json_default)
+
+    def _details(self, record: logging.LogRecord) -> dict[str, Any] | None:
+        details = _json_mapping(getattr(record, "details", None))
+        if (
+            record.exc_info
+            and record.exc_info[0] is not None
+            and record.exc_info[1] is not None
+        ):
+            if details is None:
+                details = {}
+            details["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            if details is None:
+                details = {}
+            details["stack"] = self.formatStack(record.stack_info)
+        return details
 
 
 class DynamicStderrStreamHandler(logging.Handler):

--- a/src/marketlab/log.py
+++ b/src/marketlab/log.py
@@ -1,10 +1,241 @@
 from __future__ import annotations
 
+import json
 import logging
+import sys
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+from uuid import uuid4
+
+STRUCTURED_LOG_KEYS = (
+    "timestamp",
+    "level",
+    "logger",
+    "message",
+    "event",
+    "execution_id",
+    "correlation_id",
+    "phase",
+    "deployment",
+    "trade_date",
+    "proposal_id",
+    "order_id",
+    "provider",
+    "outcome",
+    "duration_ms",
+    "details",
+)
 
 
-def configure_logging(level: int = logging.INFO) -> None:
+@dataclass(frozen=True, slots=True)
+class ExecutionContext:
+    execution_id: str
+    correlation_id: str
+    phase: str | None = None
+    deployment: str | None = None
+    trade_date: str | None = None
+    proposal_id: str | None = None
+    order_id: str | None = None
+    provider: str | None = None
+    outcome: str | None = None
+    duration_ms: float | None = None
+    details: dict[str, Any] | None = None
+
+
+_CURRENT_EXECUTION_CONTEXT: ContextVar[ExecutionContext | None] = ContextVar(
+    "marketlab_execution_context",
+    default=None,
+)
+
+
+class StructuredLogFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "event": getattr(record, "event", None),
+            "execution_id": getattr(record, "execution_id", None),
+            "correlation_id": getattr(record, "correlation_id", None),
+            "phase": getattr(record, "phase", None),
+            "deployment": getattr(record, "deployment", None),
+            "trade_date": getattr(record, "trade_date", None),
+            "proposal_id": getattr(record, "proposal_id", None),
+            "order_id": getattr(record, "order_id", None),
+            "provider": getattr(record, "provider", None),
+            "outcome": getattr(record, "outcome", None),
+            "duration_ms": getattr(record, "duration_ms", None),
+            "details": _json_mapping(getattr(record, "details", None)),
+        }
+        return json.dumps(payload, default=_json_default)
+
+
+class DynamicStderrStreamHandler(logging.Handler):
+    terminator = "\n"
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = self.format(record)
+            stream = sys.stderr
+            stream.write(message + self.terminator)
+            self.flush()
+        except Exception:
+            self.handleError(record)
+
+    def flush(self) -> None:
+        stream = sys.stderr
+        if hasattr(stream, "flush"):
+            stream.flush()
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, set):
+        return sorted(value)
+    return str(value)
+
+
+def _json_mapping(details: Any) -> dict[str, Any] | None:
+    if details is None:
+        return None
+    if isinstance(details, Mapping):
+        return {str(key): value for key, value in details.items()}
+    return {"value": details}
+
+
+def _log_level(level: int | str) -> int:
+    if isinstance(level, int):
+        return level
+    resolved = logging.getLevelNamesMapping().get(str(level).upper())
+    if resolved is None:
+        raise ValueError(f"Unsupported log level: {level}")
+    return int(resolved)
+
+
+def configure_logging(level: int | str = logging.INFO) -> None:
+    handler = DynamicStderrStreamHandler()
+    handler.setFormatter(StructuredLogFormatter())
     logging.basicConfig(
-        level=level,
-        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        level=_log_level(level),
+        handlers=[handler],
+        force=True,
+    )
+
+
+def create_execution_context(
+    *,
+    phase: str | None = None,
+    deployment: str | None = None,
+    trade_date: str | None = None,
+    proposal_id: str | None = None,
+    order_id: str | None = None,
+    provider: str | None = None,
+    outcome: str | None = None,
+    duration_ms: float | None = None,
+    details: Mapping[str, Any] | None = None,
+    correlation_id: str | None = None,
+    execution_id: str | None = None,
+) -> ExecutionContext:
+    resolved_execution_id = execution_id or uuid4().hex
+    resolved_correlation_id = correlation_id or resolved_execution_id
+    return ExecutionContext(
+        execution_id=resolved_execution_id,
+        correlation_id=resolved_correlation_id,
+        phase=phase,
+        deployment=deployment,
+        trade_date=trade_date,
+        proposal_id=proposal_id,
+        order_id=order_id,
+        provider=provider,
+        outcome=outcome,
+        duration_ms=duration_ms,
+        details=_json_mapping(details),
+    )
+
+
+def child_execution_context(
+    context: ExecutionContext | None = None,
+    *,
+    phase: str | None = None,
+    deployment: str | None = None,
+    trade_date: str | None = None,
+    proposal_id: str | None = None,
+    order_id: str | None = None,
+    provider: str | None = None,
+    outcome: str | None = None,
+    duration_ms: float | None = None,
+    details: Mapping[str, Any] | None = None,
+    refresh_execution_id: bool = False,
+) -> ExecutionContext:
+    base_context = context or current_execution_context() or create_execution_context()
+    return ExecutionContext(
+        execution_id=uuid4().hex if refresh_execution_id else base_context.execution_id,
+        correlation_id=base_context.correlation_id,
+        phase=phase if phase is not None else base_context.phase,
+        deployment=deployment if deployment is not None else base_context.deployment,
+        trade_date=trade_date if trade_date is not None else base_context.trade_date,
+        proposal_id=proposal_id if proposal_id is not None else base_context.proposal_id,
+        order_id=order_id if order_id is not None else base_context.order_id,
+        provider=provider if provider is not None else base_context.provider,
+        outcome=outcome if outcome is not None else base_context.outcome,
+        duration_ms=duration_ms if duration_ms is not None else base_context.duration_ms,
+        details=_json_mapping(details) if details is not None else base_context.details,
+    )
+
+
+def current_execution_context() -> ExecutionContext | None:
+    return _CURRENT_EXECUTION_CONTEXT.get()
+
+
+@contextmanager
+def bind_execution_context(context: ExecutionContext | None) -> Iterator[ExecutionContext | None]:
+    token = _CURRENT_EXECUTION_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_EXECUTION_CONTEXT.reset(token)
+
+
+def duration_ms_since(start_time: float) -> float:
+    return round((perf_counter() - start_time) * 1000.0, 3)
+
+
+def emit_structured_log(
+    logger: logging.Logger,
+    level: int,
+    message: str,
+    *,
+    event: str,
+    execution_context: ExecutionContext | None = None,
+    exc_info: BaseException | tuple[type[BaseException], BaseException, Any] | bool | None = None,
+) -> None:
+    context = execution_context or current_execution_context()
+    logger.log(
+        level,
+        message,
+        extra={
+            "event": event,
+            "execution_id": context.execution_id if context is not None else None,
+            "correlation_id": context.correlation_id if context is not None else None,
+            "phase": context.phase if context is not None else None,
+            "deployment": context.deployment if context is not None else None,
+            "trade_date": context.trade_date if context is not None else None,
+            "proposal_id": context.proposal_id if context is not None else None,
+            "order_id": context.order_id if context is not None else None,
+            "provider": context.provider if context is not None else None,
+            "outcome": context.outcome if context is not None else None,
+            "duration_ms": context.duration_ms if context is not None else None,
+            "details": context.details if context is not None else None,
+        },
+        exc_info=exc_info,
     )

--- a/src/marketlab/mcp/cli.py
+++ b/src/marketlab/mcp/cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from marketlab.log import configure_logging
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="marketlab-mcp")
@@ -17,6 +19,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    configure_logging(args.log_level.upper())
 
     try:
         from marketlab.mcp.server import create_server

--- a/src/marketlab/mcp/tools_paper.py
+++ b/src/marketlab/mcp/tools_paper.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import logging
+from time import perf_counter
 from typing import Any
 
 from marketlab.config import load_config
+from marketlab.log import (
+    bind_execution_context,
+    duration_ms_since,
+    emit_structured_log,
+)
 from marketlab.mcp.workspace import WorkspaceSandbox
 from marketlab.paper import (
     decide_paper_proposal,
@@ -10,6 +17,12 @@ from marketlab.paper import (
     list_paper_proposals,
     read_paper_proposal,
 )
+from marketlab.paper.observability import (
+    paper_execution_context,
+    root_execution_context,
+)
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _resolve_config_path(
@@ -97,16 +110,76 @@ def register_paper_tools(
         decision: str,
         actor: str,
     ) -> dict[str, Any]:
-        resolved = _resolve_config_path(sandbox, config_path)
-        config = load_config(resolved)
-        sandbox.validate_execution_paths(config)
-        decision_result = decide_paper_proposal(
-            config,
+        root_context = root_execution_context(
+            deployment="paper_mcp",
+            phase="paper-approve",
             proposal_id=proposal_id,
-            decision=decision,
-            actor=actor,
+            details={
+                "tool_name": "marketlab_decide_paper_proposal",
+                "config_path": config_path,
+            },
+        )
+        emit_structured_log(
+            LOGGER,
+            logging.INFO,
+            "Starting MCP paper approval tool.",
+            event="paper.mcp.approval.start",
+            execution_context=root_context,
+        )
+        start_time = perf_counter()
+        resolved_path = config_path
+        try:
+            resolved = _resolve_config_path(sandbox, config_path)
+            resolved_path = str(resolved)
+            config = load_config(resolved)
+            sandbox.validate_execution_paths(config)
+            with bind_execution_context(root_context):
+                decision_result = decide_paper_proposal(
+                    config,
+                    proposal_id=proposal_id,
+                    decision=decision,
+                    actor=actor,
+                    execution_context=root_context,
+                )
+        except Exception as exc:
+            emit_structured_log(
+                LOGGER,
+                logging.ERROR,
+                "MCP paper approval tool failed.",
+                event="paper.mcp.approval.error",
+                execution_context=paper_execution_context(
+                    root_context,
+                    phase="paper-approve",
+                    deployment="paper_mcp",
+                    outcome="error",
+                    duration_ms=duration_ms_since(start_time),
+                    details={
+                        "tool_name": "marketlab_decide_paper_proposal",
+                        "config_path": resolved_path,
+                    },
+                ),
+                exc_info=exc,
+            )
+            raise
+        emit_structured_log(
+            LOGGER,
+            logging.INFO,
+            "Finished MCP paper approval tool.",
+            event="paper.mcp.approval.finish",
+            execution_context=paper_execution_context(
+                root_context,
+                phase="paper-approve",
+                deployment="paper_mcp",
+                status=decision_result.get("status", {}),
+                proposal={"proposal_id": proposal_id},
+                duration_ms=duration_ms_since(start_time),
+                details={
+                    "tool_name": "marketlab_decide_paper_proposal",
+                    "config_path": resolved_path,
+                },
+            ),
         )
         return {
-            "config_path": str(resolved),
+            "config_path": resolved_path,
             **decision_result,
         }

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from datetime import datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.log import (
+    ExecutionContext,
+    bind_execution_context,
+    duration_ms_since,
+    emit_structured_log,
+)
 from marketlab.paper.approval_clients import build_default_paper_approval_client
 from marketlab.paper.contracts import (
     PaperApprovalClient,
@@ -20,6 +28,7 @@ from marketlab.paper.notifications import (
     build_error_fingerprint,
     build_telegram_paper_notification_sink,
 )
+from marketlab.paper.observability import paper_execution_context
 from marketlab.paper.service import (
     APPROVAL_PENDING,
     _now_utc,
@@ -29,6 +38,8 @@ from marketlab.paper.service import (
     validate_paper_trading_config,
 )
 from marketlab.paper.state import PaperStateStore
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _json_dump(path: Path, payload: dict[str, Any]) -> Path:
@@ -144,122 +155,198 @@ def run_agent_approval_iteration(
     broker: PaperBroker | None = None,
     notification_sink: PaperNotificationSink | None = None,
     approval_client: PaperApprovalClient | None = None,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any]:
+    iteration_context = paper_execution_context(
+        execution_context,
+        phase="paper-approve",
+        deployment="paper_agent",
+        refresh_execution_id=True,
+        details={"component": "agent_iteration"},
+    )
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper approval worker iteration.",
+        event="paper.agent.iteration.start",
+        execution_context=iteration_context,
+    )
+    start_time = perf_counter()
     validate_paper_trading_config(config)
     state = _load_worker_state(config)
     events: list[dict[str, Any]] = []
+    summary: dict[str, Any]
+    try:
+        with bind_execution_context(
+            paper_execution_context(
+                iteration_context,
+                phase="paper-approve",
+                deployment="paper_agent",
+                details={"component": "agent_iteration"},
+            )
+        ):
+            if config.paper.execution_mode != "agent_approval":
+                _clear_worker_error_state(state)
+                state["last_checked_at"] = _now_utc(now).isoformat()
+                state["last_result"] = "execution_mode_not_agent_approval"
+                state_path = _save_worker_state(config, state)
+                summary = {
+                    "agent_state_path": str(state_path),
+                    "events": [],
+                    "processed_count": 0,
+                }
+            else:
+                store = PaperStateStore(config)
+                proposals = sorted(
+                    [
+                        proposal
+                        for proposal in store.list_proposals()
+                        if proposal.get("approval_status", APPROVAL_PENDING) == APPROVAL_PENDING
+                        and not store.trade_submission_path(proposal["effective_date"]).exists()
+                    ],
+                    key=lambda proposal: (
+                        proposal.get("effective_date", ""),
+                        proposal.get("proposal_id", ""),
+                    ),
+                )
+                current_status = store.read_status()
+                account_context = _current_account_context(config, broker=broker) if proposals else {}
+                client = approval_client or _paper_approval_client(config)
 
-    if config.paper.execution_mode != "agent_approval":
-        _clear_worker_error_state(state)
-        state["last_checked_at"] = _now_utc(now).isoformat()
-        state["last_result"] = "execution_mode_not_agent_approval"
-        state_path = _save_worker_state(config, state)
-        return {
-            "agent_state_path": str(state_path),
-            "events": [],
-            "processed_count": 0,
-        }
+                for proposal in proposals:
+                    try:
+                        evidence = read_paper_evidence(config, proposal_id=proposal["proposal_id"])
+                    except FileNotFoundError as exc:
+                        result = decide_paper_proposal(
+                            config,
+                            proposal_id=proposal["proposal_id"],
+                            decision="reject",
+                            actor="agent",
+                            rationale=(
+                                "Rejected because the approval worker could not read the persisted "
+                                f"proposal evidence: {exc}."
+                            ),
+                            fallback_reason=str(exc),
+                            now=now,
+                            notification_sink=notification_sink,
+                            execution_context=paper_execution_context(
+                                iteration_context,
+                                phase="paper-approve",
+                                deployment="paper_agent",
+                                proposal=proposal,
+                                refresh_execution_id=True,
+                            ),
+                        )
+                        approval_result = PaperApprovalResult.from_legacy(result)
+                        events.append(
+                            {
+                                "proposal_id": proposal["proposal_id"],
+                                "decision": "reject",
+                                "provider": "",
+                                "model": "",
+                                "fallback_used": False,
+                                "fallback_reason": str(exc),
+                                "approval_path": approval_result.approval_path,
+                            }
+                        )
+                        continue
+                    try:
+                        decision = client.evaluate(
+                            PaperApprovalEvaluationRequest(
+                                proposal=proposal,
+                                evidence=evidence,
+                                status=current_status,
+                                account_context=account_context,
+                            )
+                        )
+                        result = decide_paper_proposal(
+                            config,
+                            proposal_id=proposal["proposal_id"],
+                            decision=decision.decision,
+                            actor="agent",
+                            rationale=decision.rationale,
+                            provider=decision.provider,
+                            model=decision.model,
+                            fallback_used=decision.fallback_used,
+                            fallback_reason=decision.fallback_reason,
+                            now=now,
+                            notification_sink=notification_sink,
+                            execution_context=paper_execution_context(
+                                iteration_context,
+                                phase="paper-approve",
+                                deployment="paper_agent",
+                                proposal=proposal,
+                                provider=decision.provider,
+                                refresh_execution_id=True,
+                            ),
+                        )
+                        approval_result = PaperApprovalResult.from_legacy(result)
+                    except Exception as exc:
+                        raise PaperLoopStageError(
+                            loop_name="agent",
+                            stage="paper-approve",
+                            cause=exc,
+                            proposal_id=str(proposal["proposal_id"]),
+                            trade_date=str(proposal["effective_date"]),
+                        ) from exc
+                    events.append(
+                        {
+                            "proposal_id": proposal["proposal_id"],
+                            "decision": decision.decision,
+                            "provider": decision.provider,
+                            "model": decision.model,
+                            "fallback_used": decision.fallback_used,
+                            "fallback_reason": decision.fallback_reason,
+                            "approval_path": approval_result.approval_path,
+                        }
+                    )
 
-    store = PaperStateStore(config)
-    proposals = sorted(
-        [
-            proposal
-            for proposal in store.list_proposals()
-            if proposal.get("approval_status", APPROVAL_PENDING) == APPROVAL_PENDING
-            and not store.trade_submission_path(proposal["effective_date"]).exists()
-        ],
-        key=lambda proposal: (
-            proposal.get("effective_date", ""),
-            proposal.get("proposal_id", ""),
+                _clear_worker_error_state(state)
+                state["last_checked_at"] = _now_utc(now).isoformat()
+                state["last_processed_count"] = len(events)
+                state["last_result"] = "processed" if events else "no_pending_proposals"
+                state_path = _save_worker_state(config, state)
+                summary = {
+                    "agent_state_path": str(state_path),
+                    "events": events,
+                    "processed_count": len(events),
+                }
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper approval worker iteration failed.",
+            event="paper.agent.iteration.error",
+            execution_context=paper_execution_context(
+                iteration_context,
+                phase="paper-approve",
+                deployment="paper_agent",
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "agent_iteration"},
+            ),
+            exc_info=exc,
+        )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper approval worker iteration.",
+        event="paper.agent.iteration.finish",
+        execution_context=paper_execution_context(
+            iteration_context,
+            phase="paper-approve",
+            deployment="paper_agent",
+            outcome="processed" if summary["processed_count"] > 0 else state.get("last_result", "idle"),
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "agent_iteration",
+                "agent_state_path": summary["agent_state_path"],
+                "processed_count": summary["processed_count"],
+            },
         ),
     )
-    current_status = store.read_status()
-    account_context = _current_account_context(config, broker=broker) if proposals else {}
-    client = approval_client or _paper_approval_client(config)
-
-    for proposal in proposals:
-        try:
-            evidence = read_paper_evidence(config, proposal_id=proposal["proposal_id"])
-        except FileNotFoundError as exc:
-            result = decide_paper_proposal(
-                config,
-                proposal_id=proposal["proposal_id"],
-                decision="reject",
-                actor="agent",
-                rationale=(
-                    "Rejected because the approval worker could not read the persisted "
-                    f"proposal evidence: {exc}."
-                ),
-                fallback_reason=str(exc),
-                now=now,
-                notification_sink=notification_sink,
-            )
-            approval_result = PaperApprovalResult.from_legacy(result)
-            events.append(
-                {
-                    "proposal_id": proposal["proposal_id"],
-                    "decision": "reject",
-                    "provider": "",
-                    "model": "",
-                    "fallback_used": False,
-                    "fallback_reason": str(exc),
-                    "approval_path": approval_result.approval_path,
-                }
-            )
-            continue
-        try:
-            decision = client.evaluate(
-                PaperApprovalEvaluationRequest(
-                    proposal=proposal,
-                    evidence=evidence,
-                    status=current_status,
-                    account_context=account_context,
-                )
-            )
-            result = decide_paper_proposal(
-                config,
-                proposal_id=proposal["proposal_id"],
-                decision=decision.decision,
-                actor="agent",
-                rationale=decision.rationale,
-                provider=decision.provider,
-                model=decision.model,
-                fallback_used=decision.fallback_used,
-                fallback_reason=decision.fallback_reason,
-                now=now,
-                notification_sink=notification_sink,
-            )
-            approval_result = PaperApprovalResult.from_legacy(result)
-        except Exception as exc:
-            raise PaperLoopStageError(
-                loop_name="agent",
-                stage="paper-approve",
-                cause=exc,
-                proposal_id=str(proposal["proposal_id"]),
-                trade_date=str(proposal["effective_date"]),
-            ) from exc
-        events.append(
-            {
-                "proposal_id": proposal["proposal_id"],
-                "decision": decision.decision,
-                "provider": decision.provider,
-                "model": decision.model,
-                "fallback_used": decision.fallback_used,
-                "fallback_reason": decision.fallback_reason,
-                "approval_path": approval_result.approval_path,
-            }
-        )
-
-    _clear_worker_error_state(state)
-    state["last_checked_at"] = _now_utc(now).isoformat()
-    state["last_processed_count"] = len(events)
-    state["last_result"] = "processed" if events else "no_pending_proposals"
-    state_path = _save_worker_state(config, state)
-    return {
-        "agent_state_path": str(state_path),
-        "events": events,
-        "processed_count": len(events),
-    }
+    return summary
 
 
 def run_agent_approval_loop(
@@ -270,13 +357,29 @@ def run_agent_approval_loop(
     approval_client: PaperApprovalClient | None = None,
 ) -> None:
     while True:
+        loop_context = paper_execution_context(
+            phase="paper-approve",
+            deployment="paper_agent",
+            refresh_execution_id=True,
+            details={"component": "agent_loop", "once": once},
+        )
+        emit_structured_log(
+            LOGGER,
+            logging.INFO,
+            "Starting paper approval worker loop run.",
+            event="paper.agent.loop.start",
+            execution_context=loop_context,
+        )
+        start_time = perf_counter()
         loop_error: Exception | None = None
         try:
-            summary = run_agent_approval_iteration(
-                config,
-                notification_sink=notification_sink,
-                approval_client=approval_client,
-            )
+            with bind_execution_context(loop_context):
+                summary = run_agent_approval_iteration(
+                    config,
+                    notification_sink=notification_sink,
+                    approval_client=approval_client,
+                    execution_context=loop_context,
+                )
         except Exception as exc:
             loop_error = exc
             state = _load_worker_state(config)
@@ -298,6 +401,44 @@ def run_agent_approval_loop(
                     "duplicate_suppressed": notification_path is None,
                 },
             }
+            emit_structured_log(
+                LOGGER,
+                logging.ERROR,
+                "Paper approval worker loop run failed.",
+                event="paper.agent.loop.error",
+                execution_context=paper_execution_context(
+                    loop_context,
+                    phase="paper-approve",
+                    deployment="paper_agent",
+                    outcome="error",
+                    duration_ms=duration_ms_since(start_time),
+                    details={
+                        "component": "agent_loop",
+                        "agent_state_path": summary["agent_state_path"],
+                        "duplicate_suppressed": notification_path is None,
+                    },
+                ),
+                exc_info=exc,
+            )
+        else:
+            emit_structured_log(
+                LOGGER,
+                logging.INFO,
+                "Finished paper approval worker loop run.",
+                event="paper.agent.loop.finish",
+                execution_context=paper_execution_context(
+                    loop_context,
+                    phase="paper-approve",
+                    deployment="paper_agent",
+                    outcome="processed" if summary["processed_count"] > 0 else "idle",
+                    duration_ms=duration_ms_since(start_time),
+                    details={
+                        "component": "agent_loop",
+                        "agent_state_path": summary["agent_state_path"],
+                        "processed_count": summary["processed_count"],
+                    },
+                ),
+            )
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
             if loop_error is not None:

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 from urllib import error, request
 
 from marketlab.config import ExperimentConfig
 from marketlab.env import load_env_file
+from marketlab.log import duration_ms_since, emit_structured_log
 from marketlab.paper.contracts import PaperNotificationSink
+from marketlab.paper.observability import paper_execution_context
 from marketlab.paper.state import PaperStateStore
 
 TELEGRAM_API_BASE_URL_ENV = "MARKETLAB_TELEGRAM_API_BASE_URL"
@@ -25,6 +29,7 @@ DELIVERY_SKIPPED_MISSING_CREDENTIALS = "skipped_missing_credentials"
 DELIVERY_FAILED = "failed_delivery"
 
 TelegramTransport = Callable[[str, dict[str, Any], int], tuple[int, str]]
+LOGGER = logging.getLogger(__name__)
 
 
 class PaperLoopStageError(RuntimeError):
@@ -252,6 +257,7 @@ def deliver_telegram_notification(
     now: datetime | None = None,
     transport: TelegramTransport | None = None,
 ) -> dict[str, Any]:
+    start_time = perf_counter()
     timestamp = _now_utc(now).isoformat()
     record: dict[str, Any] = {
         "channel": "telegram",
@@ -265,6 +271,14 @@ def deliver_telegram_notification(
     }
     if not config.paper.notifications.telegram.enabled:
         record["delivery_status"] = DELIVERY_SKIPPED_DISABLED
+        _log_notification_delivery(
+            stage=stage,
+            outcome=record["delivery_status"],
+            proposal_id=proposal_id,
+            trade_date=trade_date,
+            duration_ms=duration_ms_since(start_time),
+            details=record,
+        )
         return record
 
     load_env_file()
@@ -278,6 +292,14 @@ def deliver_telegram_notification(
             TELEGRAM_BOT_TOKEN_ENV: bot_token == "",
             TELEGRAM_CHAT_ID_ENV: chat_id == "",
         }
+        _log_notification_delivery(
+            stage=stage,
+            outcome=record["delivery_status"],
+            proposal_id=proposal_id,
+            trade_date=trade_date,
+            duration_ms=duration_ms_since(start_time),
+            details=record,
+        )
         return record
 
     payload = {
@@ -305,7 +327,42 @@ def deliver_telegram_notification(
         record["delivery_status"] = DELIVERY_FAILED
         record["error"] = f"{type(exc).__name__}: {exc}"
 
+    _log_notification_delivery(
+        stage=stage,
+        outcome=record["delivery_status"],
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+        duration_ms=duration_ms_since(start_time),
+        details=record,
+    )
     return record
+
+
+def _log_notification_delivery(
+    *,
+    stage: str,
+    outcome: str,
+    proposal_id: str,
+    trade_date: str,
+    duration_ms: float,
+    details: Mapping[str, Any],
+) -> None:
+    level = logging.ERROR if outcome == DELIVERY_FAILED else logging.INFO
+    emit_structured_log(
+        LOGGER,
+        level,
+        "Processed paper notification delivery.",
+        event="paper.notification.delivery",
+        execution_context=paper_execution_context(
+            phase=stage,
+            proposal={"proposal_id": proposal_id, "effective_date": trade_date},
+            provider="telegram",
+            outcome=outcome,
+            duration_ms=duration_ms,
+            details=details,
+            refresh_execution_id=True,
+        ),
+    )
 
 
 def write_notification_record(

--- a/src/marketlab/paper/observability.py
+++ b/src/marketlab/paper/observability.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from marketlab.log import (
+    ExecutionContext,
+    child_execution_context,
+    create_execution_context,
+    current_execution_context,
+)
+
+
+def _first_non_empty(*values: object) -> str | None:
+    for value in values:
+        text = str(value or "").strip()
+        if text != "":
+            return text
+    return None
+
+
+def root_execution_context(
+    *,
+    deployment: str,
+    phase: str,
+    proposal_id: str | None = None,
+    trade_date: str | None = None,
+    provider: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> ExecutionContext:
+    return create_execution_context(
+        deployment=deployment,
+        phase=phase,
+        proposal_id=proposal_id,
+        trade_date=trade_date,
+        provider=provider,
+        details=details,
+    )
+
+
+def paper_execution_context(
+    execution_context: ExecutionContext | None = None,
+    *,
+    phase: str,
+    deployment: str | None = None,
+    trade_date: str | None = None,
+    status: Mapping[str, Any] | None = None,
+    proposal: Mapping[str, Any] | None = None,
+    approval: Mapping[str, Any] | None = None,
+    submission: Mapping[str, Any] | None = None,
+    provider: str | None = None,
+    outcome: str | None = None,
+    duration_ms: float | None = None,
+    details: Mapping[str, Any] | None = None,
+    refresh_execution_id: bool = False,
+) -> ExecutionContext:
+    base_context = execution_context or current_execution_context()
+    return child_execution_context(
+        base_context,
+        phase=phase,
+        deployment=deployment,
+        trade_date=_first_non_empty(
+            trade_date,
+            (submission or {}).get("trade_date"),
+            (approval or {}).get("trade_date"),
+            (proposal or {}).get("effective_date"),
+            (status or {}).get("trade_date"),
+            (status or {}).get("market_date"),
+        ),
+        proposal_id=_first_non_empty(
+            (proposal or {}).get("proposal_id"),
+            (approval or {}).get("proposal_id"),
+            (submission or {}).get("proposal_id"),
+            (status or {}).get("proposal_id"),
+        ),
+        order_id=_first_non_empty((submission or {}).get("order_id")),
+        provider=_first_non_empty(
+            provider,
+            (approval or {}).get("provider"),
+            (proposal or {}).get("broker"),
+            (proposal or {}).get("data_provider"),
+        ),
+        outcome=_first_non_empty(
+            outcome,
+            (approval or {}).get("approval_status"),
+            (submission or {}).get("status"),
+            (status or {}).get("status"),
+        ),
+        duration_ms=duration_ms,
+        details=details,
+        refresh_execution_id=refresh_execution_id,
+    )

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from datetime import datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.log import (
+    ExecutionContext,
+    bind_execution_context,
+    duration_ms_since,
+    emit_structured_log,
+)
 from marketlab.paper.contracts import (
     PaperDecisionResult,
     PaperNotificationSink,
@@ -18,6 +26,7 @@ from marketlab.paper.notifications import (
     build_error_fingerprint,
     build_telegram_paper_notification_sink,
 )
+from marketlab.paper.observability import paper_execution_context
 from marketlab.paper.service import (
     PaperStateStore,
     _clock_value,
@@ -27,6 +36,8 @@ from marketlab.paper.service import (
     run_paper_decision,
     run_paper_submit,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _scheduler_state_path(config: ExperimentConfig) -> Path:
@@ -117,77 +128,167 @@ def run_scheduler_iteration(
     *,
     now: datetime | None = None,
     notification_sink: PaperNotificationSink | None = None,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any]:
+    iteration_context = paper_execution_context(
+        execution_context,
+        phase="paper-scheduler",
+        deployment="paper_scheduler",
+        refresh_execution_id=True,
+        details={"component": "scheduler_iteration"},
+    )
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper scheduler iteration.",
+        event="paper.scheduler.iteration.start",
+        execution_context=iteration_context,
+    )
+    start_time = perf_counter()
     local_now = _local_now(config, now)
     market_date = local_now.date().isoformat()
     decision_clock = _clock_value(config.paper.decision_time)
     submission_clock = _clock_value(config.paper.submission_time)
     state = _load_scheduler_state(config)
     events: list[dict[str, Any]] = []
-
-    if local_now.time() >= decision_clock and state.get("last_decision_market_date") != market_date:
-        try:
-            result = run_paper_decision(
-                config,
-                now=now,
-                notification_sink=notification_sink,
-            )
-            decision_result = PaperDecisionResult.from_legacy(result)
-        except Exception as exc:
-            raise PaperLoopStageError(
-                loop_name="scheduler",
-                stage="paper-decision",
-                cause=exc,
-            ) from exc
-        events.append({"phase": "decision", **decision_result.as_legacy_payload()})
-        state["last_decision_market_date"] = market_date
-        state["last_decision_at"] = _now_utc(now).isoformat()
-
-    if local_now.time() >= submission_clock and state.get("last_submission_market_date") != market_date:
-        try:
-            result = run_paper_submit(
-                config,
-                now=now,
-                notification_sink=notification_sink,
-            )
-            submission_result = PaperSubmissionResult.from_legacy(result)
-        except Exception as exc:
-            proposal = PaperStateStore(config).latest_proposal()
-            raise PaperLoopStageError(
-                loop_name="scheduler",
-                stage="paper-submit",
-                cause=exc,
-                proposal_id=str((proposal or {}).get("proposal_id", "")),
-                trade_date=str((proposal or {}).get("effective_date", "")),
-            ) from exc
-        events.append({"phase": "submission", **submission_result.as_legacy_payload()})
-        state["last_submission_market_date"] = market_date
-        state["last_submission_at"] = _now_utc(now).isoformat()
-
     try:
-        reconciliation = reconcile_latest_submission_status(config, now=now)
-    except Exception as exc:
-        proposal = PaperStateStore(config).latest_proposal()
-        raise PaperLoopStageError(
-            loop_name="scheduler",
-            stage="paper-submit-reconcile",
-            cause=exc,
-            proposal_id=str((proposal or {}).get("proposal_id", "")),
-            trade_date=str((proposal or {}).get("effective_date", "")),
-        ) from exc
-    if reconciliation is not None:
-        reconciliation_result = PaperReconciliationResult.from_legacy(reconciliation)
-        events.append({"phase": "submission_reconcile", **reconciliation_result.as_legacy_payload()})
+        with bind_execution_context(
+            paper_execution_context(
+                iteration_context,
+                phase="paper-scheduler",
+                deployment="paper_scheduler",
+                trade_date=market_date,
+                details={"component": "scheduler_iteration"},
+            )
+        ):
+            if local_now.time() >= decision_clock and state.get("last_decision_market_date") != market_date:
+                try:
+                    result = run_paper_decision(
+                        config,
+                        now=now,
+                        notification_sink=notification_sink,
+                        execution_context=paper_execution_context(
+                            iteration_context,
+                            phase="paper-decision",
+                            deployment="paper_scheduler",
+                            trade_date=market_date,
+                            provider=config.paper.data_provider,
+                            refresh_execution_id=True,
+                        ),
+                    )
+                    decision_result = PaperDecisionResult.from_legacy(result)
+                except Exception as exc:
+                    raise PaperLoopStageError(
+                        loop_name="scheduler",
+                        stage="paper-decision",
+                        cause=exc,
+                    ) from exc
+                events.append({"phase": "decision", **decision_result.as_legacy_payload()})
+                state["last_decision_market_date"] = market_date
+                state["last_decision_at"] = _now_utc(now).isoformat()
 
-    _clear_scheduler_error_state(state)
-    state["last_checked_at"] = _now_utc(now).isoformat()
-    state["last_checked_market_date"] = market_date
-    state_path = _save_scheduler_state(config, state)
-    return {
-        "scheduler_state_path": str(state_path),
-        "market_date": market_date,
-        "events": events,
-    }
+            if local_now.time() >= submission_clock and state.get("last_submission_market_date") != market_date:
+                try:
+                    result = run_paper_submit(
+                        config,
+                        now=now,
+                        notification_sink=notification_sink,
+                        execution_context=paper_execution_context(
+                            iteration_context,
+                            phase="paper-submit",
+                            deployment="paper_scheduler",
+                            trade_date=market_date,
+                            provider=config.paper.broker,
+                            refresh_execution_id=True,
+                        ),
+                    )
+                    submission_result = PaperSubmissionResult.from_legacy(result)
+                except Exception as exc:
+                    proposal = PaperStateStore(config).latest_proposal()
+                    raise PaperLoopStageError(
+                        loop_name="scheduler",
+                        stage="paper-submit",
+                        cause=exc,
+                        proposal_id=str((proposal or {}).get("proposal_id", "")),
+                        trade_date=str((proposal or {}).get("effective_date", "")),
+                    ) from exc
+                events.append({"phase": "submission", **submission_result.as_legacy_payload()})
+                state["last_submission_market_date"] = market_date
+                state["last_submission_at"] = _now_utc(now).isoformat()
+
+            try:
+                reconciliation = reconcile_latest_submission_status(
+                    config,
+                    now=now,
+                    execution_context=paper_execution_context(
+                        iteration_context,
+                        phase="paper-submit-reconcile",
+                        deployment="paper_scheduler",
+                        trade_date=market_date,
+                        provider=config.paper.broker,
+                        refresh_execution_id=True,
+                    ),
+                )
+            except Exception as exc:
+                proposal = PaperStateStore(config).latest_proposal()
+                raise PaperLoopStageError(
+                    loop_name="scheduler",
+                    stage="paper-submit-reconcile",
+                    cause=exc,
+                    proposal_id=str((proposal or {}).get("proposal_id", "")),
+                    trade_date=str((proposal or {}).get("effective_date", "")),
+                ) from exc
+            if reconciliation is not None:
+                reconciliation_result = PaperReconciliationResult.from_legacy(reconciliation)
+                events.append({"phase": "submission_reconcile", **reconciliation_result.as_legacy_payload()})
+
+            _clear_scheduler_error_state(state)
+            state["last_checked_at"] = _now_utc(now).isoformat()
+            state["last_checked_market_date"] = market_date
+            state_path = _save_scheduler_state(config, state)
+            summary = {
+                "scheduler_state_path": str(state_path),
+                "market_date": market_date,
+                "events": events,
+            }
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper scheduler iteration failed.",
+            event="paper.scheduler.iteration.error",
+            execution_context=paper_execution_context(
+                iteration_context,
+                phase="paper-scheduler",
+                deployment="paper_scheduler",
+                trade_date=market_date,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "scheduler_iteration"},
+            ),
+            exc_info=exc,
+        )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper scheduler iteration.",
+        event="paper.scheduler.iteration.finish",
+        execution_context=paper_execution_context(
+            iteration_context,
+            phase="paper-scheduler",
+            deployment="paper_scheduler",
+            trade_date=market_date,
+            outcome="events_recorded" if events else "idle",
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "scheduler_iteration",
+                "event_count": len(events),
+                "scheduler_state_path": summary["scheduler_state_path"],
+            },
+        ),
+    )
+    return summary
 
 
 def run_scheduler_loop(
@@ -197,12 +298,28 @@ def run_scheduler_loop(
     notification_sink: PaperNotificationSink | None = None,
 ) -> None:
     while True:
+        loop_context = paper_execution_context(
+            phase="paper-scheduler",
+            deployment="paper_scheduler",
+            refresh_execution_id=True,
+            details={"component": "scheduler_loop", "once": once},
+        )
+        emit_structured_log(
+            LOGGER,
+            logging.INFO,
+            "Starting paper scheduler loop run.",
+            event="paper.scheduler.loop.start",
+            execution_context=loop_context,
+        )
+        start_time = perf_counter()
         loop_error: Exception | None = None
         try:
-            summary = run_scheduler_iteration(
-                config,
-                notification_sink=notification_sink,
-            )
+            with bind_execution_context(loop_context):
+                summary = run_scheduler_iteration(
+                    config,
+                    notification_sink=notification_sink,
+                    execution_context=loop_context,
+                )
         except Exception as exc:
             loop_error = exc
             state = _load_scheduler_state(config)
@@ -223,6 +340,44 @@ def run_scheduler_loop(
                     "duplicate_suppressed": notification_path is None,
                 },
             }
+            emit_structured_log(
+                LOGGER,
+                logging.ERROR,
+                "Paper scheduler loop run failed.",
+                event="paper.scheduler.loop.error",
+                execution_context=paper_execution_context(
+                    loop_context,
+                    phase="paper-scheduler",
+                    deployment="paper_scheduler",
+                    outcome="error",
+                    duration_ms=duration_ms_since(start_time),
+                    details={
+                        "component": "scheduler_loop",
+                        "scheduler_state_path": summary["scheduler_state_path"],
+                        "duplicate_suppressed": notification_path is None,
+                    },
+                ),
+                exc_info=exc,
+            )
+        else:
+            emit_structured_log(
+                LOGGER,
+                logging.INFO,
+                "Finished paper scheduler loop run.",
+                event="paper.scheduler.loop.finish",
+                execution_context=paper_execution_context(
+                    loop_context,
+                    phase="paper-scheduler",
+                    deployment="paper_scheduler",
+                    outcome="events_recorded" if summary["events"] else "idle",
+                    duration_ms=duration_ms_since(start_time),
+                    details={
+                        "component": "scheduler_loop",
+                        "scheduler_state_path": summary["scheduler_state_path"],
+                        "event_count": len(summary["events"]),
+                    },
+                ),
+            )
         print(json.dumps(summary, indent=2, sort_keys=True))
         if once:
             if loop_error is not None:

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
+from time import perf_counter
 from typing import Any
 
 from marketlab.config import ExperimentConfig
+from marketlab.log import (
+    ExecutionContext,
+    bind_execution_context,
+    duration_ms_since,
+    emit_structured_log,
+)
 from marketlab.paper.alpaca import AlpacaMarketDataProvider, AlpacaPaperBrokerClient
 from marketlab.paper.application import (
     ApprovalService,
@@ -46,6 +54,7 @@ from marketlab.paper.core import (
     validate_paper_trading_config,
 )
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
+from marketlab.paper.observability import paper_execution_context
 from marketlab.paper.persistence import (
     build_filesystem_paper_artifact_store,
     build_filesystem_paper_uow_factory,
@@ -59,6 +68,7 @@ _clock_value = _core_clock_value
 _local_now = _core_local_now
 _now_utc = _core_now_utc
 _paper_symbol = _core_paper_symbol
+LOGGER = logging.getLogger(__name__)
 
 
 def _paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
@@ -109,25 +119,82 @@ def run_paper_decision(
     provider: PaperHistoryProvider | None = None,
     broker: PaperBroker | None = None,
     notification_sink: PaperNotificationSink | None = None,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any]:
-    result = DecisionService(
-        config,
-        uow_factory=_paper_uow_factory(config),
-        history_provider_factory=_paper_history_provider_factory(config),
-        broker_factory=_paper_broker_factory(config),
-    ).run(
-        PaperDecisionRequest(
-            now=now,
-            provider=provider,
-            broker=broker,
-        )
+    decision_context = paper_execution_context(
+        execution_context,
+        phase="paper-decision",
+        provider=config.paper.data_provider,
+        refresh_execution_id=True,
+        details={"component": "paper_service"},
     )
-    sink = notification_sink or _paper_notification_sink(config)
-    sink.notify_decision(
-        outcome=_decision_notification_outcome(result.status),
-        status=result.status,
-        proposal=result.proposal,
-        now=now,
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper decision service.",
+        event="paper.decision.start",
+        execution_context=decision_context,
+    )
+    start_time = perf_counter()
+    try:
+        with bind_execution_context(decision_context):
+            result = DecisionService(
+                config,
+                uow_factory=_paper_uow_factory(config),
+                history_provider_factory=_paper_history_provider_factory(config),
+                broker_factory=_paper_broker_factory(config),
+            ).run(
+                PaperDecisionRequest(
+                    now=now,
+                    provider=provider,
+                    broker=broker,
+                )
+            )
+            sink = notification_sink or _paper_notification_sink(config)
+            notification_path = sink.notify_decision(
+                outcome=_decision_notification_outcome(result.status),
+                status=result.status,
+                proposal=result.proposal,
+                now=now,
+            )
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper decision service failed.",
+            event="paper.decision.error",
+            execution_context=paper_execution_context(
+                decision_context,
+                phase="paper-decision",
+                provider=config.paper.data_provider,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "paper_service"},
+            ),
+            exc_info=exc,
+        )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper decision service.",
+        event="paper.decision.finish",
+        execution_context=paper_execution_context(
+            decision_context,
+            phase="paper-decision",
+            status=result.status,
+            proposal=result.proposal,
+            provider=config.paper.data_provider,
+            outcome=_decision_notification_outcome(result.status),
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "paper_service",
+                "status_path": result.status_path,
+                "proposal_path": result.proposal_path,
+                "evidence_path": result.evidence_path,
+                "notification_path": str(notification_path),
+            },
+        ),
     )
     return result.as_legacy_payload()
 
@@ -180,27 +247,89 @@ def decide_paper_proposal(
     fallback_reason: str | None = None,
     now: datetime | None = None,
     notification_sink: PaperNotificationSink | None = None,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any]:
-    result = ApprovalService(config, uow_factory=_paper_uow_factory(config)).run(
-        PaperApprovalRequest(
-            proposal_id=proposal_id,
-            decision=decision,
-            actor=actor,
-            rationale=rationale,
-            provider=provider,
-            model=model,
-            fallback_used=fallback_used,
-            fallback_reason=fallback_reason,
-            now=now,
-        )
+    approval_context = paper_execution_context(
+        execution_context,
+        phase="paper-approve",
+        proposal={"proposal_id": proposal_id},
+        provider=provider,
+        refresh_execution_id=True,
+        details={"component": "paper_service", "actor": actor, "decision": decision},
     )
-    if result.proposal is not None and result.approval is not None:
-        sink = notification_sink or _paper_notification_sink(config)
-        sink.notify_approval(
-            proposal=result.proposal,
-            approval_record=result.approval,
-            now=now,
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper approval service.",
+        event="paper.approval.start",
+        execution_context=approval_context,
+    )
+    start_time = perf_counter()
+    notification_path: str | None = None
+    try:
+        with bind_execution_context(approval_context):
+            result = ApprovalService(config, uow_factory=_paper_uow_factory(config)).run(
+                PaperApprovalRequest(
+                    proposal_id=proposal_id,
+                    decision=decision,
+                    actor=actor,
+                    rationale=rationale,
+                    provider=provider,
+                    model=model,
+                    fallback_used=fallback_used,
+                    fallback_reason=fallback_reason,
+                    now=now,
+                )
+            )
+            if result.proposal is not None and result.approval is not None:
+                sink = notification_sink or _paper_notification_sink(config)
+                notification_path = str(
+                    sink.notify_approval(
+                        proposal=result.proposal,
+                        approval_record=result.approval,
+                        now=now,
+                    )
+                )
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper approval service failed.",
+            event="paper.approval.error",
+            execution_context=paper_execution_context(
+                approval_context,
+                phase="paper-approve",
+                proposal={"proposal_id": proposal_id},
+                provider=provider,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "paper_service", "actor": actor, "decision": decision},
+            ),
+            exc_info=exc,
         )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper approval service.",
+        event="paper.approval.finish",
+        execution_context=paper_execution_context(
+            approval_context,
+            phase="paper-approve",
+            status=result.status,
+            proposal=result.proposal,
+            approval=result.approval,
+            provider=provider,
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "paper_service",
+                "status_path": result.status_path,
+                "proposal_path": result.proposal_path,
+                "approval_path": result.approval_path,
+                "notification_path": notification_path,
+            },
+        ),
+    )
     return result.as_legacy_payload()
 
 
@@ -209,19 +338,87 @@ def reconcile_latest_submission_status(
     *,
     now: datetime | None = None,
     broker: PaperBroker | None = None,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any] | None:
-    result = ReconciliationService(
-        config,
-        uow_factory=_paper_uow_factory(config),
-        broker_factory=_paper_broker_factory(config),
-    ).run(
-        PaperReconciliationRequest(
-            now=now,
-            broker=broker,
-        )
+    reconciliation_context = paper_execution_context(
+        execution_context,
+        phase="paper-submit-reconcile",
+        provider=config.paper.broker,
+        refresh_execution_id=True,
+        details={"component": "paper_service"},
     )
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper submission reconciliation service.",
+        event="paper.reconcile.start",
+        execution_context=reconciliation_context,
+    )
+    start_time = perf_counter()
+    try:
+        with bind_execution_context(reconciliation_context):
+            result = ReconciliationService(
+                config,
+                uow_factory=_paper_uow_factory(config),
+                broker_factory=_paper_broker_factory(config),
+            ).run(
+                PaperReconciliationRequest(
+                    now=now,
+                    broker=broker,
+                )
+            )
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper submission reconciliation service failed.",
+            event="paper.reconcile.error",
+            execution_context=paper_execution_context(
+                reconciliation_context,
+                phase="paper-submit-reconcile",
+                provider=config.paper.broker,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "paper_service"},
+            ),
+            exc_info=exc,
+        )
+        raise
     if result is None:
+        emit_structured_log(
+            LOGGER,
+            logging.INFO,
+            "Finished paper submission reconciliation service without updates.",
+            event="paper.reconcile.finish",
+            execution_context=paper_execution_context(
+                reconciliation_context,
+                phase="paper-submit-reconcile",
+                provider=config.paper.broker,
+                outcome="no_reconciliation_update",
+                duration_ms=duration_ms_since(start_time),
+                details={"component": "paper_service"},
+            ),
+        )
         return None
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper submission reconciliation service.",
+        event="paper.reconcile.finish",
+        execution_context=paper_execution_context(
+            reconciliation_context,
+            phase="paper-submit-reconcile",
+            submission=result.submission,
+            provider=config.paper.broker,
+            outcome=result.poll_status or result.order_status,
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "paper_service",
+                "submission_path": result.submission_path,
+                "order_status_path": result.order_status_path,
+            },
+        ),
+    )
     return result.as_legacy_payload()
 
 
@@ -232,26 +429,85 @@ def run_paper_submit(
     broker: PaperBroker | None = None,
     notification_sink: PaperNotificationSink | None = None,
     retry_failed_submission: bool = False,
+    execution_context: ExecutionContext | None = None,
 ) -> dict[str, Any]:
-    result = SubmissionService(
-        config,
-        uow_factory=_paper_uow_factory(config),
-        artifact_store=_paper_artifact_store(config),
-        broker_factory=_paper_broker_factory(config),
-    ).run(
-        PaperSubmissionRequest(
-            now=now,
-            broker=broker,
-            retry_failed_submission=retry_failed_submission,
-        )
+    submission_context = paper_execution_context(
+        execution_context,
+        phase="paper-submit",
+        provider=config.paper.broker,
+        refresh_execution_id=True,
+        details={"component": "paper_service", "retry_failed_submission": retry_failed_submission},
     )
-    sink = notification_sink or _paper_notification_sink(config)
-    sink.notify_submission(
-        outcome=str(result.status.get("status", "")),
-        status=result.status,
-        proposal=result.proposal,
-        submission=result.submission,
-        now=now,
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Starting paper submission service.",
+        event="paper.submit.start",
+        execution_context=submission_context,
+    )
+    start_time = perf_counter()
+    try:
+        with bind_execution_context(submission_context):
+            result = SubmissionService(
+                config,
+                uow_factory=_paper_uow_factory(config),
+                artifact_store=_paper_artifact_store(config),
+                broker_factory=_paper_broker_factory(config),
+            ).run(
+                PaperSubmissionRequest(
+                    now=now,
+                    broker=broker,
+                    retry_failed_submission=retry_failed_submission,
+                )
+            )
+            sink = notification_sink or _paper_notification_sink(config)
+            notification_path = sink.notify_submission(
+                outcome=str(result.status.get("status", "")),
+                status=result.status,
+                proposal=result.proposal,
+                submission=result.submission,
+                now=now,
+            )
+    except Exception as exc:
+        emit_structured_log(
+            LOGGER,
+            logging.ERROR,
+            "Paper submission service failed.",
+            event="paper.submit.error",
+            execution_context=paper_execution_context(
+                submission_context,
+                phase="paper-submit",
+                provider=config.paper.broker,
+                outcome="error",
+                duration_ms=duration_ms_since(start_time),
+                details={
+                    "component": "paper_service",
+                    "retry_failed_submission": retry_failed_submission,
+                },
+            ),
+            exc_info=exc,
+        )
+        raise
+    emit_structured_log(
+        LOGGER,
+        logging.INFO,
+        "Finished paper submission service.",
+        event="paper.submit.finish",
+        execution_context=paper_execution_context(
+            submission_context,
+            phase="paper-submit",
+            status=result.status,
+            proposal=result.proposal,
+            submission=result.submission,
+            provider=config.paper.broker,
+            duration_ms=duration_ms_since(start_time),
+            details={
+                "component": "paper_service",
+                "status_path": result.status_path,
+                "submission_path": result.submission_path,
+                "notification_path": str(notification_path),
+            },
+        ),
     )
     legacy = result.as_legacy_payload()
     legacy.pop("proposal_id", None)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
@@ -8,6 +9,14 @@ import pytest
 
 from marketlab import cli
 from marketlab.resources.templates import get_config_template_text
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
 
 
 @contextmanager
@@ -149,3 +158,63 @@ def test_write_config_rejects_unknown_template_name() -> None:
 
         assert excinfo.value.code == 2
         assert not output_path.exists()
+
+
+def test_paper_status_keeps_json_stdout_and_structured_logs_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(cli, "load_config", lambda path: object())
+    monkeypatch.setattr(
+        cli,
+        "get_paper_status",
+        lambda config: {
+            "latest_proposal": {"proposal_id": "proposal-1"},
+            "pending_proposal_count": 0,
+            "status": {"status": "proposal_created"},
+            "status_path": "status.json",
+        },
+    )
+
+    exit_code = cli.main(["paper-status", "--config", "dummy.yaml"])
+
+    captured = capsys.readouterr()
+    records = _stderr_records(captured.err)
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["latest_proposal"]["proposal_id"] == "proposal-1"
+    assert [record["event"] for record in records] == [
+        "paper.command.start",
+        "paper.command.finish",
+    ]
+    assert all(record["deployment"] == "local_cli" for record in records)
+    assert all(record["phase"] == "paper-status" for record in records)
+
+
+def test_paper_decision_keeps_path_stdout_and_structured_logs_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(cli, "load_config", lambda path: object())
+    monkeypatch.setattr(
+        cli,
+        "run_paper_decision",
+        lambda config, **kwargs: {
+            "proposal_path": "proposal.json",
+            "status_path": "status.json",
+            "status": {"status": "proposal_created"},
+        },
+    )
+
+    exit_code = cli.main(["paper-decision", "--config", "dummy.yaml"])
+
+    captured = capsys.readouterr()
+    records = _stderr_records(captured.err)
+
+    assert exit_code == 0
+    assert captured.out.strip() == "proposal.json"
+    assert [record["event"] for record in records] == [
+        "paper.command.start",
+        "paper.command.finish",
+    ]
+    assert records[-1]["outcome"] == "proposal_created"

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from marketlab.log import (
+    STRUCTURED_LOG_KEYS,
+    bind_execution_context,
+    configure_logging,
+    create_execution_context,
+    emit_structured_log,
+)
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
+
+
+def test_configure_logging_emits_stable_json_payload_to_stderr(
+    capsys,
+) -> None:
+    configure_logging()
+    logger = logging.getLogger("marketlab.tests.log")
+    emit_structured_log(
+        logger,
+        logging.INFO,
+        "hello structured logs",
+        event="test.log.event",
+        execution_context=create_execution_context(
+            phase="paper-test",
+            deployment="unit_test",
+            details={"alpha": 1},
+        ),
+    )
+
+    captured = capsys.readouterr()
+    records = _stderr_records(captured.err)
+
+    assert captured.out == ""
+    assert len(records) == 1
+    assert list(records[0].keys()) == list(STRUCTURED_LOG_KEYS)
+    assert records[0]["message"] == "hello structured logs"
+    assert records[0]["event"] == "test.log.event"
+    assert records[0]["phase"] == "paper-test"
+    assert records[0]["deployment"] == "unit_test"
+    assert records[0]["details"] == {"alpha": 1}
+    assert records[0]["proposal_id"] is None
+    assert records[0]["duration_ms"] is None
+
+
+def test_bound_execution_context_is_used_when_no_explicit_context_is_passed(
+    capsys,
+) -> None:
+    configure_logging()
+    logger = logging.getLogger("marketlab.tests.bound")
+    context = create_execution_context(
+        phase="paper-bound",
+        deployment="unit_test",
+        proposal_id="proposal-123",
+    )
+
+    with bind_execution_context(context):
+        emit_structured_log(
+            logger,
+            logging.INFO,
+            "bound log",
+            event="test.bound.event",
+        )
+
+    captured = capsys.readouterr()
+    records = _stderr_records(captured.err)
+
+    assert len(records) == 1
+    assert records[0]["execution_id"] == context.execution_id
+    assert records[0]["correlation_id"] == context.correlation_id
+    assert records[0]["proposal_id"] == "proposal-123"
+    assert records[0]["phase"] == "paper-bound"

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -79,3 +79,29 @@ def test_bound_execution_context_is_used_when_no_explicit_context_is_passed(
     assert records[0]["correlation_id"] == context.correlation_id
     assert records[0]["proposal_id"] == "proposal-123"
     assert records[0]["phase"] == "paper-bound"
+
+
+def test_error_logs_preserve_exception_details_in_payload(
+    capsys,
+) -> None:
+    configure_logging()
+    logger = logging.getLogger("marketlab.tests.error")
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        emit_structured_log(
+            logger,
+            logging.ERROR,
+            "error log",
+            event="test.error.event",
+            execution_context=create_execution_context(details={"alpha": 1}),
+            exc_info=exc,
+        )
+
+    records = _stderr_records(capsys.readouterr().err)
+
+    assert len(records) == 1
+    assert records[0]["event"] == "test.error.event"
+    assert records[0]["details"]["alpha"] == 1
+    assert "RuntimeError: boom" in str(records[0]["details"]["exception"])

--- a/tests/unit/test_mcp_paper_tools.py
+++ b/tests/unit/test_mcp_paper_tools.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests._paper_fakes import (
+    FakeAlpacaBroker,
+    FakeAlpacaProvider,
+    write_phase7_paper_config,
+)
+
+from marketlab.config import load_config
+from marketlab.log import configure_logging
+from marketlab.mcp.tools_paper import register_paper_tools
+from marketlab.mcp.workspace import WorkspaceSandbox
+from marketlab.paper.service import run_paper_decision
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, *, name: str, description: str, structured_output: bool):
+        del description
+        del structured_output
+
+        def decorator(function):
+            self.tools[name] = function
+            return function
+
+        return decorator
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
+
+
+def test_mcp_paper_approval_logs_paper_mcp_execution_context(
+    capsys,
+    tmp_path: Path,
+) -> None:
+    configure_logging()
+    workspace = tmp_path / "workspace"
+    artifact_root = workspace / "artifacts"
+    config_path = write_phase7_paper_config(workspace / "configs" / "paper.yaml")
+    config = load_config(config_path)
+    decision = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(),
+        broker=FakeAlpacaBroker(),
+    )
+
+    fake_mcp = FakeMCP()
+    sandbox = WorkspaceSandbox(
+        workspace_root=workspace,
+        artifact_root=artifact_root,
+        repo_root=workspace,
+    )
+    register_paper_tools(fake_mcp, sandbox=sandbox)
+
+    approve = fake_mcp.tools["marketlab_decide_paper_proposal"]
+    result = approve(
+        config_path="configs/paper.yaml",
+        proposal_id=decision["proposal_id"],
+        decision="approve",
+        actor="agent",
+    )
+
+    records = _stderr_records(capsys.readouterr().err)
+    start_record = next(record for record in records if record["event"] == "paper.mcp.approval.start")
+    finish_record = next(record for record in records if record["event"] == "paper.mcp.approval.finish")
+
+    assert result["status"]["status"] == "approved"
+    assert start_record["deployment"] == "paper_mcp"
+    assert finish_record["deployment"] == "paper_mcp"
+    assert start_record["proposal_id"] == decision["proposal_id"]
+    assert finish_record["proposal_id"] == decision["proposal_id"]
+    assert finish_record["outcome"] == "approved"

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -16,6 +16,7 @@ from tests._paper_fakes import (
 )
 
 import marketlab.paper.agent as agent_module
+from marketlab.log import configure_logging
 from marketlab.paper.agent import run_agent_approval_iteration, run_agent_approval_loop
 from marketlab.paper.contracts import PaperApprovalClientDecision
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
@@ -39,6 +40,14 @@ def _capture_transport(calls: list[dict[str, object]]):
 def _configure_notification_env(monkeypatch) -> None:
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
 
 
 def test_agent_worker_approves_with_openai_backend(monkeypatch, tmp_path: Path) -> None:
@@ -623,3 +632,33 @@ def test_agent_worker_loop_once_propagates_iteration_failures_after_notifying(
     assert len(calls) == 1
     assert len(records) == 1
     assert records[0]["stage"] == "paper-error"
+
+
+def test_agent_worker_loop_logs_start_and_error_with_shared_correlation_id(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    configure_logging()
+    config = build_phase7_paper_config(tmp_path)
+
+    def _failing_iteration(*args, **kwargs):
+        raise RuntimeError("agent loop boom")
+
+    monkeypatch.setattr(agent_module, "run_agent_approval_iteration", _failing_iteration)
+
+    with pytest.raises(RuntimeError, match="agent loop boom"):
+        run_agent_approval_loop(
+            config,
+            once=True,
+            notification_sink=FakePaperNotificationSink(),
+        )
+
+    records = _stderr_records(capsys.readouterr().err)
+    start_record = next(record for record in records if record["event"] == "paper.agent.loop.start")
+    error_record = next(record for record in records if record["event"] == "paper.agent.loop.error")
+
+    assert start_record["correlation_id"] == error_record["correlation_id"]
+    assert start_record["deployment"] == "paper_agent"
+    assert error_record["phase"] == "paper-approve"
+    assert error_record["outcome"] == "error"

--- a/tests/unit/test_paper_notifications.py
+++ b/tests/unit/test_paper_notifications.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from tests._paper_fakes import build_phase7_paper_config
 
+from marketlab.log import configure_logging
 from marketlab.paper.notifications import (
     DELIVERY_DELIVERED,
     DELIVERY_FAILED,
@@ -14,6 +15,14 @@ from marketlab.paper.notifications import (
     deliver_telegram_notification,
 )
 from marketlab.paper.service import PaperStateStore
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
 
 
 def test_disabled_telegram_notification_records_skipped_disabled(
@@ -160,3 +169,40 @@ def test_failed_telegram_delivery_records_failure_without_raising(
     assert record["delivery_status"] == DELIVERY_FAILED
     assert "connection refused" in record["error"]
     assert persisted["delivery_status"] == DELIVERY_FAILED
+
+
+def test_successful_telegram_delivery_emits_structured_delivery_log(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    configure_logging()
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+
+    def _transport(url: str, payload: dict[str, object], timeout_seconds: int) -> tuple[int, str]:
+        return 200, '{"ok": true, "result": {"message_id": 7}}'
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+    deliver_telegram_notification(
+        config,
+        stage="paper-submit",
+        outcome="submitted",
+        message="paper-submit\noutcome: submitted",
+        details={"order_id": "order-7"},
+        proposal_id="proposal-7",
+        trade_date="2026-04-13",
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        transport=_transport,
+    )
+
+    records = _stderr_records(capsys.readouterr().err)
+
+    assert len(records) == 1
+    assert records[0]["event"] == "paper.notification.delivery"
+    assert records[0]["phase"] == "paper-submit"
+    assert records[0]["provider"] == "telegram"
+    assert records[0]["proposal_id"] == "proposal-7"
+    assert records[0]["trade_date"] == "2026-04-13"
+    assert records[0]["outcome"] == DELIVERY_DELIVERED

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from tests._paper_fakes import FakePaperNotificationSink, build_phase7_paper_config
 
+from marketlab.log import configure_logging
 from marketlab.paper import scheduler
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
 
@@ -28,6 +29,14 @@ def _capture_transport(calls: list[dict[str, object]]):
 def _configure_notification_env(monkeypatch) -> None:
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
 
 
 def test_scheduler_iteration_runs_each_phase_once_per_market_date(
@@ -223,3 +232,34 @@ def test_scheduler_loop_once_propagates_iteration_failures_after_notifying(
     assert len(calls) == 1
     assert len(records) == 1
     assert records[0]["stage"] == "paper-error"
+
+
+def test_scheduler_loop_logs_start_and_error_with_shared_correlation_id(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    configure_logging()
+    config = build_phase7_paper_config(tmp_path)
+
+    monkeypatch.setattr(
+        scheduler,
+        "run_scheduler_iteration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("scheduler boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="scheduler boom"):
+        scheduler.run_scheduler_loop(
+            config,
+            once=True,
+            notification_sink=FakePaperNotificationSink(),
+        )
+
+    records = _stderr_records(capsys.readouterr().err)
+    start_record = next(record for record in records if record["event"] == "paper.scheduler.loop.start")
+    error_record = next(record for record in records if record["event"] == "paper.scheduler.loop.error")
+
+    assert start_record["correlation_id"] == error_record["correlation_id"]
+    assert start_record["deployment"] == "paper_scheduler"
+    assert error_record["phase"] == "paper-scheduler"
+    assert error_record["outcome"] == "error"

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -12,6 +12,7 @@ from tests._paper_fakes import (
     build_phase7_paper_config,
 )
 
+from marketlab.log import configure_logging
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.persistence import build_sqlite_paper_uow_factory
 from marketlab.paper.service import (
@@ -50,6 +51,86 @@ def _notification_records(config) -> list[dict[str, object]]:
 def _configure_notification_env(monkeypatch) -> None:
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+
+def _stderr_records(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in stderr.splitlines()
+        if line.strip() != ""
+    ]
+
+
+def test_paper_service_logs_include_phase_ids_provider_and_duration(
+    capsys,
+    tmp_path: Path,
+) -> None:
+    configure_logging()
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    provider = FakeAlpacaProvider(symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ", equity=1_000.0, buying_power=1_000.0, cash=1_000.0)
+    sink = FakePaperNotificationSink()
+
+    decision = run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=provider,
+        broker=broker,
+        notification_sink=sink,
+    )
+    store = PaperStateStore(config)
+    proposal = store.load_proposal(decision["proposal_id"])
+    proposal["decision"] = "long"
+    proposal["target_weight"] = 1.0
+    proposal["reference_price"] = 640.41
+    store.update_proposal(proposal)
+    decide_paper_proposal(
+        config,
+        proposal_id=decision["proposal_id"],
+        decision="approve",
+        actor="agent",
+        provider="approval-backend",
+        model="approval-model",
+        now=datetime(2026, 4, 10, 20, 20, tzinfo=UTC),
+        notification_sink=sink,
+    )
+    run_paper_submit(
+        config,
+        now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+        broker=broker,
+        notification_sink=sink,
+    )
+    broker.order_status = "filled"
+    reconcile_latest_submission_status(
+        config,
+        now=datetime(2026, 4, 10, 23, 6, tzinfo=UTC),
+        broker=broker,
+    )
+
+    records = _stderr_records(capsys.readouterr().err)
+    finish_records = {record["event"]: record for record in records if str(record["event"]).endswith(".finish")}
+
+    assert finish_records["paper.decision.finish"]["phase"] == "paper-decision"
+    assert finish_records["paper.decision.finish"]["proposal_id"] == decision["proposal_id"]
+    assert finish_records["paper.decision.finish"]["provider"] == "alpaca"
+    assert finish_records["paper.decision.finish"]["outcome"] == "proposal_created"
+    assert isinstance(finish_records["paper.decision.finish"]["duration_ms"], float)
+
+    assert finish_records["paper.approval.finish"]["phase"] == "paper-approve"
+    assert finish_records["paper.approval.finish"]["proposal_id"] == decision["proposal_id"]
+    assert finish_records["paper.approval.finish"]["provider"] == "approval-backend"
+    assert finish_records["paper.approval.finish"]["outcome"] == "approved"
+
+    assert finish_records["paper.submit.finish"]["phase"] == "paper-submit"
+    assert finish_records["paper.submit.finish"]["proposal_id"] == decision["proposal_id"]
+    assert finish_records["paper.submit.finish"]["provider"] == "alpaca"
+    assert finish_records["paper.submit.finish"]["order_id"] == "order-1"
+    assert finish_records["paper.submit.finish"]["outcome"] == "submitted"
+
+    assert finish_records["paper.reconcile.finish"]["phase"] == "paper-submit-reconcile"
+    assert finish_records["paper.reconcile.finish"]["proposal_id"] == decision["proposal_id"]
+    assert finish_records["paper.reconcile.finish"]["provider"] == "alpaca"
+    assert finish_records["paper.reconcile.finish"]["outcome"] == "observed"
 
 
 def test_run_paper_decision_writes_latest_daily_proposal(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -109,12 +109,13 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
     for env_name in ("lint", "docs", "typecheck", "package", "integration"):
         assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
     assert parser["testenv:typecheck"]["commands"].strip() == (
-        "{envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py "
-        "src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py "
-        "src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py "
+        "{envpython} -m mypy src/marketlab/config.py src/marketlab/log.py "
+        "src/marketlab/data/market.py src/marketlab/paper/alpaca.py "
+        "src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py "
+        "src/marketlab/paper/observability.py src/marketlab/paper/contracts.py "
         "src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py "
-        "src/marketlab/paper/application/decision.py "
-        "src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py "
+        "src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py "
+        "src/marketlab/paper/application/submission.py "
         "src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py "
         "src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
## Summary
- add a structured logging foundation with execution-context helpers and mypy coverage
- instrument the paper CLI, MCP approval path, services, scheduler, agent loop, and notification delivery with structured stderr logs
- update the roadmap, paper-trading docs, and paper launch checks for the observability rollout

## Validation
- python -m pytest -q tests/unit/test_log.py tests/unit/test_cli.py tests/unit/test_paper_notifications.py tests/unit/test_mcp_paper_tools.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_agent.py tests/unit/test_profile_validation.py tests/integration/test_mcp_server.py --basetemp .pytest_tmp_obs_full
- py -3.14 -m tox -e preflight
