### PR TITLE
feat(readiness): define service extraction rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ MarketLab is a package-first research toolkit for reproducible market experiment
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md) for the SOLID-first technical-debt audit and the pre-cloud persistence-hardening roadmap.
+See [docs/service-extraction-readiness.md](docs/service-extraction-readiness.md) for the checklist used before extracting services, ports, or adapters.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
 See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ This site is the canonical home for MarketLab's public documentation.
 - [How It Works](how-it-works.md)
 - [Architecture](architecture.md)
 - [SOLID-First Architecture Audit](solid-architecture-audit.md)
+- [Service-Extraction Readiness Rules](service-extraction-readiness.md)
 - [Phase 5 Scenario Pack](phase5-scenarios.md)
 - [Plan](PLAN.md)
 

--- a/docs/service-extraction-readiness.md
+++ b/docs/service-extraction-readiness.md
@@ -1,0 +1,102 @@
+# Service-Extraction Readiness Rules
+
+This checklist is the gate for future MarketLab service extraction work. Use it
+before moving code into an application service, introducing a port or adapter, or
+splitting a package-first module behind a new boundary.
+
+The default posture is conservative: keep simple code simple, preserve existing
+contracts, and require evidence before adding a boundary.
+
+Readiness-only PRs must not change runtime behavior. They should document or
+test the decision gate without moving code, changing command behavior, or
+redefining artifact contracts.
+
+## Keep Package-First
+
+Keep a module package-first when it is mostly pure or near-pure logic, has stable
+function inputs and outputs, and does not own external side effects.
+
+This is the default for research/runtime modules such as feature engineering,
+target construction, backtest math, strategy weight generation, metrics, and
+deterministic report assembly.
+
+Package-first code should still improve through typed stage contracts, clearer
+artifact boundaries, and focused tests. It should not be wrapped in a service
+only because the module is large or likely to change.
+
+## Extract Service
+
+Extract an application service only when orchestration has a stable business
+phase, multiple inbound callers, and enough side-effect coordination that a plain
+function boundary no longer makes the behavior clear.
+
+The paper control plane is the primary extraction candidate. Future paper
+services should keep the phase language explicit:
+
+- decision
+- agent approval
+- submission
+- reconciliation
+
+Before extracting, the PR must show these are true:
+
+- CLI, scheduler, agent, MCP, or other inbound callers can share the same
+  one-shot contract.
+- Typed request and response objects are defined or preserved.
+- Current paper proposal, approval, submission, reconciliation, and status
+  semantics remain unchanged.
+- Existing artifact paths and reviewable payload meanings are protected by
+  parity tests.
+- Side effects are named and kept out of pure domain logic.
+
+## Introduce Port Or Adapter
+
+Introduce a port or adapter when business logic depends on an external system,
+provider SDK, persistence backend, artifact store, notification channel, or
+runtime transport that must be replaceable in tests or future deployments.
+
+Good port candidates include broker access, approval providers, notification
+sinks, artifact stores, repositories, units of work, and runtime-facing side
+effect boundaries.
+
+Before adding a port, the PR must show:
+
+- the concrete dependency is outside the domain or application core;
+- at least one deterministic fake, fixture, or alternate adapter can prove the
+  substitution;
+- the port preserves domain vocabulary instead of erasing it behind generic IO;
+- transactions do not stay open across broker calls, LLM/provider calls, or
+  notification delivery.
+
+## Preserve Artifact Parity
+
+Artifact compatibility is part of the public development contract for the current
+local workflow. A service extraction or adapter split must not silently change
+artifact paths, payload meanings, report shapes, paper-state semantics, or the
+review surface used by CLI, scheduler, agent, and MCP workflows.
+
+Before changing any source-of-truth boundary, the PR must keep artifact parity
+tests in place and add persistence-agnostic tests for the new contract. JSON
+artifacts can remain the debugging and audit surface even when transactional
+state moves behind repositories.
+
+## Defer Extraction
+
+Defer extraction when the proposed boundary is only organizational, when the
+substitution point is hypothetical, or when tests would only assert wiring instead
+of behavior.
+
+Do not:
+
+- force research math, feature engineering, target creation, strategy logic, or
+  deterministic reporting into service boundaries without a concrete
+  orchestration problem;
+- add a port around pure functions or stable in-process helpers;
+- move business rules into MCP tools, CLI handlers, scheduler loops, or agent
+  loops;
+- make MCP the execution backend for a future production runtime;
+- change frozen research contracts without a dedicated PR that proves the need.
+
+If a module has unclear responsibilities but no stable service contract yet,
+first document the current responsibility split, add typed contracts or tests at
+the existing boundary, and defer the extraction decision.

