### PR TITLE
docs: align documentation with current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # MarketLab
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly and daily supervised timing rows, walk-forward folds, trained models, rank-based ML strategies, periodic allocation baselines, executable mean-variance and risk-parity baselines, shared out-of-sample experiments, reviewable artifact summaries, and a local Alpaca paper-trading MVP for a configurable daily single-ETF timing loop.
+MarketLab is a package-first research toolkit for reproducible market experiments across ETF and crypto research lanes. The current implementation includes a working baseline-plus-ML workflow, a Docker-deployable MCP server, weekly, daily, and intraday supervised timing rows, walk-forward folds, trained models, rank-based and tiered ML strategies, periodic allocation baselines, executable mean-variance, risk-parity, and Black-Litterman baselines, shared out-of-sample experiments, reviewable artifact summaries, Phase 8 BTC/crypto diagnostics, and local Alpaca paper-trading MVPs for isolated ETF and BTC paper loops.
 
 See [docs/architecture.md](docs/architecture.md) for the system map, data contracts, execution flow, and extension rules.
 See [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md) for the SOLID-first technical-debt audit and the pre-cloud persistence-hardening roadmap.
 See [docs/service-extraction-readiness.md](docs/service-extraction-readiness.md) for the checklist used before extracting services, ports, or adapters.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
 See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
+See [docs/crypto-hourly-trend.md](docs/crypto-hourly-trend.md) and [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) for the Phase 8 crypto/BTC research lanes and strict paper-gating methodology.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.
 See [docs/codex-mcp.md](docs/codex-mcp.md) for attaching the Docker-packaged MCP server to a new Codex session.
 See [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md) for the VS Code stable + GitHub Copilot connection path.
-See [docs/PLAN.md](docs/PLAN.md) for the current project status and Phase 6 direction.
+See [docs/PLAN.md](docs/PLAN.md) for the current project status, Phase 8 direction, and Phase 9 boundary.
 
 ## Current Commands
 
@@ -24,6 +25,11 @@ python scripts/run_marketlab.py paper-decision --config configs/experiment.qqq_p
 python scripts/run_marketlab.py paper-agent-approve --config configs/experiment.qqq_paper_daily.yaml --once
 python scripts/run_marketlab.py paper-scheduler --config configs/experiment.qqq_paper_daily.yaml --once
 python scripts/run_marketlab.py paper-report --config configs/experiment.qqq_paper_daily.yaml --start 2026-04-13 --end 2026-05-15
