### PR TITLE
Quiet sklearn and pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--basetemp=.pytest_tmp -p no:cacheprovider"
+addopts = "--basetemp=artifacts/pytest-tmp -p no:cacheprovider -p no:asyncio"
 markers = [
   "real_data: opt-in tests that download real market data.",
   "network: tests that depend on external network access.",

--- a/src/marketlab/models/registry.py
+++ b/src/marketlab/models/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+import os
 from dataclasses import dataclass
 from typing import Callable
 
@@ -46,27 +48,40 @@ def _logistic_regression() -> ClassifierMixin:
     )
 
 
+def _uses_logistic_l1_ratio_api() -> bool:
+    penalty = inspect.signature(LogisticRegression).parameters.get("penalty")
+    return penalty is not None and penalty.default == "deprecated"
+
+
+def _logistic_l1_parameters(*, solver: str, max_iter: int) -> dict[str, object]:
+    parameters: dict[str, object] = {
+        "solver": solver,
+        "max_iter": max_iter,
+        "random_state": 7,
+    }
+    if _uses_logistic_l1_ratio_api():
+        parameters["l1_ratio"] = 1.0
+    else:
+        parameters["penalty"] = "l1"
+    return parameters
+
+
+def _parallel_n_jobs() -> int:
+    os.environ.setdefault("LOKY_MAX_CPU_COUNT", str(os.cpu_count() or 1))
+    return -1
+
+
 def _logistic_l1() -> ClassifierMixin:
     return make_pipeline(
         StandardScaler(),
-        LogisticRegression(
-            penalty="l1",
-            solver="liblinear",
-            max_iter=1000,
-            random_state=7,
-        ),
+        LogisticRegression(**_logistic_l1_parameters(solver="liblinear", max_iter=1000)),
     )
 
 
 def _logistic_l1_multiclass() -> ClassifierMixin:
     return make_pipeline(
         StandardScaler(),
-        LogisticRegression(
-            penalty="l1",
-            solver="saga",
-            max_iter=2000,
-            random_state=7,
-        ),
+        LogisticRegression(**_logistic_l1_parameters(solver="saga", max_iter=2000)),
     )
 
 
@@ -74,7 +89,7 @@ def _random_forest() -> ClassifierMixin:
     return RandomForestClassifier(
         n_estimators=200,
         min_samples_leaf=3,
-        n_jobs=-1,
+        n_jobs=_parallel_n_jobs(),
         random_state=7,
     )
 
@@ -83,7 +98,7 @@ def _extra_trees() -> ClassifierMixin:
     return ExtraTreesClassifier(
         n_estimators=200,
         min_samples_leaf=3,
-        n_jobs=-1,
+        n_jobs=_parallel_n_jobs(),
         random_state=7,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 import pytest
+
+os.environ.setdefault("LOKY_MAX_CPU_COUNT", "1")
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -84,6 +87,37 @@ def test_regime_state_models_fit_and_score_expected_allocation(
         "prob_tier_100",
     ]
     assert probabilities.sum(axis=1).round(6).eq(1.0).all()
+
+
+@pytest.mark.parametrize(
+    ("target_type", "target"),
+    [
+        ("direction", TARGET),
+        ("allocation_utility", pd.Series([0, 1, 1, 2, 3, 3], dtype=int)),
+    ],
+)
+def test_logistic_l1_models_fit_without_future_warnings(
+    target_type: str,
+    target: pd.Series,
+) -> None:
+    _, estimator = build_model_estimator("logistic_l1", target_type)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        estimator.fit(FEATURES, target)
+
+
+@pytest.mark.parametrize("model_name", ["extra_trees", "random_forest"])
+def test_parallel_tree_models_configure_loky_cpu_count(
+    model_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOKY_MAX_CPU_COUNT", raising=False)
+
+    _, estimator = build_model_estimator(model_name, "direction")
+
+    assert estimator.n_jobs == -1
+    assert os.environ["LOKY_MAX_CPU_COUNT"] == str(os.cpu_count() or 1)
 
 
 def test_unknown_model_name_raises_clear_error() -> None:


### PR DESCRIPTION
Summary: adapts logistic L1 sklearn settings, sets joblib CPU-count defaults, and quiets pytest plugin and temp-directory noise. Validation: python -W error -m pytest -q tests/unit/test_models.py, python -m pytest -q tests/unit, python -m ruff check ., python -m mkdocs build --strict.