--- a/docs/solid-architecture-audit.md
+++ b/docs/solid-architecture-audit.md
@@ -9,6 +9,8 @@ It is intentionally critical. The goal is not to defend the current implementati
 This audit complements:
 
 - [Architecture](architecture.md) for the current system map
+- [Service-Extraction Readiness Rules](service-extraction-readiness.md) for the
+  decision checklist used before adding service, port, or adapter boundaries
 - [Phase 7 Paper Trading](paper-trading.md) for the local paper runtime
 - `CLOUD_MIGRATION_PLAN.md` at the repo root for the later hosted deployment path
 
@@ -333,6 +335,8 @@ Artifact snapshots remain separate from transactional state:
 - extraction criteria are explicit
 - the paper control plane can be split later without reopening core contracts
 - research/runtime modules still remain package-first unless a later decision changes that
+- the canonical checklist in [Service-Extraction Readiness Rules](service-extraction-readiness.md)
+  is linked from the docs site and protected by a unit test
 
 ## Module Review Sequence
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - How It Works: how-it-works.md
   - Architecture: architecture.md
   - SOLID Audit: solid-architecture-audit.md
+  - Service Extraction Readiness: service-extraction-readiness.md
   - Phase 5 Scenarios: phase5-scenarios.md
   - Phase 7 Paper Trading: paper-trading.md
   - MCP Server: mcp-server.md

--- a/tests/unit/test_service_extraction_readiness_docs.py
+++ b/tests/unit/test_service_extraction_readiness_docs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+READINESS_DOC = ROOT / "docs" / "service-extraction-readiness.md"
+MKDOCS_CONFIG = ROOT / "mkdocs.yml"
+
+
+def test_mkdocs_nav_includes_service_extraction_readiness() -> None:
+    config = yaml.safe_load(MKDOCS_CONFIG.read_text(encoding="utf-8"))
+
+    assert {"Service Extraction Readiness": "service-extraction-readiness.md"} in config["nav"]
+
+
+def test_service_extraction_readiness_contains_required_decision_headings() -> None:
+    content = READINESS_DOC.read_text(encoding="utf-8")
+
+    required_headings = [
+        "## Keep Package-First",
+        "## Extract Service",
+        "## Introduce Port Or Adapter",
+        "## Preserve Artifact Parity",
+        "## Defer Extraction",
+    ]
+
+    for heading in required_headings:
+        assert heading in content
+
+
+def test_service_extraction_readiness_locks_required_semantic_guardrails() -> None:
+    content = READINESS_DOC.read_text(encoding="utf-8")
+    normalized = " ".join(content.lower().split())
+
+    required_clauses = [
+        "readiness-only prs must not change runtime behavior.",
+        "cli, scheduler, agent, mcp, or other inbound callers",
+        "proposal, approval, submission, reconciliation, and status semantics",
+        "existing artifact paths and reviewable payload meanings",
+        "artifact paths, payload meanings, report shapes, paper-state semantics",
+        "mcp the execution backend",
+    ]
+
+    for clause in required_clauses:
+        assert clause in normalized


### PR DESCRIPTION
## Summary
- add the canonical service-extraction readiness checklist
- link it from README, docs index, SOLID audit, and MkDocs nav
- add unit coverage for the nav entry, required readiness headings, and semantic guardrails around artifact parity, paper phase semantics, inbound caller parity, MCP scope, and no runtime behavior changes

## Reviewer gates
- critic: approved; rules preserve package-first research posture and modular-monolith intent
- marketlab-ci-engineer: approved; CI/tox lanes unchanged and docs/test coverage is scoped
- marketlab-qa: initial heading-only test gap fixed; follow-up approval after semantic guardrail assertions were added

## Validation
- `py -3.14 -m tox -e docs,py312` passed
- `py -3.14 -m tox -e preflight-fast` passed
- `py -3.14 -m tox -e preflight` passed

Note: `py -3.12 -m tox ...` was unavailable locally because Python 3.12 does not have `tox` installed on this host. The tox lanes themselves still ran the configured py312 envs through the Python 3.14 tox entrypoint.