### PR TITLE
fix(paper): gate Telegram delivery by env and experiment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ OPENAI_API_KEY=your-openai-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id
+MARKETLAB_PAPER_TELEGRAM_ENABLED=false
+MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS=qqq_paper_daily

--- a/docker/compose.paper.yml
+++ b/docker/compose.paper.yml
@@ -12,6 +12,8 @@ services:
     environment:
       TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
       TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
+      MARKETLAB_PAPER_TELEGRAM_ENABLED: "${MARKETLAB_PAPER_TELEGRAM_ENABLED:-}"
+      MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS: "${MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts
@@ -41,6 +43,8 @@ services:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
       TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
+      MARKETLAB_PAPER_TELEGRAM_ENABLED: "${MARKETLAB_PAPER_TELEGRAM_ENABLED:-}"
+      MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS: "${MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts
@@ -70,6 +74,8 @@ services:
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
       TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
+      MARKETLAB_PAPER_TELEGRAM_ENABLED: "${MARKETLAB_PAPER_TELEGRAM_ENABLED:-}"
+      MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS: "${MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS:-}"
     volumes:
       - ../workspace:/app/workspace
       - ../artifacts:/app/repo/artifacts

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -138,13 +138,19 @@ OPENAI_API_KEY="..."
 ANTHROPIC_API_KEY="..."
 TELEGRAM_BOT_TOKEN="..."
 TELEGRAM_CHAT_ID="..."
+MARKETLAB_PAPER_TELEGRAM_ENABLED=false
+MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS=qqq_paper_daily
 ```
 
 The paper broker path rejects non-paper trading endpoints at runtime unless the base URL is a local test server.
 
 ## Telegram Ops Feed
 
-Telegram credentials stay out of YAML. The tracked `QQQ` config already enables the ops feed, and the alternate `VOO` config leaves it explicit but disabled. To enable it in another paper config:
+Telegram credentials stay out of YAML. The tracked `QQQ` config already enables the ops feed, and the alternate `VOO` config leaves it explicit but disabled. Set `MARKETLAB_PAPER_TELEGRAM_ENABLED=false` in `.env` to force Telegram delivery off for local CLI, scheduler, agent, and paper MCP runs even when the YAML config enables it. Set it to `true` to force delivery on for a config that leaves Telegram disabled.
+
+Use `MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS=qqq_paper_daily` to restrict real delivery to the tracked QQQ paper experiment. This keeps fixture and smoke-test configs such as `phase7_paper_fixture` from sending Telegram messages even if their YAML enables notifications.
+
+To enable it in another paper config without an env override:
 
 ```yaml
 paper:

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -8,6 +8,7 @@ from time import perf_counter
 
 from marketlab._version import get_version
 from marketlab.config import load_config