+python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-selection-probe --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 ```
 
 `python scripts/run_marketlab.py ...` is the canonical local invocation path because it always resolves to the source tree under `src/`.
@@ -47,6 +53,11 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `paper-submit`: reconcile the approved proposal against the Alpaca paper account, refresh any previously submitted broker status, and persist either a submitted buy-side notional `DAY` market order, a submitted sell-side fractional `DAY` market order, a no-op, or a skipped submission.
 - `paper-scheduler`: run the long-lived local paper loop for the configured decision and submission windows.
 - `paper-report`: build a month-run paper report comparing the realized paper path, the consensus path, each model path, `buy_hold`, and `sma`.
+- `phase8-summary`: rebuild the deterministic Phase 8 strict-gate run summary from persisted artifacts.
+- `phase8-selection-probe`: run artifact-only selection coverage probes without retraining or changing the approved strict gate.
+- `phase8-bull-participation`: attribute bull-regime underparticipation from persisted Phase 8 artifacts and, when needed, the matching config.
+- `phase8-score-diagnostic`: inspect score compression, tier confusion, model-family behavior, and validation-vs-OOS score stability.
+- `phase8-bull-counterfactual`: write artifact-only bull-exposure counterfactuals that remain diagnostics, not deployment approvals.
 
 ## Artifact Outputs
 
@@ -312,6 +323,37 @@ Interpretation rules:
 Treat this config as a timing study, not as a cross-sectional ranking experiment. Compare its ML outputs primarily against `buy_hold` and `sma`, and do not read the results as evidence about cross-sectional ranking skill.
 
 The separate Phase 7 paper-trading path is now a configurable single-ETF loop. The tracked unattended-month config is `configs/experiment.qqq_paper_daily.yaml`, and `configs/experiment.voo_paper_daily.yaml` ships as the first alternate comparison config.
+
+## Phase 8 Crypto And BTC Research
+
+Phase 8 adds research-only crypto and BTC lanes that reuse the same package-first execution path while adding intraday timing, deterministic indicator and chart-pattern baselines, direct time-series ML, allocation-utility targets, tiered BTC exposure, and strict benchmark-relative acceptance gates.
+
+The tracked crypto research configs include:
+
+- `configs/experiment.crypto_hourly_trend.yaml`
+- `configs/experiment.crypto_15m_signal_week.yaml`
+- `configs/experiment.crypto_15m_patterns_week.yaml`
+- `configs/experiment.crypto_15m_patterns_day.yaml`
+- `configs/experiment.crypto_5m_patterns_day.yaml`
+- `configs/experiment.crypto_pattern_exit_tuned_2024_ytd.yaml`
+- `configs/experiment.crypto_pattern_meta_label_2024_ytd.yaml`
+- `configs/experiment.crypto_pattern_meta_tuned_2024_ytd.yaml`
+- `configs/experiment.crypto_ts_ml_2024_ytd.yaml`
+- `configs/experiment.crypto_indicator_ml_tuned_6h_2024_ytd.yaml`
+- `configs/experiment.crypto_indicator_ml_tuned_12h_2024_ytd.yaml`
+- `configs/experiment.crypto_indicator_ml_tuned_24h_2024_ytd.yaml`
+
+The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review.
+
+BTC paper uses its own tracked config and Docker shape:
+
+- `configs/experiment.btc_paper_daily.yaml`
+- `.env.btc-paper.example`
+- `docker/compose.btc-paper.yml`
+- `marketlab-btc-paper-mcp`, `marketlab-btc-paper-scheduler`, and `marketlab-btc-paper-agent`
+- `../artifacts-btc-paper` mounted to `/app/repo/artifacts`
+
+The Phase 8 diagnostic commands read persisted run artifacts and write review CSVs. They do not retrain models, change strategy weights, or approve Phase 9 paper deployment.
 
 ## Lightweight Model Comparison Set
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-Phases 1 through 6 are complete.
+Phases 1 through 7 are complete, and Phase 8 is active as a research-first crypto/BTC lane.
 
 MarketLab is a public research MVP with:
 
@@ -13,6 +13,8 @@ MarketLab is a public research MVP with:
 - release automation and a batched release path
 - richer Phase 5 baseline, diagnostics, and scenario-pack coverage
 - a Phase 7 local paper-trading MVP for a configurable daily single-ETF timing loop
+- Phase 8 crypto/BTC research configs, diagnostics, and strict paper-gating methodology
+- an isolated BTC paper stack that stays separated from the QQQ/VOO paper state
 
 The project now supports a small, reviewable end-to-end research workflow rather than a local-only scaffold.
 
@@ -32,6 +34,11 @@ The project now supports a small, reviewable end-to-end research workflow rather
 - `marketlab paper-submit --config ...`
 - `marketlab paper-scheduler --config ...`
 - `marketlab paper-report --config ... --start ... --end ...`
+- `marketlab phase8-summary --run-dir ...`
+- `marketlab phase8-selection-probe --run-dir ...`
+- `marketlab phase8-bull-participation --run-dir ... --config ...`
+- `marketlab phase8-score-diagnostic --run-dir ...`
+- `marketlab phase8-bull-counterfactual --run-dir ... --config ...`
 
 Current workflow surface:
 
@@ -47,6 +54,8 @@ Current workflow surface:
 - sandboxed config authoring, async job control, and run-artifact inspection for MCP clients
 - local file-backed paper-trading proposals, approvals, and submission state
 - local Docker Compose scheduling for the daily single-ETF paper loop
+- isolated BTC paper proposal, approval, and submission state under `artifacts/btc-paper` / `artifacts-btc-paper`
+- artifact-only Phase 8 diagnostic commands for post-run review
 
 ## Phase 4 Outcomes Worth Keeping
 
@@ -81,6 +90,22 @@ Priority direction:
 - tracked `QQQ` plus alternate `VOO` paper configs
 - month-run paper reporting against consensus, per-model paths, `buy_hold`, and `sma`
 - local Docker Compose scheduler and agent worker plus the Phase 7 operations runbook
+
+## Phase 8 Direction
+
+Phase 8 is a research lane for crypto and BTC timing, not a production trading lane. It extends the package-first research workflow with intraday bars, indicator-stack baselines, deterministic chart-pattern detectors, direct time-series ML, allocation-utility targets, BTC tiered exposure, and strict benchmark-relative diagnostics.
+
+Current Phase 8 rules:
+
+- use checked-in configs for repeatable BTC and crypto experiments
+- keep BTC exposure decisions limited to `0%`, `25%`, `50%`, or `100%`
+- compare selected strategies against BTC buy-and-hold plus static and rebalanced BTC/cash benchmarks
+- treat Phase 8 diagnostic commands as artifact review only
+- keep crypto/BTC paper work blocked unless the strict research gate passes
+
+## Phase 9 Boundary
+
+Phase 9 is an isolated BTC paper experiment, not an extension of the QQQ/VOO paper inbox. It uses `configs/experiment.btc_paper_daily.yaml`, `.env.btc-paper.example`, `docker/compose.btc-paper.yml`, `marketlab-btc-paper-mcp`, separate scheduler and agent container names, and separate artifact roots. The LLM approval role remains approve/reject only; it cannot invent trades or resize target exposure.
 
 ## Deferred
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-MarketLab is a package-first research toolkit for reproducible market experiments over a fixed ETF universe. The current implementation includes canonical market data, trailing features, weekly modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, a ranking strategy, three baseline strategies including periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input scaffolding, additive factor-attribution and covariance diagnostics, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Black-Litterman assumptions artifacts, a Docker-deployable MCP server surface, backtests, and reviewable artifacts.
+MarketLab is a package-first research toolkit for reproducible market experiments across ETF and crypto research lanes. The current implementation includes canonical market data, trailing and crypto-specific features, weekly, daily, and intraday modeling datasets, walk-forward fold generation, additive guardrail and embargo controls, skipped-fold diagnostics, a lightweight model registry, the `train-models` command, ranking-aware fold evaluation and downside diagnostics, calibration and threshold diagnostics, ranking and tiered-allocation strategies, periodic allocation baselines, executable long-only mean-variance, risk-parity, and Black-Litterman baselines, optimizer input scaffolding, additive factor-attribution and covariance diagnostics, unified `run-experiment` baseline-plus-ML comparison, fold and model summaries, exposure-aware strategy analytics artifacts, benchmark-relative reporting artifacts, turnover and cost-sensitivity diagnostics, Phase 8 BTC/crypto diagnostics, local ETF and BTC paper loops, a Docker-deployable MCP server surface, backtests, and reviewable artifacts.
 
 This document ties the current pieces together and records the working rules that should guide later iterations.
 
@@ -10,22 +10,24 @@ This document ties the current pieces together and records the working rules tha
 
 - In scope now:
   - canonical market panel preparation
-  - trailing feature engineering
-  - weekly modeling dataset generation
+  - trailing feature engineering, crypto time-series features, indicator-stack features, and regime features
+  - weekly, daily, and intraday modeling dataset generation
   - walk-forward fold generation with additive guardrails, embargo controls, and skipped-fold diagnostics
   - model registry for configured estimators
   - walk-forward `train-models` execution and artifact generation
-  - score-to-weight ranking strategies for ML portfolios, including long-short, long-only, confidence-gated cash-underfilled variants, and additive exposure caps
+  - score-to-weight ranking and tiered-allocation strategies for ML portfolios, including long-short, long-only, confidence-gated cash-underfilled variants, additive exposure caps, and BTC partial-exposure tiers
   - fold and model summary artifacts
   - ranking-aware model evaluation artifacts with downside diagnostics
   - calibration, score-histogram, and threshold-sweep diagnostics plus review plots
-  - `buy_hold`, `sma`, config-defined allocation baselines, the executable `mean_variance`, `risk_parity`, and `black_litterman` optimized baselines, plus additive factor and covariance diagnostics for review
+  - `buy_hold`, `sma`, config-defined allocation baselines, indicator-stack and chart-pattern baselines, static/rebalanced BTC partial-exposure baselines, the executable `mean_variance`, `risk_parity`, and `black_litterman` optimized baselines, plus additive factor and covariance diagnostics for review
   - unified `run-experiment` comparison across baselines and ML strategies on a shared OOS window
   - daily backtest with turnover-based costs
   - metrics, exposure-aware, benchmark-relative, and cost-sensitivity strategy analytics CSVs, plots, and Markdown reporting
+  - Phase 8 artifact-only diagnostics for strict-gate review, selection probes, bull participation, score behavior, and bull-exposure counterfactuals
+  - Phase 7 ETF paper trading plus isolated BTC paper state and Docker sidecars
   - required PR CI for lint, docs, packaging, unit tests, and offline integration tests
   - Docker packaging for the installed CLI plus a manual GitHub Actions Docker runner
-  - a stdio MCP server with sandboxed config authoring, queued workflow control, and artifact inspection
+  - a stdio MCP server with sandboxed config authoring, queued workflow control, artifact inspection, and paper proposal review
   - release automation with a monthly-batching Release PR and a PyPI publish path
   - fixture-backed tests and a real-data E2E runner that validates baseline, training, experiment, and analytics artifact sets
 - Deferred to later sprints:
@@ -37,6 +39,9 @@ This document ties the current pieces together and records the working rules tha
 - Local repo execution:
   - `python scripts/run_marketlab.py run-experiment --config configs/experiment.weekly_rank.yaml`
   - `python scripts/run_marketlab.py train-models --config configs/experiment.weekly_rank.yaml`
+  - `python scripts/run_marketlab.py run-experiment --config configs/experiment.crypto_ts_ml_2024_ytd.yaml`
+  - `python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>`
+  - `python scripts/run_marketlab.py phase8-selection-probe --run-dir artifacts/runs/<experiment>/<run-id>`
 - Installed package bootstrap:
   - `marketlab --version`
   - `marketlab list-configs`
@@ -47,6 +52,8 @@ This document ties the current pieces together and records the working rules tha
 - Dockerized MCP sidecar:
   - `docker compose -f docker/compose.mcp.yml up -d --build`
   - `docker exec -i marketlab-mcp marketlab-mcp --workspace-root /app/workspace --artifact-root /app/artifacts --repo-root /app/repo`
+  - `docker compose --env-file .env -f docker/compose.paper.yml up -d --build`
+  - `docker compose --env-file .env.btc-paper -f docker/compose.btc-paper.yml up -d --build`
   - Codex helper snippet: `docs/codex.config.toml.example`
   - workspace helper file: `.vscode/mcp.json.example`
   - documented clients: Codex and VS Code stable with GitHub Copilot Chat
@@ -72,6 +79,8 @@ The repo uses a `src/` layout. That means `python -m marketlab.cli ...` is not a
 The installed package uses bundled example config templates so a pip-installed user can bootstrap a working run config without needing the repository checkout. That keeps the distribution self-contained while preserving the repo-local launcher as the default development path.
 
 The Docker image deliberately uses the installed package entrypoints instead of the repo-local launcher. That split keeps local development pointed at the source tree while the container validates the packaged CLI and MCP paths.
+
+The BTC paper compose stack is intentionally separate from the ETF paper stack. It uses `marketlab-btc-paper-*` container names, `.env.btc-paper`, and a host `artifacts-btc-paper` mount so BTC paper proposals cannot share the QQQ/VOO approval inbox or state directory.
 
 ## Validation Flow
 
@@ -790,6 +799,17 @@ Best practice:
 - Keep the exposure policy explicit: default `long_short` uses `+0.5` total long and `-0.5` total short, while `long_only` uses `+1.0` total long exposure with any missing slots left in cash only when configured.
 - Treat the tracked `configs/experiment.voo_long_only.ytd.yaml` example as a directional timing configuration, not as a cross-sectional ranking benchmark.
 
+### Crypto And BTC Strategy Modules
+
+- `src/marketlab/strategies/indicator_stack.py` builds deterministic long/cash indicator baselines from trailing bar data.
+- `src/marketlab/strategies/chart_patterns.py` and `pattern_*` helpers implement chart-pattern research and overlays without subjective drawing.
+- `src/marketlab/strategies/tiered_allocation.py` maps BTC model scores into allowed `0%`, `25%`, `50%`, and `100%` exposure tiers with risk-off caps, holding periods, and hysteresis.
+- `src/marketlab/strategies/static_partial.py` and `rebalanced_partial.py` provide BTC/cash benchmark families so mostly-cash strategies cannot pass only by avoiding BTC drawdowns.
+
+Best practice:
+- Keep these strategies research-only until the documented Phase 8 strict gate passes.
+- Treat diagnostic fallbacks and counterfactuals as artifact review, not as production selection policy.
+
 ### `src/marketlab/backtest/engine.py`
 
 - Joins target weights to adjusted open and close data.
@@ -856,6 +876,24 @@ Best practice:
 
 Best practice:
 - Report modules should only render artifacts from already-computed outputs.
+
+### `src/marketlab/reports/phase8_*.py`
+
+- Rebuild Phase 8 run summaries, selection probes, bull participation diagnostics, score diagnostics, and bull counterfactuals from persisted artifacts.
+- Keep diagnostic outputs artifact-only: no model retraining, no strategy-weight rewrites, and no paper-deployment approval side effects.
+- Preserve the strict research gate as the source of truth for Phase 8 pass/fail review.
+
+### `src/marketlab/paper/*`
+
+- `paper/service.py` remains the compatibility facade for the paper command surface.
+- `paper/application/*` owns the phase-oriented services for decision, approval, submission, and reconciliation.
+- `paper/contracts.py` carries typed request and result contracts used by CLI, scheduler, agent, and MCP adapters.
+- `paper/persistence/*` provides filesystem and SQLite persistence implementations while preserving JSON artifacts as the review contract.
+- `paper/agent.py`, `paper/scheduler.py`, and MCP paper tools are entry adapters over the shared services.
+
+Best practice:
+- Keep ETF and BTC paper state roots isolated.
+- Do not let LLM approval paths invent trades or resize model-produced target exposure.
 
 ### `tests/`
 

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -35,6 +35,12 @@ docker compose -f docker/compose.mcp.yml up -d --build
 docker compose --env-file .env -f docker/compose.paper.yml up -d --build
 ```
 
+- BTC paper-review workflow:
+
+```bash
+docker compose --env-file .env.btc-paper -f docker/compose.btc-paper.yml up -d --build
+```
+
 On Linux, export the host UID/GID before starting either sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container, then run the matching compose command:
 
 ```bash
@@ -43,7 +49,7 @@ export MARKETLAB_GID="$(id -g)"
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-This creates a long-lived container named `marketlab-mcp` for the research sidecar or `marketlab-paper-mcp` for the paper-review sidecar. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
+This creates a long-lived container named `marketlab-mcp` for the research sidecar, `marketlab-paper-mcp` for the ETF paper-review sidecar, or `marketlab-btc-paper-mcp` for the isolated BTC paper-review sidecar. The MCP server itself is not started as a daemon. Each Codex session starts its own foreground stdio process through `docker exec -i`.
 
 If Docker access fails on Windows with a named-pipe permission error, fix Docker Desktop / daemon access first. Codex cannot attach the MCP server until `docker ps` works for the current user.
 
@@ -63,6 +69,8 @@ The example defines four servers:
 - `marketlab_paper_online`: paper-review sidecar plus `--allow-network`
 
 Use `marketlab` for normal cached-panel or cached-raw workflows. Use `marketlab_paper` when you want MCP to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
+
+For BTC paper review, reuse the same sample shape with container name `marketlab-btc-paper-mcp`, the same `--artifact-root /app/repo/artifacts`, and the config path `configs/experiment.btc_paper_daily.yaml` after starting `docker/compose.btc-paper.yml`. Keep this in a separate user-local MCP server entry if you need it regularly so BTC approval state cannot be confused with the QQQ/VOO paper sidecar.
 
 If the paper config enables `paper.notifications.telegram.enabled`, the paper compose stack also needs `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `.env`. `marketlab-paper-mcp` needs the same env because MCP approvals call the shared paper approval service and should emit the same notification side effects as the CLI and agent worker.
 
@@ -131,7 +139,7 @@ After updating `~/.codex/config.toml`, start a new Codex session in this repo an
 - If Codex does not show the server in `/mcp`, restart Codex after editing `~/.codex/config.toml`.
 - If `/debug-config` does not show the new server, check for a syntax error in `config.toml`.
 - If Codex cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
-- If the paper entry does not start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp`.
+- If the paper entry does not start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp` for ETF paper or `marketlab-btc-paper-mcp` for BTC paper.
 - If Docker access fails with a Windows named-pipe permission error, fix Docker daemon access for the current user before retrying.
 - If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If job planning says network is required, switch to `marketlab_online` or preload the raw cache / prepared panel.

--- a/docs/crypto-hourly-trend.md
+++ b/docs/crypto-hourly-trend.md
@@ -17,6 +17,9 @@ The tracked config is:
 - `configs/experiment.crypto_15m_patterns_week.yaml`
 - `configs/experiment.crypto_15m_patterns_day.yaml`
 - `configs/experiment.crypto_5m_patterns_day.yaml`
+- `configs/experiment.crypto_pattern_exit_tuned_2024_ytd.yaml`
+- `configs/experiment.crypto_pattern_meta_label_2024_ytd.yaml`
+- `configs/experiment.crypto_pattern_meta_tuned_2024_ytd.yaml`
 - `configs/experiment.crypto_ts_ml_2024_ytd.yaml`
 - `configs/experiment.crypto_indicator_ml_tuned_6h_2024_ytd.yaml`
 - `configs/experiment.crypto_indicator_ml_tuned_12h_2024_ytd.yaml`
@@ -344,3 +347,8 @@ stays blocked.
 Future crypto shadow-paper work must define provider and broker ports separately
 from the existing Alpaca ETF paper services. The Phase 7 paper bot remains daily,
 single-ETF, long/cash, and Alpaca-paper specific.
+
+BTC paper is tracked separately from this generic crypto research lane. Its
+config is `configs/experiment.btc_paper_daily.yaml`, its compose file is
+`docker/compose.btc-paper.yml`, and it must remain isolated from the QQQ/VOO
+paper inbox and artifacts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,12 @@ This site is the canonical home for MarketLab's public documentation.
 - [SOLID-First Architecture Audit](solid-architecture-audit.md)
 - [Service-Extraction Readiness Rules](service-extraction-readiness.md)
 - [Phase 5 Scenario Pack](phase5-scenarios.md)
+- [Phase 7 Paper Trading](paper-trading.md)
 - [Phase 8 Crypto Hourly Trend Signals](crypto-hourly-trend.md)
+- [BTC Phase 8 Methodology](btc-phase8-methodology.md)
+- [MCP Server](mcp-server.md)
+- [Codex MCP](codex-mcp.md)
+- [VS Code Copilot MCP](mcp-vscode-copilot.md)
 - [Plan](PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -76,6 +76,7 @@ Example helper files:
 
 - `docker/compose.mcp.yml`
 - `docker/compose.paper.yml`
+- `docker/compose.btc-paper.yml`
 - `docs/codex.config.toml.example`
 - `.vscode/mcp.json.example`
 
@@ -104,6 +105,13 @@ docker exec -i marketlab-mcp \
 ```
 
 This is the intended bridge for generic MCP clients. The client owns the stdio session lifetime; the container just provides the packaged `marketlab-mcp` executable plus the mounted workspace and artifact volumes.
+
+Paper review sidecars use the same stdio server contract with different container names and artifact roots:
+
+- ETF paper review: `marketlab-paper-mcp` with `--artifact-root /app/repo/artifacts`
+- BTC paper review: `marketlab-btc-paper-mcp` with `../artifacts-btc-paper` mounted to `/app/repo/artifacts`
+
+The MCP paper tools remain review-and-approval tools only. Order submission continues through the CLI-backed scheduler path.
 
 For the Codex setup flow, see [Codex MCP Setup](codex-mcp.md).
 For the supported VS Code stable + GitHub Copilot setup, see [VS Code Copilot MCP Setup](mcp-vscode-copilot.md).

--- a/docs/mcp-vscode-copilot.md
+++ b/docs/mcp-vscode-copilot.md
@@ -35,6 +35,12 @@ docker compose -f docker/compose.mcp.yml up -d --build
 docker compose --env-file .env -f docker/compose.paper.yml up -d --build
 ```
 
+- BTC paper-review workflow:
+
+```bash
+docker compose --env-file .env.btc-paper -f docker/compose.btc-paper.yml up -d --build
+```
+
 On Linux, export the host UID/GID before starting either sidecar so the bind-mounted `workspace/` and `artifacts/` directories stay writable inside the container, then run the matching compose command:
 
 ```bash
@@ -43,7 +49,7 @@ export MARKETLAB_GID="$(id -g)"
 docker compose -f docker/compose.mcp.yml up -d --build
 ```
 
-This creates a long-lived container named `marketlab-mcp` for the research sidecar or `marketlab-paper-mcp` for the paper-review sidecar. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
+This creates a long-lived container named `marketlab-mcp` for the research sidecar, `marketlab-paper-mcp` for the ETF paper-review sidecar, or `marketlab-btc-paper-mcp` for the isolated BTC paper-review sidecar. The MCP server itself is not started as a daemon. Each Copilot session starts its own foreground stdio process through `docker exec -i`.
 
 ## Add The VS Code MCP Config
 
@@ -67,6 +73,8 @@ The sample defines four servers:
 - `marketlab-paper-docker-online`: paper-review sidecar plus `--allow-network`
 
 Use `marketlab-docker-offline` for normal cached-panel or cached-raw workflows. Use `marketlab-paper-docker-offline` when you want Copilot to inspect the same proposal, approval, and submission state that the paper scheduler and agent containers are writing under `/app/repo/artifacts`.
+
+For BTC paper review, use the same stdio shape with container name `marketlab-btc-paper-mcp`, `--artifact-root /app/repo/artifacts`, and `configs/experiment.btc_paper_daily.yaml` after starting `docker/compose.btc-paper.yml`. Keep a separate local server entry for that flow if you need it, rather than repointing the QQQ/VOO paper entry.
 
 If the paper config enables `paper.notifications.telegram.enabled`, the paper compose stack also needs `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `.env`. `marketlab-paper-mcp` needs the same env because MCP approvals use the shared paper approval service and should emit the same notification side effects as the CLI and agent worker.
 
@@ -139,7 +147,7 @@ After copying `.vscode/mcp.json` and reloading VS Code:
 ## Troubleshooting
 
 - If VS Code cannot start the server, run `docker ps` and verify the container name is exactly `marketlab-mcp`.
-- If the paper entry cannot start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp`.
+- If the paper entry cannot start, verify the paper stack is up and the container name is exactly `marketlab-paper-mcp` for ETF paper or `marketlab-btc-paper-mcp` for BTC paper.
 - If Copilot connects but job planning says network is required, switch to the online server or preload the raw cache / prepared panel.
 - If config writes fail on Linux, make sure `MARKETLAB_UID` and `MARKETLAB_GID` match `id -u` and `id -g` before starting the compose sidecar.
 - If config writes fail, verify the host `workspace/` and `artifacts/` directories exist and are writable on the host.

--- a/docs/solid-architecture-audit.md
+++ b/docs/solid-architecture-audit.md
@@ -12,6 +12,7 @@ This audit complements:
 - [Service-Extraction Readiness Rules](service-extraction-readiness.md) for the
   decision checklist used before adding service, port, or adapter boundaries
 - [Phase 7 Paper Trading](paper-trading.md) for the local paper runtime
+- [BTC Phase 8 Methodology](btc-phase8-methodology.md) for the current BTC research gate and isolated paper boundary
 - `CLOUD_MIGRATION_PLAN.md` at the repo root for the later hosted deployment path
 
 ## Locked Design Posture
@@ -116,6 +117,9 @@ Do not do:
 Targets:
 
 - `src/marketlab/paper/service.py`
+- `src/marketlab/paper/application/*`
+- `src/marketlab/paper/contracts.py`
+- `src/marketlab/paper/persistence/*`
 - `src/marketlab/paper/agent.py`
 - `src/marketlab/paper/scheduler.py`
 - `src/marketlab/paper/alpaca.py`
@@ -125,27 +129,23 @@ Targets:
 Current assessment:
 
 - this is the highest-risk part of the codebase for the next phase
-- `paper/service.py` is the main orchestration hotspot and currently carries too many responsibilities
-- `paper/agent.py` mixes worker control, provider policy, prompting, fallback behavior, and approval orchestration
-- scheduler and agent loops are acceptable as local adapters, but they should not own business rules
-- the current filesystem-first state model is workable for the laptop flow, but it is too tightly coupled to orchestration logic for a future transactional runtime
+- the first service split has landed: decision, approval, submission, and reconciliation now live behind application-service classes while `paper/service.py` remains the compatibility facade
+- persistence has explicit filesystem and SQLite implementations, but file-backed JSON artifacts still remain the review and debugging contract
+- `paper/agent.py`, scheduler, CLI, and MCP are acceptable local adapters as long as they keep delegating to application services
+- the BTC paper path is intentionally isolated from QQQ/VOO state, but it still shares the same approve/reject-only control-plane shape
 
 Keep:
 
 - explicit phase language: `decision`, `agent_approve`, `submit`, `reconcile`
 - reviewable artifacts and deterministic fallback semantics
 - adapters for local scheduler and local agent loops
+- separate ETF and BTC paper state roots
 
 Harden:
 
-- split phase orchestration into application services:
-  - `DecisionService`
-  - `ApprovalService`
-  - `SubmissionService`
-  - `ReconciliationService`
-- move Alpaca, Telegram, artifact writing, and provider calls behind explicit interfaces
+- keep moving Alpaca, Telegram, artifact writing, broker submission, and provider calls behind explicit interfaces
 - make scheduler, CLI, MCP, and agent worker thin entry adapters over the same one-shot service contracts
-- define typed request/response objects for each phase instead of relying on raw dicts and ad hoc file payloads
+- keep typed request/response objects for each phase rather than adding new raw dict payloads
 - preserve current paper-state artifact semantics while transactional persistence is being introduced, so parity can be proven before any source-of-truth transition
 
 ### MCP And Ops Tooling
@@ -161,7 +161,7 @@ Current assessment:
 
 - MCP is correctly positioned as an ops and review surface, not the execution backend
 - `mcp/jobs.py` is a local in-process queue for repo workflows; it should not become the production control-plane model
-- MCP tools should stay thin and call application services rather than growing their own runtime logic
+- MCP tools stay thin today and paper approval/status calls route through the shared paper service layer
 
 Keep:
 
@@ -190,7 +190,7 @@ Targets:
 Current assessment:
 
 - the repo has meaningful behavioral coverage, especially around the paper path
-- static typing is not enforced today; that is a real gap for the next phase
+- static typing is enforced through the current tox/CI typecheck lane for selected package surfaces
 - many tests still prove behavior through filesystem artifacts, which is useful, but not enough for a future DB-backed control plane
 
 Keep:
@@ -200,7 +200,7 @@ Keep:
 
 Harden:
 
-- add a real type-check gate to tox and CI
+- keep the type-check gate aligned with new typed paper modules when package surfaces move
 - add contract tests for phase services, repositories, and adapters
 - keep artifact parity tests while adding persistence-agnostic service tests
 - prepare for multi-adapter testing of the same repository contracts

--- a/tests/unit/test_phase8_issue_seed.py
+++ b/tests/unit/test_phase8_issue_seed.py
@@ -31,4 +31,31 @@ def test_phase8_docs_are_linked_from_mkdocs_nav() -> None:
     nav_text = Path("mkdocs.yml").read_text(encoding="utf-8")
 
     assert "Phase 8 Crypto Hourly Trend: crypto-hourly-trend.md" in nav_text
+    assert "BTC Phase 8 Methodology: btc-phase8-methodology.md" in nav_text
     assert Path("docs/crypto-hourly-trend.md").exists()
+    assert Path("docs/btc-phase8-methodology.md").exists()
+
+
+def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    plan = Path("docs/PLAN.md").read_text(encoding="utf-8")
+
+    for content in (readme, plan):
+        assert "Phase 8" in content
+        assert "phase8-summary" in content
+        assert "phase8-selection-probe" in content
+        assert "phase8-bull-counterfactual" in content
+        assert "configs/experiment.btc_paper_daily.yaml" in content
+        assert "docker/compose.btc-paper.yml" in content
+        assert "marketlab-btc-paper-mcp" in content
+
+
+def test_mcp_docs_describe_btc_paper_sidecar_without_changing_samples() -> None:
+    mcp_server = Path("docs/mcp-server.md").read_text(encoding="utf-8")
+    codex = Path("docs/codex-mcp.md").read_text(encoding="utf-8")
+    vscode = Path("docs/mcp-vscode-copilot.md").read_text(encoding="utf-8")
+
+    for content in (mcp_server, codex, vscode):
+        assert "docker/compose.btc-paper.yml" in content
+        assert "marketlab-btc-paper-mcp" in content
+        assert "/app/repo/artifacts" in content


### PR DESCRIPTION
## Summary
- refresh README, plan, architecture, and audit docs for current Phase 8/BTC surfaces
- document BTC paper sidecar boundaries across MCP/Codex/VS Code docs
- add docs guard coverage for Phase 8 and BTC paper references

## Validation
- python -m pytest -q tests/unit/test_service_extraction_readiness_docs.py tests/unit/test_phase8_issue_seed.py tests/unit/test_mcp_codex_config.py tests/unit/test_mcp_vscode_config.py -o addopts="-p no:cacheprovider" --basetemp C:\Users\ricar\AppData\Local\Temp\marketlab_pytest_docs
- python -m tox -e docs
- python -m tox -e lint
- python -m pytest -q tests/unit/test_profile_validation.py -o addopts="-p no:cacheprovider" --basetemp C:\Users\ricar\AppData\Local\Temp\marketlab_pytest_profile