+from marketlab.env import load_env_file
 from marketlab.log import (
     ExecutionContext,
     bind_execution_context,
@@ -238,6 +239,7 @@ def main(argv: list[str] | None = None) -> int:
         print(output_path)
         return 0
 
+    load_env_file()
     config = load_config(args.config)
 
     if args.command == "paper-decision":

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -245,13 +245,13 @@ def _parse_optional_bool_env(name: str) -> bool | None:
     if raw_value is None:
         return None
     value = raw_value.strip().lower()
+    if value == "":
+        return None
     if value in {"1", "true", "yes", "on"}:
         return True
-    if value in {"0", "false", "no", "off", ""}:
+    if value in {"0", "false", "no", "off"}:
         return False
-    raise ValueError(
-        f"{name} must be one of true/false, 1/0, yes/no, or on/off; got {raw_value!r}."
-    )
+    return False
 
 
 def _telegram_notifications_enabled(config: ExperimentConfig) -> bool:

--- a/src/marketlab/paper/notifications.py
+++ b/src/marketlab/paper/notifications.py
@@ -21,6 +21,8 @@ from marketlab.paper.state import PaperStateStore
 TELEGRAM_API_BASE_URL_ENV = "MARKETLAB_TELEGRAM_API_BASE_URL"
 TELEGRAM_BOT_TOKEN_ENV = "TELEGRAM_BOT_TOKEN"
 TELEGRAM_CHAT_ID_ENV = "TELEGRAM_CHAT_ID"
+TELEGRAM_ENABLED_ENV = "MARKETLAB_PAPER_TELEGRAM_ENABLED"
+TELEGRAM_ALLOWED_EXPERIMENTS_ENV = "MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS"
 DEFAULT_TELEGRAM_API_BASE_URL = "https://api.telegram.org"
 DEFAULT_TELEGRAM_TIMEOUT_SECONDS = 10
 DELIVERY_DELIVERED = "delivered"
@@ -238,6 +240,39 @@ def _telegram_api_base_url() -> str:
     return DEFAULT_TELEGRAM_API_BASE_URL
 
 
+def _parse_optional_bool_env(name: str) -> bool | None:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return None
+    value = raw_value.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off", ""}:
+        return False
+    raise ValueError(
+        f"{name} must be one of true/false, 1/0, yes/no, or on/off; got {raw_value!r}."
+    )
+
+
+def _telegram_notifications_enabled(config: ExperimentConfig) -> bool:
+    configured = _parse_optional_bool_env(TELEGRAM_ENABLED_ENV)
+    if configured is not None:
+        return configured
+    return config.paper.notifications.telegram.enabled
+
+
+def _telegram_experiment_allowed(config: ExperimentConfig) -> bool:
+    raw_value = os.environ.get(TELEGRAM_ALLOWED_EXPERIMENTS_ENV, "").strip()
+    if raw_value == "":
+        return True
+    allowed = {
+        item.strip()
+        for item in raw_value.split(",")
+        if item.strip() != ""
+    }
+    return config.experiment_name in allowed
+
+
 def _safe_json(text: str) -> Any:
     try:
         return json.loads(text)
@@ -269,7 +304,8 @@ def deliver_telegram_notification(
         "details": dict(details or {}),
         "requested_at": timestamp,
     }
-    if not config.paper.notifications.telegram.enabled:
+    load_env_file()
+    if not _telegram_notifications_enabled(config) or not _telegram_experiment_allowed(config):
         record["delivery_status"] = DELIVERY_SKIPPED_DISABLED
         _log_notification_delivery(
             stage=stage,
@@ -281,7 +317,6 @@ def deliver_telegram_notification(
         )
         return record
 
-    load_env_file()
     bot_token = os.environ.get(TELEGRAM_BOT_TOKEN_ENV, "").strip()
     chat_id = os.environ.get(TELEGRAM_CHAT_ID_ENV, "").strip()
     api_base_url = _telegram_api_base_url()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(autouse=True)
+def isolate_paper_telegram_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    empty_env_file = tmp_path / ".marketlab-test.env"
+    empty_env_file.write_text("", encoding="utf-8")
+    monkeypatch.setenv("MARKETLAB_ENV_FILE", str(empty_env_file))
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)

--- a/tests/integration/test_real_telegram_smoke.py
+++ b/tests/integration/test_real_telegram_smoke.py
@@ -25,6 +25,18 @@ def _require_real_telegram_env() -> None:
         pytest.skip("Set MARKETLAB_RUN_REAL_TELEGRAM=1 to run the real Telegram smoke test.")
 
     load_env_file()
+    telegram_enabled = os.getenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", "").strip().lower()
+    if telegram_enabled in {"0", "false", "no", "off"}:
+        pytest.skip("MARKETLAB_PAPER_TELEGRAM_ENABLED disables Telegram delivery.")
+
+    allowed_experiments = {
+        item.strip()
+        for item in os.getenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", "").split(",")
+        if item.strip() != ""
+    }
+    if allowed_experiments and "phase7_paper_fixture" not in allowed_experiments:
+        pytest.skip("Telegram experiment allowlist excludes phase7_paper_fixture.")
+
     missing = [
         name
         for name in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID")
@@ -40,6 +52,7 @@ def test_real_telegram_smoke_sends_one_message_and_persists_audit_record(
     tmp_path: Path,
 ) -> None:
     monkeypatch.chdir(REPO_ROOT)
+    monkeypatch.delenv("MARKETLAB_ENV_FILE", raising=False)
     monkeypatch.delenv("MARKETLAB_TELEGRAM_API_BASE_URL", raising=False)
     _require_real_telegram_env()
 

--- a/tests/unit/test_paper_compose.py
+++ b/tests/unit/test_paper_compose.py
@@ -18,6 +18,10 @@ def test_paper_compose_includes_scheduler_agent_and_mcp_sidecar() -> None:
     assert "ANTHROPIC_API_KEY" in compose_text
     assert "TELEGRAM_BOT_TOKEN" in compose_text
     assert "TELEGRAM_CHAT_ID" in compose_text
+    assert "MARKETLAB_PAPER_TELEGRAM_ENABLED" in compose_text
+    assert "MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS" in compose_text
     assert 'container_name: marketlab-paper-mcp' in compose_text
     assert compose_text.count("TELEGRAM_BOT_TOKEN") == 6
     assert compose_text.count("TELEGRAM_CHAT_ID") == 6
+    assert compose_text.count("MARKETLAB_PAPER_TELEGRAM_ENABLED") == 6
+    assert compose_text.count("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS") == 6

--- a/tests/unit/test_paper_notifications.py
+++ b/tests/unit/test_paper_notifications.py
@@ -31,6 +31,8 @@ def test_disabled_telegram_notification_records_skipped_disabled(
 ) -> None:
     config = build_phase7_paper_config(tmp_path, telegram_enabled=False)
     store = PaperStateStore(config)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
     monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
 
@@ -53,6 +55,100 @@ def test_disabled_telegram_notification_records_skipped_disabled(
     assert persisted["delivery_status"] == DELIVERY_SKIPPED_DISABLED
 
 
+def test_telegram_env_override_disables_yaml_enabled_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", "false")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\noutcome: proposal_created",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, "{}"),
+    )
+
+    assert record["delivery_status"] == DELIVERY_SKIPPED_DISABLED
+    assert request_calls == []
+
+
+def test_telegram_experiment_allowlist_blocks_fixture_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", "qqq_paper_daily")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\nexperiment: phase7_paper_fixture",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, "{}"),
+    )
+
+    assert record["delivery_status"] == DELIVERY_SKIPPED_DISABLED
+    assert request_calls == []
+
+
+def test_telegram_experiment_allowlist_allows_qqq_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True, symbol="QQQ")
+    config.experiment_name = "qqq_paper_daily"
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", "qqq_paper_daily")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", "http://127.0.0.1:9999")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\nexperiment: qqq_paper_daily",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, '{"ok": true}'),
+    )
+
+    assert record["delivery_status"] == DELIVERY_DELIVERED
+    assert len(request_calls) == 1
+
+
+def test_telegram_env_override_enables_yaml_disabled_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=False)
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", "true")
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", "http://127.0.0.1:9999")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\noutcome: proposal_created",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, '{"ok": true}'),
+    )
+
+    assert record["delivery_status"] == DELIVERY_DELIVERED
+    assert len(request_calls) == 1
+
+
 def test_enabled_telegram_notification_without_credentials_records_skip(
     monkeypatch,
     tmp_path: Path,
@@ -61,6 +157,8 @@ def test_enabled_telegram_notification_without_credentials_records_skip(
     store = PaperStateStore(config)
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("MARKETLAB_ENV_FILE", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
     monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
     monkeypatch.delenv("TELEGRAM_CHAT_ID", raising=False)
 
@@ -104,6 +202,8 @@ def test_successful_telegram_delivery_records_request_and_audit(
 
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
     monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", "http://127.0.0.1:9999")
 
     record = deliver_telegram_notification(
@@ -149,6 +249,8 @@ def test_failed_telegram_delivery_records_failure_without_raising(
 
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
 
     record = deliver_telegram_notification(
         config,
@@ -184,6 +286,8 @@ def test_successful_telegram_delivery_emits_structured_delivery_log(
 
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS", raising=False)
 
     deliver_telegram_notification(
         config,

--- a/tests/unit/test_paper_notifications.py
+++ b/tests/unit/test_paper_notifications.py
@@ -77,6 +77,51 @@ def test_telegram_env_override_disables_yaml_enabled_notifications(
     assert request_calls == []
 
 
+def test_telegram_empty_env_override_falls_back_to_yaml_enabled_notifications(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", "")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+    monkeypatch.setenv("MARKETLAB_TELEGRAM_API_BASE_URL", "http://127.0.0.1:9999")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\noutcome: proposal_created",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, '{"ok": true}'),
+    )
+
+    assert record["delivery_status"] == DELIVERY_DELIVERED
+    assert len(request_calls) == 1
+
+
+def test_telegram_invalid_env_override_skips_without_raising(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, telegram_enabled=True)
+    request_calls: list[tuple[str, dict[str, object], int]] = []
+    monkeypatch.setenv("MARKETLAB_PAPER_TELEGRAM_ENABLED", "not-a-bool")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat-id")
+
+    record = deliver_telegram_notification(
+        config,
+        stage="paper-decision",
+        outcome="proposal_created",
+        message="paper-decision\noutcome: proposal_created",
+        transport=lambda url, payload, timeout: request_calls.append((url, payload, timeout)) or (200, "{}"),
+    )
+
+    assert record["delivery_status"] == DELIVERY_SKIPPED_DISABLED
+    assert request_calls == []
+
+
 def test_telegram_experiment_allowlist_blocks_fixture_notifications(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary - load paper Telegram env controls before delivery decisions; add MARKETLAB_PAPER_TELEGRAM_ALLOWED_EXPERIMENTS so only qqq_paper_daily is eligible in local ops; keep fixture and smoke-test experiments from sending real Telegram messages; pass the controls through paper compose and docs. ## Validation - py -3.14 -m pytest targeted Telegram guard tests passed; py -3.14 -m tox -e preflight-fast passed; py -3.14 -m tox -e preflight passed lint/docs/typecheck/package/py312 and then hit the known Windows WinError 5 while recreating the integration tox env; direct offline integration fallback passed with 39 passed and 2 deselected.