### PR TITLE
Phase 8 guarded gate-bull cost robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md) for the
 See [docs/service-extraction-readiness.md](docs/service-extraction-readiness.md) for the checklist used before extracting services, ports, or adapters.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
 See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
-See [docs/crypto-hourly-trend.md](docs/crypto-hourly-trend.md), [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md), and [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md) for the Phase 8 crypto/BTC research lanes, strict paper-gating methodology, and current BTC bull-upside plan.
+See [docs/crypto-hourly-trend.md](docs/crypto-hourly-trend.md), [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md), [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md), and [docs/phase8/BTC/shadow-confirmation-plan.md](docs/phase8/BTC/shadow-confirmation-plan.md) for the Phase 8 crypto/BTC research lanes, strict paper-gating methodology, current BTC bull-upside plan, and locked shadow-confirmation handoff.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.
 See [docs/codex-mcp.md](docs/codex-mcp.md) for attaching the Docker-packaged MCP server to a new Codex session.
 See [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md) for the VS Code stable + GitHub Copilot connection path.
@@ -353,7 +353,7 @@ The tracked crypto research configs include:
 - `configs/experiment.crypto_indicator_ml_tuned_12h_2024_ytd.yaml`
 - `configs/experiment.crypto_indicator_ml_tuned_24h_2024_ytd.yaml`
 
-The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review. `configs/experiment.btc_phase8_methodology_review.yaml` records the strict methodology review, and the current target/score, regime-policy, and score-transform experiments are tracked from [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md).
+The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review. `configs/experiment.btc_phase8_methodology_review.yaml` records the strict methodology review, the current target/score, regime-policy, and score-transform experiments are tracked from [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md), and the locked historical challenger handoff is defined in [docs/phase8/BTC/shadow-confirmation-plan.md](docs/phase8/BTC/shadow-confirmation-plan.md).
 
 BTC paper uses its own tracked config and Docker shape:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/ru
 python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-target-profile-sweep --config configs/<experiment>.yaml --output artifacts/runs/phase8_btc_target_profile_sweep.csv
 python scripts/run_marketlab.py phase8-regime-policy-sweep --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
@@ -63,6 +64,7 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `phase8-score-diagnostic`: inspect score compression, tier confusion, model-family behavior, and validation-vs-OOS score stability.
 - `phase8-target-diagnostic`: inspect target and prediction behavior across bull-continuation and drawdown-defense rows without retraining.
 - `phase8-bull-counterfactual`: write artifact-only bull-exposure counterfactuals that remain diagnostics, not deployment approvals.
+- `phase8-target-profile-sweep`: deterministically compare allocation-utility target penalties and record the first profile with strict-gate partial-tier support before launching another expensive training batch.
 - `phase8-regime-policy-sweep`: test completed-bar BTC regime exposure policies against persisted run artifacts before launching another expensive training batch.
 - `phase8-methodology-review`: consolidate strict-gate, benchmark-family, score-validity, bull-participation, and counterfactual diagnostics into one methodology review CSV.
 - `phase8-grid-compare`: compare completed BTC Phase 8 runs across strict-gate status, bull-upside capture, downside capture, score validity, counterfactual hypotheses, and conservative artifact-pruning recommendations.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experim
 python scripts/run_marketlab.py phase8-selection-probe --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-regime-policy-sweep --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
 ```
@@ -59,7 +61,9 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `phase8-selection-probe`: run artifact-only selection coverage probes without retraining or changing the approved strict gate.
 - `phase8-bull-participation`: attribute bull-regime underparticipation from persisted Phase 8 artifacts and, when needed, the matching config.
 - `phase8-score-diagnostic`: inspect score compression, tier confusion, model-family behavior, and validation-vs-OOS score stability.
+- `phase8-target-diagnostic`: inspect target and prediction behavior across bull-continuation and drawdown-defense rows without retraining.
 - `phase8-bull-counterfactual`: write artifact-only bull-exposure counterfactuals that remain diagnostics, not deployment approvals.
+- `phase8-regime-policy-sweep`: test completed-bar BTC regime exposure policies against persisted run artifacts before launching another expensive training batch.
 - `phase8-methodology-review`: consolidate strict-gate, benchmark-family, score-validity, bull-participation, and counterfactual diagnostics into one methodology review CSV.
 - `phase8-grid-compare`: compare completed BTC Phase 8 runs across strict-gate status, bull-upside capture, downside capture, score validity, counterfactual hypotheses, and conservative artifact-pruning recommendations.
 
@@ -347,7 +351,7 @@ The tracked crypto research configs include:
 - `configs/experiment.crypto_indicator_ml_tuned_12h_2024_ytd.yaml`
 - `configs/experiment.crypto_indicator_ml_tuned_24h_2024_ytd.yaml`
 
-The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review. `configs/experiment.btc_phase8_methodology_review.yaml` records the current strict methodology review. The next BTC bull-upside grid is tracked in `configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml`, `configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml`, and `configs/experiment.btc_phase8_bull_capture_static_audit.yaml`; see [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md).
+The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review. `configs/experiment.btc_phase8_methodology_review.yaml` records the strict methodology review, and the current target/score, regime-policy, and score-transform experiments are tracked from [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md).
 
 BTC paper uses its own tracked config and Docker shape:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See [docs/solid-architecture-audit.md](docs/solid-architecture-audit.md) for the
 See [docs/service-extraction-readiness.md](docs/service-extraction-readiness.md) for the checklist used before extracting services, ports, or adapters.
 See [docs/how-it-works.md](docs/how-it-works.md) for a narrative walkthrough of the library and the `voo_long_only_ytd` timing example.
 See [docs/paper-trading.md](docs/paper-trading.md) for the Phase 7 daily single-ETF paper-trading loop and local Docker Compose shape.
-See [docs/crypto-hourly-trend.md](docs/crypto-hourly-trend.md) and [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) for the Phase 8 crypto/BTC research lanes and strict paper-gating methodology.
+See [docs/crypto-hourly-trend.md](docs/crypto-hourly-trend.md), [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md), and [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md) for the Phase 8 crypto/BTC research lanes, strict paper-gating methodology, and current BTC bull-upside plan.
 See [docs/mcp-server.md](docs/mcp-server.md) for the MCP tool surface and the Docker sidecar pattern.
 See [docs/codex-mcp.md](docs/codex-mcp.md) for attaching the Docker-packaged MCP server to a new Codex session.
 See [docs/mcp-vscode-copilot.md](docs/mcp-vscode-copilot.md) for the VS Code stable + GitHub Copilot connection path.
@@ -30,6 +30,8 @@ python scripts/run_marketlab.py phase8-selection-probe --run-dir artifacts/runs/
 python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
 ```
 
 `python scripts/run_marketlab.py ...` is the canonical local invocation path because it always resolves to the source tree under `src/`.
@@ -58,6 +60,8 @@ marketlab-mcp --workspace-root ./workspace --artifact-root ./artifacts --repo-ro
 - `phase8-bull-participation`: attribute bull-regime underparticipation from persisted Phase 8 artifacts and, when needed, the matching config.
 - `phase8-score-diagnostic`: inspect score compression, tier confusion, model-family behavior, and validation-vs-OOS score stability.
 - `phase8-bull-counterfactual`: write artifact-only bull-exposure counterfactuals that remain diagnostics, not deployment approvals.
+- `phase8-methodology-review`: consolidate strict-gate, benchmark-family, score-validity, bull-participation, and counterfactual diagnostics into one methodology review CSV.
+- `phase8-grid-compare`: compare completed BTC Phase 8 runs across strict-gate status, bull-upside capture, downside capture, score validity, counterfactual hypotheses, and conservative artifact-pruning recommendations.
 
 ## Artifact Outputs
 
@@ -343,7 +347,7 @@ The tracked crypto research configs include:
 - `configs/experiment.crypto_indicator_ml_tuned_12h_2024_ytd.yaml`
 - `configs/experiment.crypto_indicator_ml_tuned_24h_2024_ytd.yaml`
 
-The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review.
+The BTC Phase 8 configs under `configs/experiment.btc_phase8_*.yaml` are not a shortcut into live or paper trading. They must satisfy the strict research gate documented in [docs/btc-phase8-methodology.md](docs/btc-phase8-methodology.md) before the isolated BTC paper path is treated as eligible for deployment review. `configs/experiment.btc_phase8_methodology_review.yaml` records the current strict methodology review. The next BTC bull-upside grid is tracked in `configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml`, `configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml`, and `configs/experiment.btc_phase8_bull_capture_static_audit.yaml`; see [docs/phase8/BTC/bull-upside-methodology.md](docs/phase8/BTC/bull-upside-methodology.md).
 
 BTC paper uses its own tracked config and Docker shape:
 
@@ -353,7 +357,7 @@ BTC paper uses its own tracked config and Docker shape:
 - `marketlab-btc-paper-mcp`, `marketlab-btc-paper-scheduler`, and `marketlab-btc-paper-agent`
 - `../artifacts-btc-paper` mounted to `/app/repo/artifacts`
 
-The Phase 8 diagnostic commands read persisted run artifacts and write review CSVs. They do not retrain models, change strategy weights, or approve Phase 9 paper deployment.
+The Phase 8 diagnostic commands read persisted run artifacts and write review CSVs. They do not retrain models, change strategy weights, or approve Phase 9 paper deployment. `phase8_methodology_review.csv` separates the unchanged deployment gate from risk-allocation, target-support, signal-validity, bull-participation, and diagnostic-only counterfactual hypotheses. `phase8_btc_grid_comparison.csv` compares BTC Phase 8 runs and marks incomplete artifact directories as review/pruning candidates without deleting files.
 
 ## Lightweight Model Comparison Set
 

--- a/configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml
+++ b/configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml
@@ -1,0 +1,172 @@
+experiment_name: btc_phase8_bull_capture_prob100_grid
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold: 0.16
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.5
+      - name: "vol_sensitive_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.50
+        risk_penalty_power: 2.5
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "none"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml
+++ b/configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml
@@ -1,0 +1,176 @@
+experiment_name: btc_phase8_bull_capture_rebalanced_gate
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull50_sideways25"
+        bull_floor: 0.50
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.5
+      - name: "vol_sensitive_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.50
+        risk_penalty_power: 2.5
+    allocation_class_weighting: "balanced_partial_boost"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_capture_static_audit.yaml
+++ b/configs/experiment.btc_phase8_bull_capture_static_audit.yaml
@@ -1,0 +1,176 @@
+experiment_name: btc_phase8_bull_capture_static_audit
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull50_sideways25"
+        bull_floor: 0.50
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.5
+      - name: "vol_sensitive_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.50
+        risk_penalty_power: 2.5
+    allocation_class_weighting: "balanced_partial_boost"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_low_turnover.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_low_turnover.yaml
@@ -1,0 +1,173 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_low_turnover
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [18, 36, 54]
+    hysteresis_margin_grid: [0.02, 0.04]
+    regime_participation_policies:
+      - name: "bull100_sideways25_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+      - name: "bull100_sideways50_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+    no_valid_candidate_regime_fallback: "bull100_sideways25_gate_bull100"
+    max_annualized_turnover: 12.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_override.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_override.yaml
@@ -1,0 +1,173 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_override
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+      - name: "bull100_sideways50_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+    no_valid_candidate_regime_fallback: "bull100_sideways25_gate_bull100"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml
@@ -1,0 +1,172 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_prob100_score_validity
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml
@@ -1,0 +1,172 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [18, 36, 54]
+    hysteresis_margin_grid: [0.02, 0.04]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 12.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml
@@ -1,0 +1,172 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "none"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_riskoff0.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_riskoff0.yaml
@@ -1,0 +1,179 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_riskoff0
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways0_gate_bull100_riskoff0"
+        bull_floor: 1.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.0
+        gate_bull_floor: 1.0
+      - name: "bull100_sideways25_gate_bull100_riskoff0"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.0
+        gate_bull_floor: 1.0
+      - name: "bull100_sideways50_gate_bull100_riskoff0"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.0
+        gate_bull_floor: 1.0
+    no_valid_candidate_regime_fallback: "bull100_sideways25_gate_bull100_riskoff0"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_gate_bull_score_validity.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_gate_bull_score_validity.yaml
@@ -1,0 +1,173 @@
+experiment_name: btc_phase8_bull_floor_gate_bull_score_validity
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+      - name: "bull100_sideways50_gate_bull100"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+        gate_bull_floor: 1.0
+    no_valid_candidate_regime_fallback: "bull100_sideways25_gate_bull100"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml
@@ -1,0 +1,189 @@
+experiment_name: btc_phase8_bull_floor_score_boost_fallback
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+    allocation_score_transforms:
+      - name: "identity"
+      - name: "bull_shift_10"
+        bull_addend: 0.10
+      - name: "bull_shift_18"
+        bull_addend: 0.18
+      - name: "bull_mult115_shift10"
+        bull_multiplier: 1.15
+        bull_addend: 0.10
+      - name: "bull_mult125_shift10"
+        bull_multiplier: 1.25
+        bull_addend: 0.10
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml
@@ -1,0 +1,189 @@
+experiment_name: btc_phase8_bull_floor_score_boost_long_train
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [1095, 1460]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+    allocation_score_transforms:
+      - name: "identity"
+      - name: "bull_shift_10"
+        bull_addend: 0.10
+      - name: "bull_shift_18"
+        bull_addend: 0.18
+      - name: "bull_mult115_shift10"
+        bull_multiplier: 1.15
+        bull_addend: 0.10
+      - name: "bull_mult125_shift10"
+        bull_multiplier: 1.25
+        bull_addend: 0.10
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml
@@ -1,0 +1,189 @@
+experiment_name: btc_phase8_bull_floor_score_boost_uncalibrated
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "none"
+    allocation_calibration_cv: 3
+    allocation_score_transforms:
+      - name: "identity"
+      - name: "bull_shift_10"
+        bull_addend: 0.10
+      - name: "bull_shift_18"
+        bull_addend: 0.18
+      - name: "bull_mult115_shift10"
+        bull_multiplier: 1.15
+        bull_addend: 0.10
+      - name: "bull_mult125_shift10"
+        bull_multiplier: 1.25
+        bull_addend: 0.10
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_score_validity_selection.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_score_validity_selection.yaml
@@ -1,0 +1,171 @@
+experiment_name: btc_phase8_bull_floor_score_validity_selection
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_floor_signal_return_capture_fallback.yaml
+++ b/configs/experiment.btc_phase8_bull_floor_signal_return_capture_fallback.yaml
@@ -1,0 +1,177 @@
+experiment_name: btc_phase8_bull_floor_signal_return_capture_fallback
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_bull_signal_feature_utility.yaml
+++ b/configs/experiment.btc_phase8_bull_signal_feature_utility.yaml
@@ -1,0 +1,171 @@
+experiment_name: btc_phase8_bull_signal_feature_utility
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml
+++ b/configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml
@@ -1,0 +1,173 @@
+experiment_name: btc_phase8_guarded_cost_robust_selector
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    selection_validation_cost_bps: [35, 50]
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml
+++ b/configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml
@@ -1,0 +1,174 @@
+experiment_name: btc_phase8_guarded_gate_bull_risk_off_override
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    selection_validation_cost_bps: [35, 50]
+    guarded_gate_bull_risk_off_override: true
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml
+++ b/configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml
@@ -1,0 +1,166 @@
+experiment_name: btc_phase8_guarded_gate_bull_risk_off_override_partial_support
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.75
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    selection_validation_cost_bps: [35, 50]
+    guarded_gate_bull_risk_off_override: true
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_support_dd075"
+        drawdown_penalty: 0.75
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_methodology_review.yaml
+++ b/configs/experiment.btc_phase8_methodology_review.yaml
@@ -1,0 +1,176 @@
+experiment_name: btc_phase8_methodology_review
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "strict"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull50_sideways25"
+        bull_floor: 0.50
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.5
+      - name: "vol_sensitive_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.50
+        risk_penalty_power: 2.5
+    allocation_class_weighting: "balanced_partial_boost"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_prob100_signal_threshold_fallback.yaml
+++ b/configs/experiment.btc_phase8_prob100_signal_threshold_fallback.yaml
@@ -1,0 +1,175 @@
+experiment_name: btc_phase8_prob100_signal_threshold_fallback
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold: 0.20
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.5
+      - name: "vol_sensitive_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.50
+        risk_penalty_power: 2.5
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "none"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_regime_floor_state_fallback.yaml
+++ b/configs/experiment.btc_phase8_regime_floor_state_fallback.yaml
@@ -1,0 +1,177 @@
+experiment_name: btc_phase8_regime_floor_state_fallback
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "regime_state"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull75_sideways25"
+        bull_floor: 0.75
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_regime_state_bull_signal.yaml
+++ b/configs/experiment.btc_phase8_regime_state_bull_signal.yaml
@@ -1,0 +1,171 @@
+experiment_name: btc_phase8_regime_state_bull_signal
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "regime_state"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/configs/experiment.btc_phase8_target_return_capture_utility.yaml
+++ b/configs/experiment.btc_phase8_target_return_capture_utility.yaml
@@ -1,0 +1,171 @@
+experiment_name: btc_phase8_target_return_capture_utility
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2026-05-07"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase8-1d-long"
+  prepared_panel_filename: "btc_usd_1d_long_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_rsi_window: 14
+  crypto_macd_fast_window: 12
+  crypto_macd_slow_window: 26
+  crypto_macd_signal_window: 9
+  crypto_bollinger_window: 20
+  crypto_bollinger_std: 2.0
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: false
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.50
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "expected_allocation"
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "model_only"
+        bull_floor: 0.0
+        sideways_floor: 0.0
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    max_annualized_turnover: 24.0
+    objective: "net_return_and_risk_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "return_capture_p15"
+        drawdown_penalty: 0.15
+        volatility_penalty: 0.05
+        risk_penalty_power: 1.5
+      - name: "return_capture_p25"
+        drawdown_penalty: 0.25
+        volatility_penalty: 0.10
+        risk_penalty_power: 1.5
+      - name: "baseline_p25"
+        drawdown_penalty: 0.50
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/runs"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -39,6 +39,8 @@ The project now supports a small, reviewable end-to-end research workflow rather
 - `marketlab phase8-bull-participation --run-dir ... --config ...`
 - `marketlab phase8-score-diagnostic --run-dir ...`
 - `marketlab phase8-bull-counterfactual --run-dir ... --config ...`
+- `marketlab phase8-methodology-review --run-dir ...`
+- `marketlab phase8-grid-compare --runs-root ... --output ...`
 
 Current workflow surface:
 
@@ -55,7 +57,8 @@ Current workflow surface:
 - local file-backed paper-trading proposals, approvals, and submission state
 - local Docker Compose scheduling for the daily single-ETF paper loop
 - isolated BTC paper proposal, approval, and submission state under `artifacts/btc-paper` / `artifacts-btc-paper`
-- artifact-only Phase 8 diagnostic commands for post-run review
+- artifact-only Phase 8 diagnostic commands for post-run review, including a consolidated methodology review
+- cross-run BTC Phase 8 grid comparison for bull-upside capture, downside capture, score validity, counterfactual hypotheses, and artifact-pruning review
 
 ## Phase 4 Outcomes Worth Keeping
 
@@ -101,6 +104,8 @@ Current Phase 8 rules:
 - keep BTC exposure decisions limited to `0%`, `25%`, `50%`, or `100%`
 - compare selected strategies against BTC buy-and-hold plus static and rebalanced BTC/cash benchmarks
 - treat Phase 8 diagnostic commands as artifact review only
+- use `phase8-methodology-review` to separate deployment readiness from risk allocation, score validity, bull participation, and diagnostic-only counterfactual hypotheses
+- use `phase8-grid-compare` and the BTC bull-upside methodology notes before pivoting to heavier ML models
 - keep crypto/BTC paper work blocked unless the strict research gate passes
 
 ## Phase 9 Boundary

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -111,6 +111,7 @@ Current Phase 8 rules:
 - treat Phase 8 diagnostic commands as artifact review only
 - use `phase8-methodology-review` to separate deployment readiness from risk allocation, score validity, bull participation, and diagnostic-only counterfactual hypotheses
 - use `phase8-grid-compare`, `phase8-target-diagnostic`, `phase8-regime-policy-sweep`, and the BTC target/score pivot notes before pivoting to heavier ML models
+- use the [BTC Phase 8 Shadow-Confirmation Plan](phase8/BTC/shadow-confirmation-plan.md) as the locked forward-confirmation handoff for the historical partial-support challenger
 - keep crypto/BTC paper work blocked unless the strict research gate passes
 
 ## Phase 9 Boundary

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -38,7 +38,9 @@ The project now supports a small, reviewable end-to-end research workflow rather
 - `marketlab phase8-selection-probe --run-dir ...`
 - `marketlab phase8-bull-participation --run-dir ... --config ...`
 - `marketlab phase8-score-diagnostic --run-dir ...`
+- `marketlab phase8-target-diagnostic --run-dir ... --config ...`
 - `marketlab phase8-bull-counterfactual --run-dir ... --config ...`
+- `marketlab phase8-regime-policy-sweep --run-dir ... --config ...`
 - `marketlab phase8-methodology-review --run-dir ...`
 - `marketlab phase8-grid-compare --runs-root ... --output ...`
 
@@ -58,6 +60,9 @@ Current workflow surface:
 - local Docker Compose scheduling for the daily single-ETF paper loop
 - isolated BTC paper proposal, approval, and submission state under `artifacts/btc-paper` / `artifacts-btc-paper`
 - artifact-only Phase 8 diagnostic commands for post-run review, including a consolidated methodology review
+- artifact-only Phase 8 target diagnostics for separating bull-continuation and drawdown-defense labels
+- artifact-only BTC regime-policy sweeps for testing completed-bar exposure policies before expensive retraining
+- research-only BTC score-transform grids for repairing compressed bull-floor fallback scores before tier mapping
 - cross-run BTC Phase 8 grid comparison for bull-upside capture, downside capture, score validity, counterfactual hypotheses, and artifact-pruning review
 
 ## Phase 4 Outcomes Worth Keeping
@@ -105,7 +110,7 @@ Current Phase 8 rules:
 - compare selected strategies against BTC buy-and-hold plus static and rebalanced BTC/cash benchmarks
 - treat Phase 8 diagnostic commands as artifact review only
 - use `phase8-methodology-review` to separate deployment readiness from risk allocation, score validity, bull participation, and diagnostic-only counterfactual hypotheses
-- use `phase8-grid-compare` and the BTC bull-upside methodology notes before pivoting to heavier ML models
+- use `phase8-grid-compare`, `phase8-target-diagnostic`, `phase8-regime-policy-sweep`, and the BTC target/score pivot notes before pivoting to heavier ML models
 - keep crypto/BTC paper work blocked unless the strict research gate passes
 
 ## Phase 9 Boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,7 @@ This document ties the current pieces together and records the working rules tha
   - `python scripts/run_marketlab.py run-experiment --config configs/experiment.crypto_ts_ml_2024_ytd.yaml`
   - `python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>`
   - `python scripts/run_marketlab.py phase8-selection-probe --run-dir artifacts/runs/<experiment>/<run-id>`
+  - `python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>`
 - Installed package bootstrap:
   - `marketlab --version`
   - `marketlab list-configs`
@@ -879,7 +880,7 @@ Best practice:
 
 ### `src/marketlab/reports/phase8_*.py`
 
-- Rebuild Phase 8 run summaries, selection probes, bull participation diagnostics, score diagnostics, and bull counterfactuals from persisted artifacts.
+- Rebuild Phase 8 run summaries, selection probes, bull participation diagnostics, score diagnostics, bull counterfactuals, and consolidated methodology reviews from persisted artifacts.
 - Keep diagnostic outputs artifact-only: no model retraining, no strategy-weight rewrites, and no paper-deployment approval side effects.
 - Preserve the strict research gate as the source of truth for Phase 8 pass/fail review.
 

--- a/docs/btc-phase8-methodology.md
+++ b/docs/btc-phase8-methodology.md
@@ -106,6 +106,12 @@ score compression is suppressing full BTC participation. It does not change
 the allowed strategy tiers, fallback selection rules, or the strict Phase 8
 research gate.
 
+Score-transform grids are also research-only candidate parameters. They apply
+after model probability scoring and before tier mapping, hysteresis, and regime
+participation policy. The Phase 8 score-repair configs use completed-bar
+runtime regime labels to boost only runtime-bull scores; they do not change
+target labels, paper behavior, or the strict deployment gate.
+
 ## 4. Walk-Forward Training
 
 The outer walk-forward split defines the real out-of-sample test windows. Each
@@ -329,6 +335,22 @@ iteration before expanding the grid:
   It includes buy-hold, static BTC/cash, and rebalanced BTC/cash benchmarks in
   validation selection so the selected candidates face the same benchmark
   family that the strict gate requires.
+- `btc_phase8_bull_floor_score_boost_fallback`: the score-repair successor to
+  the first buy-hold-beating bull-floor fallback branch. It evaluates identity
+  plus runtime-bull score boosts with sigmoid calibration.
+- `btc_phase8_bull_floor_score_boost_uncalibrated`: the same score-transform
+  grid without probability calibration, isolating whether calibration is
+  compressing full-participation scores.
+- `btc_phase8_bull_floor_score_boost_long_train`: the same score-transform grid
+  with longer rolling train windows.
+- `btc_phase8_bull_floor_gate_bull_prob100_score_validity`: a research-only
+  completed-bar `gate_bull` 100% tier repair. It authorizes promotion from raw
+  validation expected-allocation score ordering before applying promotion.
+- `btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated`: the
+  same non-circular gate-bull repair without probability calibration.
+- `btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover`: the
+  same non-circular gate-bull repair with longer holding periods and a lower
+  turnover cap.
 
 ## 7. Cost-Aware Candidate Selection
 
@@ -399,6 +421,17 @@ python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs
 This report checks whether score compression, tier confusion, or validation to
 OOS score instability explains weak BTC participation.
 
+Run the target diagnostic without retraining models:
+
+```bash
+python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+```
+
+This report checks whether current target and prediction rows are mixing BTC
+bull-continuation participation with drawdown-defense behavior. The `--config`
+argument adds strict-gate bull labels for the run window; it does not retrain
+models or change portfolio weights.
+
 Run the bull counterfactual diagnostic without retraining models:
 
 ```bash
@@ -413,6 +446,14 @@ or redefine the unchanged strict research gate.
 The fallback and turnover-only probe profiles are diagnostic only. The runtime
 `best_active_fallback` policy is also diagnostic until a regenerated OOS run
 passes the unchanged strict Phase 8 research gate.
+
+The `gate_bull_prob100_threshold` score policy is also research-only. It may
+promote a completed-bar `gate_bull` row to 100% only when raw validation
+expected-allocation scores have finite non-negative forward-return correlation,
+`prob_tier_100` passes its threshold, and `prob_tier_100 >= prob_tier_0`.
+Authorization is computed before promotion. Negative-correlation fallback
+folds keep expected-allocation scores and persist the denial reason. This rule
+does not change the strict research gate or approve paper deployment.
 
 Build the consolidated methodology review without retraining models:
 
@@ -439,9 +480,10 @@ python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs -
 ```
 
 This comparison report is the main handoff into the BTC bull-upside methodology
-notes in [Phase 8 BTC Bull Upside](phase8/BTC/bull-upside-methodology.md). It
-also surfaces incomplete artifact directories as pruning candidates, but the
-CLI never deletes or moves files.
+notes in [Phase 8 BTC Bull Upside](phase8/BTC/bull-upside-methodology.md) and
+the current [Target/Score Pivot](phase8/BTC/target-score-pivot.md). It also
+surfaces incomplete artifact directories as pruning candidates, but the CLI
+never deletes or moves files.
 
 ## 8. Strict Research Gate
 

--- a/docs/btc-phase8-methodology.md
+++ b/docs/btc-phase8-methodology.md
@@ -351,6 +351,16 @@ iteration before expanding the grid:
 - `btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover`: the
   same non-circular gate-bull repair with longer holding periods and a lower
   turnover cap.
+- `btc_phase8_guarded_cost_robust_selector`: the calibrated score-validity
+  repair with validation candidates required to beat the configured benchmark
+  family at both 35 and 50 bps.
+- `btc_phase8_guarded_gate_bull_risk_off_override`: the same cost-robust
+  selector plus a validation-authorized completed-bar `gate_bull` override for
+  risk-off rows. The override applies to the next effective allocation only.
+- `btc_phase8_guarded_gate_bull_risk_off_override_partial_support`: the same
+  guarded override with the deterministic target-profile sweep result
+  `drawdown_penalty=0.75`, `volatility_penalty=0.25`, and
+  `risk_penalty_power=2.0`.
 
 ## 7. Cost-Aware Candidate Selection
 
@@ -388,6 +398,28 @@ max_annualized_turnover: 24.0
 This budget rejects candidates that can only work by changing exposure too
 often. It also protects the strict gate from accepting an overfit strategy that
 looks acceptable before realistic BTC cost drag.
+
+The guarded cost-robustness configs additionally set:
+
+```yaml
+selection_validation_cost_bps: [35, 50]
+```
+
+The same validation weights are repriced at each configured cost. A candidate
+must retain positive excess return versus every selection benchmark at every
+configured cost, and ranking prefers the strongest worst-cost benchmark
+margin. This changes research candidate selection only; it does not change the
+strict gate.
+
+Run the allocation-utility target sweep before the guarded batch:
+
+```bash
+python scripts/run_marketlab.py phase8-target-profile-sweep --config configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml --output artifacts/runs/phase8_btc_target_profile_sweep.csv
+```
+
+The sweep relabels the already prepared modeling rows without retraining. It
+records partial-tier support and selects the first passing profile
+deterministically.
 
 After a run, regenerate the deterministic summary without training models:
 
@@ -454,6 +486,14 @@ expected-allocation scores have finite non-negative forward-return correlation,
 Authorization is computed before promotion. Negative-correlation fallback
 folds keep expected-allocation scores and persist the denial reason. This rule
 does not change the strict research gate or approve paper deployment.
+
+The optional guarded risk-off override is also research-only. It is authorized
+from raw pre-promotion validation score ordering, never repaired scores. When
+authorized, only a completed-bar `gate_bull` row whose runtime label is
+`risk_off` receives a 100% next-effective allocation marker. Negative or
+non-finite raw correlation disables the override and persists the denial
+reason. A future shadow confirmation window that was not inspected while
+designing this rule is required before any deployment discussion.
 
 Build the consolidated methodology review without retraining models:
 

--- a/docs/btc-phase8-methodology.md
+++ b/docs/btc-phase8-methodology.md
@@ -187,6 +187,13 @@ The research artifacts to inspect are:
   `phase8_bull_counterfactual_gate.csv` for artifact-only bull-exposure
   counterfactuals. These rows are diagnostic and do not replace
   `strict_research_gate.csv`.
+- `phase8_methodology_review.csv` for the consolidated methodology view that
+  separates the unchanged deployment gate from risk-allocation, benchmark
+  family, target-support, signal-validity, bull-participation, and
+  diagnostic-only counterfactual evidence.
+- `phase8_btc_grid_comparison.csv` for the cross-run BTC Phase 8 comparison of
+  strict-gate status, bull-upside capture, downside capture, score validity,
+  counterfactual hypotheses, and conservative artifact-pruning recommendations.
 
 ## 6. Long Or Cash Decision
 
@@ -306,6 +313,22 @@ iteration before expanding the grid:
   calibration. This tests whether the model can produce real `100%`
   predicted-tier support in bull regimes without changing the strict success
   definition.
+- `btc_phase8_methodology_review`: the focused next daily allocation-utility
+  methodology run. It keeps the strict gate unchanged, includes buy-hold plus
+  static and rebalanced partial BTC benchmarks in candidate selection, and
+  treats bull-participation floors as validation-selected candidate parameters
+  rather than paper-trading overrides or counterfactual approvals.
+- `btc_phase8_bull_capture_rebalanced_gate`: the next rebalanced-benchmark
+  bull-capture grid. It uses diagnostic `best_active_fallback` selection,
+  expected-allocation scoring, the existing sklearn trio, and validation-chosen
+  bull participation floors while leaving the strict deployment gate unchanged.
+- `btc_phase8_bull_capture_prob100_grid`: the next score-mapping grid. It uses
+  `bull_prob100_threshold` scoring at 0.16 with no probability calibration to
+  test whether 100% BTC exposure is being suppressed by score mapping.
+- `btc_phase8_bull_capture_static_audit`: the full benchmark-family audit grid.
+  It includes buy-hold, static BTC/cash, and rebalanced BTC/cash benchmarks in
+  validation selection so the selected candidates face the same benchmark
+  family that the strict gate requires.
 
 ## 7. Cost-Aware Candidate Selection
 
@@ -391,8 +414,34 @@ The fallback and turnover-only probe profiles are diagnostic only. The runtime
 `best_active_fallback` policy is also diagnostic until a regenerated OOS run
 passes the unchanged strict Phase 8 research gate.
 
-The same summary is embedded into `report.md` when Phase 8 artifacts are
-generated.
+Build the consolidated methodology review without retraining models:
+
+```bash
+python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
+```
+
+The methodology review makes the current research state explicit: a run may
+improve drawdown and Sharpe and beat rebalanced BTC/cash benchmarks while still
+failing deployment because it lags buy-and-hold, lags static partial BTC
+benchmarks, lacks enough selected-fold coverage, has weak score-to-outcome
+relationships, or misses positive BTC bull-regime upside. Counterfactual rows
+can identify hypotheses for the next validation-selected rule, but they remain
+diagnostic-only and cannot approve Phase 8 or redefine the unchanged strict
+research gate.
+
+The Phase 8 run summary and methodology review are embedded into `report.md`
+when Phase 8 artifacts are generated.
+
+Compare completed BTC Phase 8 runs without retraining models:
+
+```bash
+python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
+```
+
+This comparison report is the main handoff into the BTC bull-upside methodology
+notes in [Phase 8 BTC Bull Upside](phase8/BTC/bull-upside-methodology.md). It
+also surfaces incomplete artifact directories as pruning candidates, but the
+CLI never deletes or moves files.
 
 ## 8. Strict Research Gate
 

--- a/docs/btc-phase8-methodology.md
+++ b/docs/btc-phase8-methodology.md
@@ -495,6 +495,12 @@ non-finite raw correlation disables the override and persists the denial
 reason. A future shadow confirmation window that was not inspected while
 designing this rule is required before any deployment discussion.
 
+The first historical OOS run of the isolated partial-support challenger passed
+every unchanged strict-gate row on June 2, 2026. It remains a shadow-confirmation
+candidate, not a paper or live approval: the methodology review still flags
+signal-validity and bull-participation diagnostics, and all selected folds used
+diagnostic fallback paths rather than strict validation-selected candidates.
+
 Build the consolidated methodology review without retraining models:
 
 ```bash

--- a/docs/btc-phase8-methodology.md
+++ b/docs/btc-phase8-methodology.md
@@ -500,6 +500,8 @@ every unchanged strict-gate row on June 2, 2026. It remains a shadow-confirmatio
 candidate, not a paper or live approval: the methodology review still flags
 signal-validity and bull-participation diagnostics, and all selected folds used
 diagnostic fallback paths rather than strict validation-selected candidates.
+The locked forward-confirmation lane is defined in the
+[BTC Phase 8 Shadow-Confirmation Plan](phase8/BTC/shadow-confirmation-plan.md).
 
 Build the consolidated methodology review without retraining models:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ This site is the canonical home for MarketLab's public documentation.
 - [Phase 7 Paper Trading](paper-trading.md)
 - [Phase 8 Crypto Hourly Trend Signals](crypto-hourly-trend.md)
 - [BTC Phase 8 Methodology](btc-phase8-methodology.md)
+- [BTC Phase 8 Bull Upside](phase8/BTC/bull-upside-methodology.md)
+- [BTC Phase 8 Target/Score Pivot](phase8/BTC/target-score-pivot.md)
 - [MCP Server](mcp-server.md)
 - [Codex MCP](codex-mcp.md)
 - [VS Code Copilot MCP](mcp-vscode-copilot.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ This site is the canonical home for MarketLab's public documentation.
 - [BTC Phase 8 Methodology](btc-phase8-methodology.md)
 - [BTC Phase 8 Bull Upside](phase8/BTC/bull-upside-methodology.md)
 - [BTC Phase 8 Target/Score Pivot](phase8/BTC/target-score-pivot.md)
+- [BTC Phase 8 Shadow Confirmation](phase8/BTC/shadow-confirmation-plan.md)
 - [MCP Server](mcp-server.md)
 - [Codex MCP](codex-mcp.md)
 - [VS Code Copilot MCP](mcp-vscode-copilot.md)

--- a/docs/phase8/BTC/bull-upside-methodology.md
+++ b/docs/phase8/BTC/bull-upside-methodology.md
@@ -1,0 +1,137 @@
+# BTC Phase 8 Bull-Upside Methodology
+
+This document captures the current BTC Phase 8 research state and the next
+methodological step for improving bull-market upside capture without weakening
+the strict research gate.
+
+## Current State
+
+The latest completed local methodology run is:
+
+```text
+artifacts/runs/btc_phase8_methodology_review/20260522T162012Z
+```
+
+It confirms that the current strict methodology is not deployment-ready:
+
+| Area | Current evidence |
+| --- | --- |
+| Strict gate | Failed. Only 1 of 15 folds selected a candidate. |
+| Net return | Strategy returned 0.0951 versus BTC buy-and-hold at 12.8086. |
+| Exposure | Average gross exposure was 0.0167, below the 0.20 strict minimum. |
+| Bull participation | Gate-bull average long exposure was 0.0100. |
+| Missed upside | Positive BTC gate-bull days with underexposure contributed 17.0353 buy-hold return. |
+| Score validity | Score-to-target, score-to-forward-return, and score-to-realized-utility correlations were negative. |
+| Predicted tiers | Selected OOS predictions collapsed to 25% exposure and produced no 100% tier support. |
+
+The diagnostic counterfactuals are useful but not approval evidence. Forcing
+runtime bull days to 100% exposure returned 75.3241 with 0.4502 average exposure,
+and treating strict-gate bull days as buy-hold returned 58.9625 with 0.5164
+average exposure. Those rows show that upside exists in the run window; they do
+not show that the validation-selected model can identify it without look-ahead.
+
+## What Has Been Tested
+
+The completed BTC Phase 8 experiments currently show three distinct failure
+modes:
+
+| Experiment family | Best observed role | Main limitation |
+| --- | --- | --- |
+| Strict methodology review | Preserves the unchanged gate and exposes target/score failure clearly. | Too little exposure; almost every fold stays cash. |
+| Bull-floor immediate diagnostic | Improves absolute return and risk profile versus strict cash-heavy runs. | Still lags buy-and-hold and static BTC/cash benchmarks. |
+| Full-tier score diagnostic | Tests 100% tier score support. | Still compresses selected OOS predictions and misses bull upside. |
+| Fallback diagnostics | Improves selection coverage. | Does not solve buy-and-hold underperformance. |
+| Allocation and regime-state challengers | Explores alternate labels. | No evidence yet that they produce deployable BTC participation. |
+
+The financial interpretation is straightforward: the current system behaves
+more like a low-exposure risk filter than a BTC bull-capture strategy. That can
+be valuable only if it preserves a large enough portion of upside while
+materially reducing drawdown. Current artifacts do not satisfy that tradeoff.
+
+## Next Run Matrix
+
+Run the next grid before adding new model families. The current failure is not
+yet proven to be a scikit-learn model limitation; the artifacts first need to
+separate selection objective, score mapping, and regime-floor effects.
+
+| Config | Purpose | Expected question |
+| --- | --- | --- |
+| `configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml` | Rebalanced benchmark selection with bull floors in the validation grid. | Can the strategy beat smoother BTC/cash benchmarks while keeping enough bull exposure? |
+| `configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml` | Lower `prob_tier_100` trigger to 0.16 and remove probability calibration. | Is 100% exposure being suppressed by score mapping/calibration rather than by the labels? |
+| `configs/experiment.btc_phase8_bull_capture_static_audit.yaml` | Include static and rebalanced benchmarks in selection. | Does any candidate survive when the validation objective matches the full strict benchmark family? |
+
+Run one experiment at a time because each BTC long-history run is expensive:
+
+```bash
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_static_audit.yaml
+```
+
+After each run, regenerate diagnostics:
+
+```bash
+python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
+```
+
+Then compare all completed BTC Phase 8 runs:
+
+```bash
+python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
+```
+
+## Decision Criteria
+
+Use `phase8_btc_grid_comparison.csv` to rank the next BTC method by these
+criteria, in this order:
+
+1. `strict_gate_passed` remains the only deployment pass condition.
+2. `active_return_vs_buy_hold` must improve materially, not only versus
+   rebalanced benchmarks.
+3. `bull_upside_capture_ratio` and `gate_bull_average_long_exposure` must show
+   actual BTC bull participation.
+4. `gate_bull_underexposed_positive_benchmark_return_sum` must shrink; a high
+   value means the strategy still misses positive BTC days while underexposed.
+5. `downside_capture_ratio`, `strategy_max_drawdown`, and `strategy_sharpe_like`
+   must preserve the reason to use an active strategy instead of buy-and-hold.
+6. `selected_fold_fraction` must reach the strict coverage threshold rather
+   than relying on one lucky fold.
+7. Score diagnostics must stop showing negative score-to-outcome relationships
+   before adding heavier ML models.
+
+If none of the three configs improves bull capture and score validity, then the
+next logical pivot is target/model research:
+
+- add target diagnostics that distinguish bull-continuation labels from
+  drawdown-defense labels
+- test a binary bull-participation classifier as a separate candidate feature,
+  not as an override
+- compare gradient boosting variants only after the current sklearn trio is
+  shown to fail under a better-defined target
+- keep counterfactual exposure rules diagnostic until they are selected by
+  validation and survive OOS strict-gate review
+
+## Artifact Pruning Policy
+
+Do not delete artifacts while methodology is still moving. First write a
+comparison manifest:
+
+```bash
+python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
+```
+
+The `recommended_artifact_action` column is intentionally conservative:
+
+| Action | Meaning |
+| --- | --- |
+| `keep_latest_complete` | Latest complete run for that experiment. Keep. |
+| `keep_for_grid_comparison` | Complete older run. Keep until the comparison is reviewed. |
+| `review_before_pruning` | Diagnostic or summary-only directory. Inspect manually. |
+| `archive_or_prune_after_manifest` | Incomplete one/two-file run candidate. Archive or delete only after explicit approval. |
+
+Pruning should happen only after the manifest is reviewed and copied into the
+research notes or PR summary. The CLI never removes files.

--- a/docs/phase8/BTC/bull-upside-methodology.md
+++ b/docs/phase8/BTC/bull-upside-methodology.md
@@ -1,12 +1,12 @@
 # BTC Phase 8 Bull-Upside Methodology
 
-This document captures the current BTC Phase 8 research state and the next
-methodological step for improving bull-market upside capture without weakening
-the strict research gate.
+This document records the completed BTC Phase 8 bull-capture allocation grid
+and the resulting research pivot. The strict research gate remains the only
+deployment pass condition.
 
 ## Current State
 
-The latest completed local methodology run is:
+The latest completed baseline methodology run is:
 
 ```text
 artifacts/runs/btc_phase8_methodology_review/20260522T162012Z
@@ -24,57 +24,88 @@ It confirms that the current strict methodology is not deployment-ready:
 | Score validity | Score-to-target, score-to-forward-return, and score-to-realized-utility correlations were negative. |
 | Predicted tiers | Selected OOS predictions collapsed to 25% exposure and produced no 100% tier support. |
 
-The diagnostic counterfactuals are useful but not approval evidence. Forcing
-runtime bull days to 100% exposure returned 75.3241 with 0.4502 average exposure,
-and treating strict-gate bull days as buy-hold returned 58.9625 with 0.5164
-average exposure. Those rows show that upside exists in the run window; they do
-not show that the validation-selected model can identify it without look-ahead.
+The diagnostic counterfactuals remain hypothesis evidence only. Forcing runtime
+bull days to 100% exposure returned 75.3241 with 0.4502 average exposure, and
+treating strict-gate bull days as buy-hold returned 58.9625 with 0.5164 average
+exposure. Those rows show that upside exists in the run window; they do not show
+that the validation-selected model can identify it without look-ahead.
 
-## What Has Been Tested
+## Completed Bull-Capture Matrix
 
-The completed BTC Phase 8 experiments currently show three distinct failure
-modes:
+The previous next-run matrix is now complete in
+`artifacts/runs/phase8_btc_grid_comparison.csv`.
 
-| Experiment family | Best observed role | Main limitation |
-| --- | --- | --- |
-| Strict methodology review | Preserves the unchanged gate and exposes target/score failure clearly. | Too little exposure; almost every fold stays cash. |
-| Bull-floor immediate diagnostic | Improves absolute return and risk profile versus strict cash-heavy runs. | Still lags buy-and-hold and static BTC/cash benchmarks. |
-| Full-tier score diagnostic | Tests 100% tier score support. | Still compresses selected OOS predictions and misses bull upside. |
-| Fallback diagnostics | Improves selection coverage. | Does not solve buy-and-hold underperformance. |
-| Allocation and regime-state challengers | Explores alternate labels. | No evidence yet that they produce deployable BTC participation. |
+| Config | Run ID | Strict gate | Active return vs buy-hold | Selected fold fraction | Predicted 100% tier | Score validity |
+| --- | --- | --- | ---: | ---: | ---: | --- |
+| `configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml` | `20260524T194740Z` | Failed | -10.1846 | 1.0000 | 0.0000 | Negative score/outcome correlations. |
+| `configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml` | `20260524T221456Z` | Failed | -10.4788 | 0.9333 | 0.1927 | 100% predictions appeared, but score/outcome correlations stayed negative. |
+| `configs/experiment.btc_phase8_bull_capture_static_audit.yaml` | `20260524T232741Z` | Failed | -10.1846 | 1.0000 | 0.0000 | Negative score/outcome correlations. |
 
-The financial interpretation is straightforward: the current system behaves
-more like a low-exposure risk filter than a BTC bull-capture strategy. That can
-be valuable only if it preserves a large enough portion of upside while
-materially reducing drawdown. Current artifacts do not satisfy that tradeoff.
+The matrix improved selection coverage relative to the cash-heavy methodology
+review, but it did not solve the research problem:
 
-## Next Run Matrix
+- every completed run failed the unchanged strict gate
+- active return versus buy-and-hold stayed deeply negative
+- gate-bull active return stayed negative
+- positive gate-bull days were still materially underexposed
+- target support stayed concentrated in 25% and 50% labels
+- selected OOS 100% prediction support was absent or insufficient
+- score-to-target, score-to-forward-return, and score-to-realized-utility
+  correlations stayed negative
 
-Run the next grid before adding new model families. The current failure is not
-yet proven to be a scikit-learn model limitation; the artifacts first need to
-separate selection objective, score mapping, and regime-floor effects.
+Allocation-grid tuning is therefore no longer the next best path. The current
+evidence points to a target/score definition problem: the labels and scores do
+not reliably separate BTC bull-continuation participation from drawdown-defense
+behavior.
 
-| Config | Purpose | Expected question |
-| --- | --- | --- |
-| `configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml` | Rebalanced benchmark selection with bull floors in the validation grid. | Can the strategy beat smoother BTC/cash benchmarks while keeping enough bull exposure? |
-| `configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml` | Lower `prob_tier_100` trigger to 0.16 and remove probability calibration. | Is 100% exposure being suppressed by score mapping/calibration rather than by the labels? |
-| `configs/experiment.btc_phase8_bull_capture_static_audit.yaml` | Include static and rebalanced benchmarks in selection. | Does any candidate survive when the validation objective matches the full strict benchmark family? |
+## Pivot
 
-Run one experiment at a time because each BTC long-history run is expensive:
+The next methodology work is tracked in
+[BTC Phase 8 Target/Score Pivot](target-score-pivot.md).
+
+The pivot adds one artifact-only diagnostic and three runnable configs:
+
+- `phase8-target-diagnostic` to inspect target and prediction behavior by
+  runtime regime, gate-bull rows, forward-return sign, target tier, predicted
+  tier, drawdown, and realized utility
+- `phase8-regime-policy-sweep` to test completed-bar runtime and gate-bull
+  exposure policies against persisted artifacts before launching another
+  expensive BTC training batch
+- `configs/experiment.btc_phase8_target_return_capture_utility.yaml`
+- `configs/experiment.btc_phase8_bull_signal_feature_utility.yaml`
+- `configs/experiment.btc_phase8_regime_state_bull_signal.yaml`
+
+The first target/score batch found one useful branch:
+`btc_phase8_bull_floor_signal_return_capture_fallback` beat buy-and-hold by
+`+0.1227`, but still failed the strict gate and produced no selected OOS 100%
+predicted tiers. The next repair batch adds research-only score transforms to
+that branch:
+
+- `configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml`
+- `configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml`
+- `configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml`
+
+Run the pivot batch one experiment at a time because each BTC long-history run
+is expensive:
 
 ```bash
-python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml
-python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml
-python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_capture_static_audit.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_target_return_capture_utility.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_signal_feature_utility.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_regime_state_bull_signal.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml
 ```
 
 After each run, regenerate diagnostics:
 
 ```bash
 python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
 python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-regime-policy-sweep --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
 python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
 ```
 
@@ -86,34 +117,21 @@ python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs -
 
 ## Decision Criteria
 
-Use `phase8_btc_grid_comparison.csv` to rank the next BTC method by these
-criteria, in this order:
+Use `phase8_btc_grid_comparison.csv` plus the target diagnostic to rank the
+next BTC method by these criteria, in this order:
 
 1. `strict_gate_passed` remains the only deployment pass condition.
 2. `active_return_vs_buy_hold` must improve materially, not only versus
    rebalanced benchmarks.
 3. `bull_upside_capture_ratio` and `gate_bull_average_long_exposure` must show
    actual BTC bull participation.
-4. `gate_bull_underexposed_positive_benchmark_return_sum` must shrink; a high
-   value means the strategy still misses positive BTC days while underexposed.
-5. `downside_capture_ratio`, `strategy_max_drawdown`, and `strategy_sharpe_like`
-   must preserve the reason to use an active strategy instead of buy-and-hold.
-6. `selected_fold_fraction` must reach the strict coverage threshold rather
-   than relying on one lucky fold.
-7. Score diagnostics must stop showing negative score-to-outcome relationships
-   before adding heavier ML models.
-
-If none of the three configs improves bull capture and score validity, then the
-next logical pivot is target/model research:
-
-- add target diagnostics that distinguish bull-continuation labels from
-  drawdown-defense labels
-- test a binary bull-participation classifier as a separate candidate feature,
-  not as an override
-- compare gradient boosting variants only after the current sklearn trio is
-  shown to fail under a better-defined target
-- keep counterfactual exposure rules diagnostic until they are selected by
-  validation and survive OOS strict-gate review
+4. `gate_bull_underexposed_positive_benchmark_return_sum` must shrink.
+5. Score diagnostics must stop showing negative score-to-outcome relationships.
+6. `phase8-target-diagnostic` should show higher full-target and
+   full-prediction fractions on bull-continuation rows without turning
+   drawdown-defense rows into full-exposure labels.
+7. `selected_fold_fraction` must reach the strict coverage threshold without
+   relying on fallback-only success.
 
 ## Artifact Pruning Policy
 

--- a/docs/phase8/BTC/shadow-confirmation-plan.md
+++ b/docs/phase8/BTC/shadow-confirmation-plan.md
@@ -1,0 +1,104 @@
+# BTC Phase 8 Shadow-Confirmation Plan
+
+Yes, challenger 3 beat BTC buy-and-hold on the inspected historical
+out-of-sample window. Active return versus buy-and-hold was `+2.2940` at
+`35 bps` and remained positive at `+0.8094` at `50 bps`. The unchanged strict
+gate passed.
+
+This is not paper or live approval. The rule was designed against inspected
+history, methodology diagnostics still fail, and every selected fold depends
+on a fallback path. The next step is an unchanged, signals-only forward shadow
+lane.
+
+## Historical Decision Snapshot
+
+Lock this candidate without parameter changes:
+
+```text
+config: configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml
+run: artifacts/runs/btc_phase8_guarded_gate_bull_risk_off_override_partial_support/20260602T081225Z
+code lock: ce01124
+```
+
+The completed control-to-champion sequence is:
+
+| Run | Active vs buy-hold | 50 bps active | OOS 100% tier | Score/return correlation | Strict gate |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Score-validity control | +0.1227 | -1.2909 | 0.0000 | 0.0805 | Failed |
+| Cost-robust selector | +0.1227 | -1.2909 | 0.1380 | 0.0620 | Failed |
+| Guarded risk-off override | +1.5032 | +0.1636 | 0.0629 | 0.0721 | Failed |
+| Partial-support challenger | +2.2940 | +0.8094 | 0.0569 | 0.0430 | Passed |
+
+The passed historical row still has material weaknesses:
+
+- score-to-realized-utility correlation: `-0.0614`
+- gate-bull active-return sum: `-0.6571`
+- missed positive gate-bull benchmark return: `2.0599`
+- selected folds: `10` `best_active_fallback`, `5` deterministic
+  `regime_policy_fallback`, `0` strict selections
+- validation candidates: `2160` rows, `0` strict passes
+- every candidate failed required-benchmark excess and 35/50 bps robust-cost
+  excess
+
+## Locked Shadow Lane
+
+Use the signals-only shadow lane as the approval lane:
+
+- Freeze challenger 3 without parameter changes.
+- Run from `June 3, 2026` through `June 2, 2027`.
+- Perform the final labeled evaluation no earlier than `June 16, 2027`
+  because the target horizon is `14` daily bars.
+- Recompute daily after the completed BTC bar using only matured labels
+  available at that time.
+- Emit the next-effective `0%`, `25%`, `50%`, or `100%` allocation into an
+  append-only journal.
+- Publish monthly non-promoting progress snapshots and one final report.
+- Treat any tuning change as a new candidate that restarts its confirmation
+  clock.
+
+## Separate Paper Observation Lane
+
+The current `configs/experiment.btc_paper_daily.yaml` stack is not a mirror of
+challenger 3. It is a separate `4h` direction-target consensus strategy.
+
+Plan a later implementation packet for a true challenger-3 mirror:
+
+- Keep Alpaca paper execution isolated from the signals-only approval lane.
+- Use the same daily rolling allocation-utility procedure and completed-bar
+  timing.
+- Preserve next-effective allocation semantics.
+- Persist paper fills, slippage, and broker-state evidence separately.
+- Treat paper results as operational evidence only, never as approval
+  evidence.
+
+## Graduation Criteria
+
+Require all of the following before paper-deployment review:
+
+- Complete the full 365-day shadow window and 14-day maturity lag.
+- Pass the unchanged strict research gate.
+- Keep active return versus buy-and-hold positive at `35` and `50 bps`.
+- Pass the methodology `signal_validity_gate`, including positive
+  score-to-utility correlation.
+- Pass the methodology `bull_participation_gate`, including positive
+  gate-bull active return and no missed positive underexposed benchmark return.
+- Record zero `best_active_fallback` selections.
+- Record zero deterministic regime-policy fallback selections.
+- Allow no paper or live promotion from monthly snapshots.
+
+## Parallel Research Fork
+
+Keep this ordered experiment backlog separate while the locked lane accumulates
+evidence:
+
+1. Run an artifact-only rejection audit by fold and benchmark cost.
+2. Add a strict-only control cloned from challenger 3 with both fallback paths
+   disabled.
+3. Test one-variable strict-candidate viability challengers without relaxing
+   benchmark families or 35/50 bps costs.
+4. Prioritize validation robustness and score-validity repair before heavier
+   models.
+5. Keep heavier model families deferred until strict candidate coverage
+   materially improves.
+6. Compare every fork against the locked challenger without modifying the
+   locked shadow lane.

--- a/docs/phase8/BTC/target-score-pivot.md
+++ b/docs/phase8/BTC/target-score-pivot.md
@@ -175,6 +175,28 @@ even if it improves the historical OOS window. Before any deployment
 discussion, confirm the selected rule on a future shadow window that was not
 inspected while designing the override.
 
+### Completed Guarded Batch
+
+The guarded batch completed on June 2, 2026. The isolated partial-support
+challenger passed every unchanged strict-gate row on the inspected historical
+OOS window:
+
+| Experiment | Run ID | Active return vs buy-hold | 50 bps active return vs buy-hold | Gate-bull exposure | OOS 100% tier fraction | Score/forward-return correlation | Guarded trigger fraction | Strict gate |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `btc_phase8_bull_floor_score_validity_selection` | `20260529T233127Z` | +0.1227 | -1.2909 | 0.8327 | 0.0000 | 0.0805 | n/a | Failed |
+| `btc_phase8_guarded_cost_robust_selector` | `20260601T204931Z` | +0.1227 | -1.2909 | 0.8327 | 0.1380 | 0.0620 | 0.0000 | Failed |
+| `btc_phase8_guarded_gate_bull_risk_off_override` | `20260602T045028Z` | +1.5032 | +0.1636 | 0.9301 | 0.0629 | 0.0721 | 0.0780 | Failed |
+| `btc_phase8_guarded_gate_bull_risk_off_override_partial_support` | `20260602T081225Z` | +2.2940 | +0.8094 | 0.9323 | 0.0569 | 0.0430 | 0.0892 | Passed |
+
+The passed row is promoted only to future shadow confirmation. Its methodology
+review still flags signal-validity and bull-participation diagnostics, and its
+15 selected folds use diagnostic fallback paths: 10 `best_active_fallback`
+selections and 5 deterministic `regime_policy_fallback` selections. No fold
+uses a strict validation-selected candidate. Keep paper and live deployment
+blocked until the same locked rule is confirmed on an uninspected shadow
+window and the fallback dependency is resolved or explicitly accepted by a
+separate methodology decision.
+
 Run one experiment at a time:
 
 ```bash

--- a/docs/phase8/BTC/target-score-pivot.md
+++ b/docs/phase8/BTC/target-score-pivot.md
@@ -140,6 +140,41 @@ No challenger is promoted for further research from this batch:
   50 bps evidence
 - all strict gates remained failed, so paper and live deployment remain blocked
 
+## Guarded Cost-Robustness Batch
+
+The next research batch keeps the calibrated non-circular score repair and
+tests two narrower hypotheses:
+
+- validation candidates must retain positive benchmark excess at both 35 and
+  50 bps using the same weights
+- a completed-bar `gate_bull` risk-off row may receive a 100% next-effective
+  allocation marker only when raw validation score ordering is finite and
+  non-negative
+
+The deterministic target-profile sweep selected
+`dd0.75_vol0.25_power2`, with 0%, 25%, 50%, and 100% target fractions of
+`0.4787`, `0.0537`, `0.0547`, and `0.4129`. The third challenger isolates that
+profile so partial-tier support is tested without another target search during
+training.
+
+Run the foreground batch with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_phase8_guarded_gate_bull_cost_robustness_batch.ps1
+```
+
+The batch runs:
+
+- `configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml`
+- `configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml`
+- `configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml`
+
+All three configs keep `paper.enabled: false`, avoid `gate_bull_floor`, and
+leave the strict gate unchanged. The guarded override remains research-only
+even if it improves the historical OOS window. Before any deployment
+discussion, confirm the selected rule on a future shadow window that was not
+inspected while designing the override.
+
 Run one experiment at a time:
 
 ```bash
@@ -185,6 +220,9 @@ python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs -
 | `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml` | Tests validation-authorized completed-bar gate-bull 100% tier repair. | Uses raw pre-promotion score validity and leaves the strict gate unchanged. |
 | `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml` | Tests the same repair without sigmoid calibration. | Isolates probability calibration without using `gate_bull_floor`. |
 | `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml` | Tests the same repair with longer holding periods and lower turnover. | Keeps the score-validity objective and strict gate unchanged. |
+| `configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml` | Requires the calibrated repair to survive selection repricing at 35 and 50 bps. | Changes research candidate selection only; strict gate remains unchanged. |
+| `configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml` | Tests a raw-score-authorized completed-bar gate-bull risk-off override. | The marker applies to next-effective allocation only and cannot authorize itself. |
+| `configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml` | Tests the same guarded override with the deterministic partial-support target profile. | Isolates target shape while retaining multi-cost selection and the unchanged strict gate. |
 
 ## Decision Rule
 

--- a/docs/phase8/BTC/target-score-pivot.md
+++ b/docs/phase8/BTC/target-score-pivot.md
@@ -1,0 +1,202 @@
+# BTC Phase 8 Target/Score Pivot
+
+This note is the Phase 8 handoff after the completed bull-capture allocation
+matrix. It keeps the strict research gate unchanged and pivots the next batch
+away from allocation-grid tuning toward target and score methodology.
+
+## Completed Evidence
+
+The completed matrix in `artifacts/runs/phase8_btc_grid_comparison.csv` shows
+that selection coverage improved, but the strategy still did not produce
+deployable BTC bull participation.
+
+| Experiment | Run ID | Strict gate | Active return vs buy-hold | Gate-bull exposure | Gate-bull active return | Score/target correlation |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| `btc_phase8_bull_capture_rebalanced_gate` | `20260524T194740Z` | Failed | -10.1846 | 0.5322 | -2.8026 | -0.1084 |
+| `btc_phase8_bull_capture_prob100_grid` | `20260524T221456Z` | Failed | -10.4788 | 0.4945 | -2.9749 | -0.0365 |
+| `btc_phase8_bull_capture_static_audit` | `20260524T232741Z` | Failed | -10.1846 | 0.5322 | -2.8026 | -0.1084 |
+
+The matrix answered the allocation-grid question:
+
+- selection coverage reached 0.9333 to 1.0000
+- target support for 25% and 50% labels remained near 0.0433 and 0.0494
+- 100% predicted tier support was either absent or only 0.1927
+- every run stayed negative versus buy-and-hold by more than 10 cumulative
+  return points
+- gate-bull active return stayed negative
+- positive gate-bull days were still underexposed
+- score-to-target, score-to-forward-return, and score-to-realized-utility
+  correlations stayed negative
+
+The evidence does not justify more bull-floor or threshold-grid tuning as the
+next default step. The failure mode is now target/score validity: selected
+models are not learning a score that rewards BTC bull continuation while still
+defending drawdowns.
+
+## New Diagnostic
+
+Run the artifact-only target diagnostic after each new experiment:
+
+```bash
+python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+```
+
+It writes:
+
+- `phase8_target_diagnostic.csv`
+- `phase8_target_diagnostic_summary.csv`
+
+The report reads existing run artifacts and, when `--config` is supplied, joins
+strict-gate bull labels from the prepared panel. It does not retrain models,
+change exposure, change paper behavior, or redefine the strict research gate.
+
+Review these summary rows first:
+
+- `bull_continuation_full_target_fraction`
+- `bull_continuation_full_prediction_fraction`
+- `positive_return_rows_assigned_below_100_fraction`
+- `drawdown_defense_rows_assigned_below_100_fraction`
+- `score_target_weight_correlation`
+- `score_forward_return_correlation`
+- `score_realized_utility_correlation`
+- `gate_bull_full_target_fraction`
+- `gate_bull_full_prediction_fraction`
+
+Run the regime-policy sweep before the next expensive batch when a completed
+run shows recoverable bull upside:
+
+```bash
+python scripts/run_marketlab.py phase8-regime-policy-sweep --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+```
+
+It writes:
+
+- `phase8_regime_policy_sweep.csv`
+- `phase8_regime_policy_sweep_summary.csv`
+
+The sweep tests completed-bar runtime and gate-bull exposure policies against
+persisted artifacts. It is diagnostic only and does not approve deployment.
+
+## Next Experiment Batch
+
+The target/score pivot batch completed after this note was first written. The
+only branch that beat buy-and-hold was
+`btc_phase8_bull_floor_signal_return_capture_fallback`, but it still failed the
+strict gate and predicted no 100% allocation tiers. The next batch therefore
+keeps that bull-floor fallback structure and repairs score mapping first.
+
+## Gate-Bull Score-Validity Repair
+
+The score-validity control is
+`btc_phase8_bull_floor_score_validity_selection/20260529T233127Z`. The next
+research-only batch evaluates a narrower `gate_bull_prob100_threshold` repair:
+
+- `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml`
+- `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml`
+- `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml`
+
+The repair may promote a row to 100% BTC only when the completed-bar
+`gate_bull` label is true, `prob_tier_100` passes its configured threshold,
+`prob_tier_100 >= prob_tier_0`, and raw validation expected-allocation scores
+have finite non-negative correlation with forward returns. Authorization is
+computed before promotion, so repaired scores cannot validate their own use.
+Negative-correlation fallback folds retain expected-allocation scores and
+persist the denial reason.
+
+All three challengers keep `paper.enabled: false`, do not use
+`gate_bull_floor`, and leave the strict research gate unchanged. Run the
+foreground batch with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/run_phase8_gate_bull_score_validity_repair_batch.ps1
+```
+
+Use the regenerated `phase8_btc_grid_comparison.csv` to compare each challenger
+against the control. A challenger is research-worthy only when selected OOS
+100% support appears with positive score/forward-return correlation and bull
+participation improves without regressing buy-hold or 50 bps cost evidence.
+The unchanged strict gate remains the only paper or live deployment approval.
+
+### Completed Repair Batch
+
+The batch completed on June 1, 2026. The calibrated repair produced selected
+OOS 100% tier support with positive score/forward-return correlation, proving
+that the non-circular promotion path is active. It did not improve portfolio
+results versus the control because the existing validation-selected runtime
+policies already produced the same effective allocations.
+
+| Experiment | Run ID | Active return vs buy-hold | 50 bps active return vs buy-hold | Gate-bull exposure | OOS 100% tier fraction | Score/forward-return correlation | Strict gate |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `btc_phase8_bull_floor_score_validity_selection` | `20260529T233127Z` | +0.1227 | -1.2909 | 0.8327 | 0.0000 | 0.0805 | Failed |
+| `btc_phase8_bull_floor_gate_bull_prob100_score_validity` | `20260531T182636Z` | +0.1227 | -1.2909 | 0.8327 | 0.1380 | 0.0620 | Failed |
+| `btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated` | `20260601T023458Z` | -4.1469 | -5.3712 | 0.7929 | 0.2218 | -0.1083 | Failed |
+| `btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover` | `20260601T064223Z` | -5.4814 | -6.1353 | 0.7483 | 0.1067 | 0.0883 | Failed |
+
+No challenger is promoted for further research from this batch:
+
+- every negative-raw-correlation candidate was denied repair authorization
+- invalid selected fallback folds produced zero repaired 100% trigger rows
+- no challenger improved bull participation without regressing buy-hold or
+  50 bps evidence
+- all strict gates remained failed, so paper and live deployment remain blocked
+
+Run one experiment at a time:
+
+```bash
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_target_return_capture_utility.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_signal_feature_utility.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_regime_state_bull_signal.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml
+python scripts/run_marketlab.py run-experiment --config configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml
+```
+
+After each run:
+
+```bash
+python scripts/run_marketlab.py phase8-summary --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-target-diagnostic --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-bull-participation --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-score-diagnostic --run-dir artifacts/runs/<experiment>/<run-id>
+python scripts/run_marketlab.py phase8-bull-counterfactual --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-regime-policy-sweep --run-dir artifacts/runs/<experiment>/<run-id> --config configs/<experiment>.yaml
+python scripts/run_marketlab.py phase8-methodology-review --run-dir artifacts/runs/<experiment>/<run-id>
+```
+
+Then regenerate the comparison manifest:
+
+```bash
+python scripts/run_marketlab.py phase8-grid-compare --runs-root artifacts/runs --output artifacts/runs/phase8_btc_grid_comparison.csv
+```
+
+## Config Intent
+
+| Config | Purpose | Isolation boundary |
+| --- | --- | --- |
+| `configs/experiment.btc_phase8_target_return_capture_utility.yaml` | Tests lower drawdown/volatility penalties so positive BTC continuation is less likely to be demoted from 100% exposure. | Uses only `model_only` regime participation and keeps signal features disabled. |
+| `configs/experiment.btc_phase8_bull_signal_feature_utility.yaml` | Tests explicit binary bull-participation and drawdown-defense signals as model inputs. | Signals do not override exposure, strict gate, or paper behavior. |
+| `configs/experiment.btc_phase8_regime_state_bull_signal.yaml` | Tests whether the `regime_state` target separates risk-off/reduced/risk-on behavior better when the model receives explicit regime signals. | Still uses the unchanged strict benchmark family and `model_only` participation policy. |
+| `configs/experiment.btc_phase8_bull_floor_signal_return_capture_fallback.yaml` | Tests explicit research-only bull floors plus regime signal features when no ML candidate is valid. | Uses `no_valid_candidate_regime_fallback`; strict gate remains unchanged. |
+| `configs/experiment.btc_phase8_prob100_signal_threshold_fallback.yaml` | Tests a prob100 threshold grid with regime signal features and fallback coverage. | Threshold grid changes model scoring only inside research runs. |
+| `configs/experiment.btc_phase8_regime_floor_state_fallback.yaml` | Tests `regime_state` target behavior with explicit bull-floor regime policies. | Research-only exposure policies do not change paper behavior. |
+| `configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml` | Tests runtime-bull score boosts on the current champion branch. | Score transforms run after model scoring and before tier mapping; strict gate remains unchanged. |
+| `configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml` | Tests the same score-transform grid without sigmoid calibration. | Isolates whether calibration is compressing 100% participation. |
+| `configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml` | Tests the same score-transform grid with longer rolling train windows. | Keeps the bull-floor fallback and benchmark family unchanged. |
+| `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml` | Tests validation-authorized completed-bar gate-bull 100% tier repair. | Uses raw pre-promotion score validity and leaves the strict gate unchanged. |
+| `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml` | Tests the same repair without sigmoid calibration. | Isolates probability calibration without using `gate_bull_floor`. |
+| `configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml` | Tests the same repair with longer holding periods and lower turnover. | Keeps the score-validity objective and strict gate unchanged. |
+
+## Decision Rule
+
+A candidate becomes interesting only if it improves target/score validity and
+BTC participation together:
+
+- full-target and full-prediction support should rise on bull-continuation rows
+- drawdown-defense rows should still be assigned below 100% exposure
+- score correlations should stop being negative
+- active return versus buy-and-hold should improve beyond the current champion
+  margin of `+0.1227`
+- strict-gate status remains the deployment decision
+
+Counterfactual reports and target diagnostics can explain failure modes, but
+they cannot approve deployment or rewrite strategy weights.

--- a/docs/phase8/BTC/target-score-pivot.md
+++ b/docs/phase8/BTC/target-score-pivot.md
@@ -197,6 +197,10 @@ blocked until the same locked rule is confirmed on an uninspected shadow
 window and the fallback dependency is resolved or explicitly accepted by a
 separate methodology decision.
 
+The locked dates, approval boundary, graduation criteria, and parallel
+experiment backlog are recorded in the
+[BTC Phase 8 Shadow-Confirmation Plan](shadow-confirmation-plan.md).
+
 Run one experiment at a time:
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - BTC Phase 8 Methodology: btc-phase8-methodology.md
   - BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md
   - BTC Phase 8 Target/Score Pivot: phase8/BTC/target-score-pivot.md
+  - BTC Phase 8 Shadow Confirmation: phase8/BTC/shadow-confirmation-plan.md
   - MCP Server: mcp-server.md
   - Codex MCP: codex-mcp.md
   - VS Code Copilot MCP: mcp-vscode-copilot.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Phase 8 Crypto Hourly Trend: crypto-hourly-trend.md
   - BTC Phase 8 Methodology: btc-phase8-methodology.md
   - BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md
+  - BTC Phase 8 Target/Score Pivot: phase8/BTC/target-score-pivot.md
   - MCP Server: mcp-server.md
   - Codex MCP: codex-mcp.md
   - VS Code Copilot MCP: mcp-vscode-copilot.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Phase 7 Paper Trading: paper-trading.md
   - Phase 8 Crypto Hourly Trend: crypto-hourly-trend.md
   - BTC Phase 8 Methodology: btc-phase8-methodology.md
+  - BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md
   - MCP Server: mcp-server.md
   - Codex MCP: codex-mcp.md
   - VS Code Copilot MCP: mcp-vscode-copilot.md

--- a/scripts/run_phase8_bull_floor_batch.ps1
+++ b/scripts/run_phase8_bull_floor_batch.ps1
@@ -1,0 +1,125 @@
+param(
+    [string]$LogPath = "",
+    [string]$RunsRoot = "artifacts\runs"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+    $LogPath = Join-Path $RunsRoot "phase8_bull_floor_batch_$stamp.log"
+}
+
+$logDirectory = Split-Path -Parent $LogPath
+if (-not [string]::IsNullOrWhiteSpace($logDirectory)) {
+    New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
+}
+
+function Write-BatchLog {
+    param([string]$Message)
+
+    $line = "[{0}] {1}" -f (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), $Message
+    $line | Tee-Object -FilePath $LogPath -Append
+}
+
+function Invoke-LoggedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Command,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    Write-BatchLog "START $Description"
+    Write-BatchLog ("COMMAND " + ($Command -join " "))
+    $startedAt = Get-Date
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & $Command[0] @($Command[1..($Command.Length - 1)]) 2>&1 |
+            Tee-Object -FilePath $LogPath -Append
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $duration = New-TimeSpan -Start $startedAt -End (Get-Date)
+    Write-BatchLog ("FINISH {0} exit={1} duration={2}" -f $Description, $exitCode, $duration)
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode"
+    }
+    return @($output | ForEach-Object { $_.ToString() })
+}
+
+$configs = @(
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_override.yaml",
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_riskoff0.yaml",
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_low_turnover.yaml",
+    "configs\experiment.btc_phase8_bull_floor_score_validity_selection.yaml",
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_score_validity.yaml"
+)
+
+$completedRunDirs = @()
+
+Write-BatchLog "Phase 8 BTC bull-floor batch started."
+foreach ($config in $configs) {
+    Write-BatchLog "CONFIG $config"
+    $runOutput = Invoke-LoggedCommand `
+        -Description "run-experiment $config" `
+        -Command @("python", "scripts\run_marketlab.py", "run-experiment", "--config", $config)
+
+    $runDir = @(
+        $runOutput |
+            Where-Object { $_ -match "^(?:[A-Za-z]:\\.*\\)?artifacts[\\/]+runs[\\/]" } |
+            Select-Object -Last 1
+    )
+    if ($runDir.Count -ne 1) {
+        throw "Could not determine run directory for $config"
+    }
+    $runDir = $runDir[0]
+    $completedRunDirs += $runDir
+    Write-BatchLog "RUN_DIR $config $runDir"
+
+    Invoke-LoggedCommand `
+        -Description "phase8-summary $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-summary", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-target-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-target-diagnostic", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-participation $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-participation", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-score-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-score-diagnostic", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-counterfactual $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-counterfactual", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-regime-policy-sweep $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-regime-policy-sweep", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-methodology-review $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-methodology-review", "--run-dir", $runDir) | Out-Null
+}
+
+Invoke-LoggedCommand `
+    -Description "phase8-grid-compare" `
+    -Command @(
+        "python",
+        "scripts\run_marketlab.py",
+        "phase8-grid-compare",
+        "--runs-root",
+        $RunsRoot,
+        "--output",
+        (Join-Path $RunsRoot "phase8_btc_grid_comparison.csv")
+    ) | Out-Null
+
+Write-BatchLog "Phase 8 BTC bull-floor batch completed."
+foreach ($runDir in $completedRunDirs) {
+    Write-BatchLog "COMPLETED_RUN $runDir"
+}

--- a/scripts/run_phase8_gate_bull_score_validity_repair_batch.ps1
+++ b/scripts/run_phase8_gate_bull_score_validity_repair_batch.ps1
@@ -1,0 +1,123 @@
+param(
+    [string]$LogPath = "",
+    [string]$RunsRoot = "artifacts\runs"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+    $LogPath = Join-Path $RunsRoot "phase8_gate_bull_score_validity_repair_batch_$stamp.log"
+}
+
+$logDirectory = Split-Path -Parent $LogPath
+if (-not [string]::IsNullOrWhiteSpace($logDirectory)) {
+    New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
+}
+
+function Write-BatchLog {
+    param([string]$Message)
+
+    $line = "[{0}] {1}" -f (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), $Message
+    $line | Tee-Object -FilePath $LogPath -Append
+}
+
+function Invoke-LoggedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Command,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    Write-BatchLog "START $Description"
+    Write-BatchLog ("COMMAND " + ($Command -join " "))
+    $startedAt = Get-Date
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & $Command[0] @($Command[1..($Command.Length - 1)]) 2>&1 |
+            Tee-Object -FilePath $LogPath -Append
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $duration = New-TimeSpan -Start $startedAt -End (Get-Date)
+    Write-BatchLog ("FINISH {0} exit={1} duration={2}" -f $Description, $exitCode, $duration)
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode"
+    }
+    return @($output | ForEach-Object { $_.ToString() })
+}
+
+$configs = @(
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml",
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml",
+    "configs\experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml"
+)
+
+$completedRunDirs = @()
+
+Write-BatchLog "Phase 8 BTC gate-bull score-validity repair batch started."
+foreach ($config in $configs) {
+    Write-BatchLog "CONFIG $config"
+    $runOutput = Invoke-LoggedCommand `
+        -Description "run-experiment $config" `
+        -Command @("python", "scripts\run_marketlab.py", "run-experiment", "--config", $config)
+
+    $runDir = @(
+        $runOutput |
+            Where-Object { $_ -match "^(?:[A-Za-z]:\\.*\\)?artifacts[\\/]+runs[\\/]" } |
+            Select-Object -Last 1
+    )
+    if ($runDir.Count -ne 1) {
+        throw "Could not determine run directory for $config"
+    }
+    $runDir = $runDir[0]
+    $completedRunDirs += $runDir
+    Write-BatchLog "RUN_DIR $config $runDir"
+
+    Invoke-LoggedCommand `
+        -Description "phase8-summary $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-summary", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-target-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-target-diagnostic", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-participation $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-participation", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-score-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-score-diagnostic", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-counterfactual $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-counterfactual", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-regime-policy-sweep $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-regime-policy-sweep", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-methodology-review $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-methodology-review", "--run-dir", $runDir) | Out-Null
+}
+
+Invoke-LoggedCommand `
+    -Description "phase8-grid-compare" `
+    -Command @(
+        "python",
+        "scripts\run_marketlab.py",
+        "phase8-grid-compare",
+        "--runs-root",
+        $RunsRoot,
+        "--output",
+        (Join-Path $RunsRoot "phase8_btc_grid_comparison.csv")
+    ) | Out-Null
+
+Write-BatchLog "Phase 8 BTC gate-bull score-validity repair batch completed."
+foreach ($runDir in $completedRunDirs) {
+    Write-BatchLog "COMPLETED_RUN $runDir"
+}

--- a/scripts/run_phase8_guarded_gate_bull_cost_robustness_batch.ps1
+++ b/scripts/run_phase8_guarded_gate_bull_cost_robustness_batch.ps1
@@ -1,0 +1,136 @@
+param(
+    [string]$LogPath = "",
+    [string]$RunsRoot = "artifacts\runs"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $stamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+    $LogPath = Join-Path $RunsRoot "phase8_guarded_gate_bull_cost_robustness_batch_$stamp.log"
+}
+
+$logDirectory = Split-Path -Parent $LogPath
+if (-not [string]::IsNullOrWhiteSpace($logDirectory)) {
+    New-Item -ItemType Directory -Force -Path $logDirectory | Out-Null
+}
+
+function Write-BatchLog {
+    param([string]$Message)
+
+    $line = "[{0}] {1}" -f (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), $Message
+    $line | Tee-Object -FilePath $LogPath -Append
+}
+
+function Invoke-LoggedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Command,
+        [Parameter(Mandatory = $true)]
+        [string]$Description
+    )
+
+    Write-BatchLog "START $Description"
+    Write-BatchLog ("COMMAND " + ($Command -join " "))
+    $startedAt = Get-Date
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & $Command[0] @($Command[1..($Command.Length - 1)]) 2>&1 |
+            Tee-Object -FilePath $LogPath -Append
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+    $duration = New-TimeSpan -Start $startedAt -End (Get-Date)
+    Write-BatchLog ("FINISH {0} exit={1} duration={2}" -f $Description, $exitCode, $duration)
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode"
+    }
+    return @($output | ForEach-Object { $_.ToString() })
+}
+
+$controlConfig = "configs\experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml"
+$configs = @(
+    "configs\experiment.btc_phase8_guarded_cost_robust_selector.yaml",
+    "configs\experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml",
+    "configs\experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml"
+)
+
+$completedRunDirs = @()
+
+Write-BatchLog "Phase 8 BTC guarded gate-bull cost-robustness batch started."
+Invoke-LoggedCommand `
+    -Description "phase8-target-profile-sweep $controlConfig" `
+    -Command @(
+        "python",
+        "scripts\run_marketlab.py",
+        "phase8-target-profile-sweep",
+        "--config",
+        $controlConfig,
+        "--output",
+        (Join-Path $RunsRoot "phase8_btc_target_profile_sweep.csv")
+    ) | Out-Null
+
+foreach ($config in $configs) {
+    Write-BatchLog "CONFIG $config"
+    $runOutput = Invoke-LoggedCommand `
+        -Description "run-experiment $config" `
+        -Command @("python", "scripts\run_marketlab.py", "run-experiment", "--config", $config)
+
+    $runDir = @(
+        $runOutput |
+            Where-Object { $_ -match "^(?:[A-Za-z]:\\.*\\)?artifacts[\\/]+runs[\\/]" } |
+            Select-Object -Last 1
+    )
+    if ($runDir.Count -ne 1) {
+        throw "Could not determine run directory for $config"
+    }
+    $runDir = $runDir[0]
+    $completedRunDirs += $runDir
+    Write-BatchLog "RUN_DIR $config $runDir"
+
+    Invoke-LoggedCommand `
+        -Description "phase8-summary $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-summary", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-target-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-target-diagnostic", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-participation $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-participation", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-score-diagnostic $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-score-diagnostic", "--run-dir", $runDir) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-bull-counterfactual $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-bull-counterfactual", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-regime-policy-sweep $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-regime-policy-sweep", "--run-dir", $runDir, "--config", $config) | Out-Null
+    Invoke-LoggedCommand `
+        -Description "phase8-methodology-review $runDir" `
+        -Command @("python", "scripts\run_marketlab.py", "phase8-methodology-review", "--run-dir", $runDir) | Out-Null
+}
+
+Invoke-LoggedCommand `
+    -Description "phase8-grid-compare" `
+    -Command @(
+        "python",
+        "scripts\run_marketlab.py",
+        "phase8-grid-compare",
+        "--runs-root",
+        $RunsRoot,
+        "--output",
+        (Join-Path $RunsRoot "phase8_btc_grid_comparison.csv")
+    ) | Out-Null
+
+Write-BatchLog "Phase 8 BTC guarded gate-bull cost-robustness batch completed."
+foreach ($runDir in $completedRunDirs) {
+    Write-BatchLog "COMPLETED_RUN $runDir"
+}

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -43,7 +43,11 @@ from marketlab.reports.phase8_score_diagnostic import write_phase8_score_diagnos
 from marketlab.reports.phase8_selection_probe import write_phase8_selection_probe
 from marketlab.reports.phase8_summary import write_phase8_run_summary
 from marketlab.reports.phase8_target_diagnostic import write_phase8_target_diagnostic
+from marketlab.reports.phase8_target_profile_sweep import (
+    write_phase8_target_profile_sweep,
+)
 from marketlab.resources.templates import CONFIG_TEMPLATE_NAMES, write_config_template
+from marketlab.targets import build_modeling_dataset
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,6 +117,10 @@ def build_parser() -> argparse.ArgumentParser:
     phase8_target_diagnostic.add_argument("--run-dir", required=True)
     phase8_target_diagnostic.add_argument("--config")
     phase8_target_diagnostic.add_argument("--output-dir")
+
+    phase8_target_profile_sweep = subparsers.add_parser("phase8-target-profile-sweep")
+    phase8_target_profile_sweep.add_argument("--config", required=True)
+    phase8_target_profile_sweep.add_argument("--output")
 
     phase8_bull_counterfactual = subparsers.add_parser("phase8-bull-counterfactual")
     phase8_bull_counterfactual.add_argument("--run-dir", required=True)
@@ -334,6 +342,25 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(detail_path)
         print(summary_path)
+        return 0
+
+    if args.command == "phase8-target-profile-sweep":
+        load_env_file()
+        config = load_config(args.config)
+        panel, _ = prepare_data(config)
+        modeling_dataset = build_modeling_dataset(panel, config)
+        output_path = (
+            args.output
+            if args.output is not None
+            else "artifacts/runs/phase8_btc_target_profile_sweep.csv"
+        )
+        print(
+            write_phase8_target_profile_sweep(
+                modeling_dataset,
+                config=config,
+                output_path=output_path,
+            )
+        )
         return 0
 
     if args.command == "phase8-bull-counterfactual":

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -36,9 +36,13 @@ from marketlab.reports.phase8_bull_counterfactual import (
 from marketlab.reports.phase8_bull_participation import write_phase8_bull_participation
 from marketlab.reports.phase8_grid_compare import write_phase8_grid_comparison
 from marketlab.reports.phase8_methodology import write_phase8_methodology_review
+from marketlab.reports.phase8_regime_policy_sweep import (
+    write_phase8_regime_policy_sweep,
+)
 from marketlab.reports.phase8_score_diagnostic import write_phase8_score_diagnostic
 from marketlab.reports.phase8_selection_probe import write_phase8_selection_probe
 from marketlab.reports.phase8_summary import write_phase8_run_summary
+from marketlab.reports.phase8_target_diagnostic import write_phase8_target_diagnostic
 from marketlab.resources.templates import CONFIG_TEMPLATE_NAMES, write_config_template
 
 LOGGER = logging.getLogger(__name__)
@@ -105,10 +109,20 @@ def build_parser() -> argparse.ArgumentParser:
     phase8_score_diagnostic.add_argument("--run-dir", required=True)
     phase8_score_diagnostic.add_argument("--output-dir")
 
+    phase8_target_diagnostic = subparsers.add_parser("phase8-target-diagnostic")
+    phase8_target_diagnostic.add_argument("--run-dir", required=True)
+    phase8_target_diagnostic.add_argument("--config")
+    phase8_target_diagnostic.add_argument("--output-dir")
+
     phase8_bull_counterfactual = subparsers.add_parser("phase8-bull-counterfactual")
     phase8_bull_counterfactual.add_argument("--run-dir", required=True)
     phase8_bull_counterfactual.add_argument("--config", required=True)
     phase8_bull_counterfactual.add_argument("--output-dir")
+
+    phase8_regime_policy_sweep = subparsers.add_parser("phase8-regime-policy-sweep")
+    phase8_regime_policy_sweep.add_argument("--run-dir", required=True)
+    phase8_regime_policy_sweep.add_argument("--config", required=True)
+    phase8_regime_policy_sweep.add_argument("--output-dir")
 
     phase8_methodology_review = subparsers.add_parser("phase8-methodology-review")
     phase8_methodology_review.add_argument("--run-dir", required=True)
@@ -312,6 +326,16 @@ def main(argv: list[str] | None = None) -> int:
         print(summary_path)
         return 0
 
+    if args.command == "phase8-target-diagnostic":
+        detail_path, summary_path = write_phase8_target_diagnostic(
+            args.run_dir,
+            config_path=args.config,
+            output_dir=args.output_dir,
+        )
+        print(detail_path)
+        print(summary_path)
+        return 0
+
     if args.command == "phase8-bull-counterfactual":
         detail_path, summary_path, gate_path = write_phase8_bull_counterfactual(
             args.run_dir,
@@ -321,6 +345,16 @@ def main(argv: list[str] | None = None) -> int:
         print(detail_path)
         print(summary_path)
         print(gate_path)
+        return 0
+
+    if args.command == "phase8-regime-policy-sweep":
+        detail_path, summary_path = write_phase8_regime_policy_sweep(
+            args.run_dir,
+            config_path=args.config,
+            output_dir=args.output_dir,
+        )
+        print(detail_path)
+        print(summary_path)
         return 0
 
     if args.command == "phase8-methodology-review":

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -34,6 +34,8 @@ from marketlab.reports.phase8_bull_counterfactual import (
     write_phase8_bull_counterfactual,
 )
 from marketlab.reports.phase8_bull_participation import write_phase8_bull_participation
+from marketlab.reports.phase8_grid_compare import write_phase8_grid_comparison
+from marketlab.reports.phase8_methodology import write_phase8_methodology_review
 from marketlab.reports.phase8_score_diagnostic import write_phase8_score_diagnostic
 from marketlab.reports.phase8_selection_probe import write_phase8_selection_probe
 from marketlab.reports.phase8_summary import write_phase8_run_summary
@@ -107,6 +109,16 @@ def build_parser() -> argparse.ArgumentParser:
     phase8_bull_counterfactual.add_argument("--run-dir", required=True)
     phase8_bull_counterfactual.add_argument("--config", required=True)
     phase8_bull_counterfactual.add_argument("--output-dir")
+
+    phase8_methodology_review = subparsers.add_parser("phase8-methodology-review")
+    phase8_methodology_review.add_argument("--run-dir", required=True)
+    phase8_methodology_review.add_argument("--output")
+
+    phase8_grid_compare = subparsers.add_parser("phase8-grid-compare")
+    phase8_grid_compare.add_argument("--runs-root", default="artifacts/runs")
+    phase8_grid_compare.add_argument("--run-dir", action="append")
+    phase8_grid_compare.add_argument("--output")
+    phase8_grid_compare.add_argument("--experiment-prefix", default="btc_phase8")
 
     return parser
 
@@ -309,6 +321,21 @@ def main(argv: list[str] | None = None) -> int:
         print(detail_path)
         print(summary_path)
         print(gate_path)
+        return 0
+
+    if args.command == "phase8-methodology-review":
+        print(write_phase8_methodology_review(args.run_dir, output_path=args.output))
+        return 0
+
+    if args.command == "phase8-grid-compare":
+        print(
+            write_phase8_grid_comparison(
+                runs_root=args.runs_root,
+                run_dirs=args.run_dir,
+                output_path=args.output,
+                experiment_prefix=args.experiment_prefix,
+            )
+        )
         return 0
 
     load_env_file()

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -366,6 +366,8 @@ class MLStrategyTuningConfig:
     allocation_score_policy: str = "expected_allocation"
     allocation_score_policy_prob100_threshold: float = 0.20
     allocation_score_policy_prob100_threshold_grid: list[float] = field(default_factory=list)
+    selection_validation_cost_bps: list[float] = field(default_factory=list)
+    guarded_gate_bull_risk_off_override: bool = False
     allocation_score_transforms: list[AllocationScoreTransformConfig] = field(
         default_factory=lambda: [AllocationScoreTransformConfig()]
     )
@@ -998,6 +1000,30 @@ def _validate_config(config: ExperimentConfig) -> None:
     ml_tuning.allocation_score_policy_prob100_threshold_grid = (
         validated_prob100_threshold_grid
     )
+    validated_selection_validation_cost_bps: list[float] = []
+    seen_selection_validation_cost_bps: set[float] = set()
+    for cost_bps in ml_tuning.selection_validation_cost_bps:
+        try:
+            cost_value = float(cost_bps)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.selection_validation_cost_bps must contain finite non-negative values."
+            ) from exc
+        if not math.isfinite(cost_value) or cost_value < 0.0:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.selection_validation_cost_bps must contain finite non-negative values."
+            )
+        if cost_value in seen_selection_validation_cost_bps:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.selection_validation_cost_bps must not contain duplicate values."
+            )
+        seen_selection_validation_cost_bps.add(cost_value)
+        validated_selection_validation_cost_bps.append(cost_value)
+    ml_tuning.selection_validation_cost_bps = validated_selection_validation_cost_bps
+    if not isinstance(ml_tuning.guarded_gate_bull_risk_off_override, bool):
+        raise ValueError(
+            "evaluation.ml_strategy_tuning.guarded_gate_bull_risk_off_override must be a boolean."
+        )
     seen_score_transform_names: set[str] = set()
     for transform in ml_tuning.allocation_score_transforms:
         transform.name = str(transform.name).strip()
@@ -1043,7 +1069,11 @@ def _validate_config(config: ExperimentConfig) -> None:
             )
         seen_selection_benchmarks.add(benchmark_name)
     if (
-        ml_tuning.objective == "net_return_and_risk_vs_required_benchmarks"
+        ml_tuning.objective
+        in {
+            "net_return_and_risk_vs_required_benchmarks",
+            "net_return_risk_score_validity_vs_required_benchmarks",
+        }
         and not ml_tuning.selection_benchmark_strategies
     ):
         raise ValueError(

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -24,11 +24,13 @@ ML_STRATEGY_ALLOCATION_MODES = {"binary", "direct_tiered", "tiered"}
 ML_STRATEGY_TUNING_OBJECTIVES = {
     "net_return_and_risk_vs_buy_hold",
     "net_return_and_risk_vs_required_benchmarks",
+    "net_return_risk_score_validity_vs_required_benchmarks",
 }
 ML_STRATEGY_SELECTION_POLICIES = {"best_active_fallback", "strict"}
 ML_STRATEGY_ALLOCATION_SCORE_POLICIES = {
     "bull_prob100_threshold",
     "expected_allocation",
+    "gate_bull_prob100_threshold",
 }
 ALLOCATION_CLASS_WEIGHTING_MODES = {
     "balanced",
@@ -36,7 +38,7 @@ ALLOCATION_CLASS_WEIGHTING_MODES = {
     "none",
 }
 ALLOCATION_PROBABILITY_CALIBRATION_MODES = {"none", "sigmoid"}
-REGIME_PARTICIPATION_POLICY_TIERS = {0.0, 0.25, 0.50, 1.0}
+REGIME_PARTICIPATION_POLICY_TIERS = {0.0, 0.25, 0.50, 0.75, 1.0}
 WEIGHT_TOLERANCE = 1e-6
 INTERVAL_PERIODS_PER_YEAR = {
     "1d": 252.0,
@@ -93,6 +95,7 @@ class FeaturesConfig:
     crypto_regime_percentile_window: int = 252
     crypto_regime_drawdown_window: int = 252
     crypto_regime_volume_window: int = 42
+    crypto_regime_signal_features_enabled: bool = False
 
 
 @dataclass(slots=True)
@@ -317,6 +320,16 @@ class RegimeParticipationPolicyConfig:
     sideways_floor: float = 0.0
     bear_floor: float = 0.0
     risk_off_cap: float | None = 0.25
+    gate_bull_floor: float | None = None
+
+
+@dataclass(slots=True)
+class AllocationScoreTransformConfig:
+    name: str = "identity"
+    bull_multiplier: float = 1.0
+    bull_addend: float = 0.0
+    risk_off_score_cap: float | None = None
+    non_bull_score_cap: float | None = None
 
 
 @dataclass(slots=True)
@@ -345,12 +358,17 @@ class MLStrategyTuningConfig:
         default_factory=lambda: [RegimeParticipationPolicyConfig()]
     )
     no_candidate_fallback_regime_policy: str | None = None
+    no_valid_candidate_regime_fallback: str | None = None
     allocation_class_weighting: str = "none"
     allocation_partial_class_weight_multiplier: float = 1.0
     allocation_probability_calibration: str = "none"
     allocation_calibration_cv: int = 3
     allocation_score_policy: str = "expected_allocation"
     allocation_score_policy_prob100_threshold: float = 0.20
+    allocation_score_policy_prob100_threshold_grid: list[float] = field(default_factory=list)
+    allocation_score_transforms: list[AllocationScoreTransformConfig] = field(
+        default_factory=lambda: [AllocationScoreTransformConfig()]
+    )
 
 
 @dataclass(slots=True)
@@ -558,6 +576,19 @@ def _normalize_mapping_sections(config: ExperimentConfig) -> None:
         config.evaluation.ml_strategy_tuning.min_holding_period_bars_grid = [0]
     if config.evaluation.ml_strategy_tuning.hysteresis_margin_grid is None:
         config.evaluation.ml_strategy_tuning.hysteresis_margin_grid = [0.0]
+    if config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid is None:
+        config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid = []
+    if config.evaluation.ml_strategy_tuning.allocation_score_transforms is None:
+        config.evaluation.ml_strategy_tuning.allocation_score_transforms = [
+            AllocationScoreTransformConfig()
+        ]
+    else:
+        config.evaluation.ml_strategy_tuning.allocation_score_transforms = [
+            transform
+            if isinstance(transform, AllocationScoreTransformConfig)
+            else _section(AllocationScoreTransformConfig, transform)
+            for transform in config.evaluation.ml_strategy_tuning.allocation_score_transforms
+        ] or [AllocationScoreTransformConfig()]
     if config.evaluation.ml_strategy_tuning.allocation_utility_profiles is None:
         config.evaluation.ml_strategy_tuning.allocation_utility_profiles = []
     else:
@@ -627,6 +658,28 @@ def _validate_cap(label: str, value: float | None) -> None:
         return
     if not 0.0 <= value <= 1.0:
         raise ValueError(f"{label} must be between 0.0 and 1.0.")
+
+
+def _validate_optional_score_cap(label: str, value: float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite value between 0.0 and 1.0.") from exc
+    if not math.isfinite(numeric_value) or not 0.0 <= numeric_value <= 1.0:
+        raise ValueError(f"{label} must be a finite value between 0.0 and 1.0.")
+    return numeric_value
+
+
+def _validate_score_transform_float(label: str, value: float) -> float:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be finite.") from exc
+    if not math.isfinite(numeric_value):
+        raise ValueError(f"{label} must be finite.")
+    return numeric_value
 
 
 def _validate_non_negative_bps_list(label: str, values: list[float]) -> None:
@@ -925,6 +978,58 @@ def _validate_config(config: ExperimentConfig) -> None:
     ml_tuning.allocation_score_policy_prob100_threshold = (
         allocation_score_policy_prob100_threshold
     )
+    validated_prob100_threshold_grid: list[float] = []
+    for threshold in ml_tuning.allocation_score_policy_prob100_threshold_grid:
+        try:
+            threshold_value = float(threshold)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid must contain finite values between 0.0 and 1.0."
+            ) from exc
+        if (
+            not math.isfinite(threshold_value)
+            or threshold_value < 0.0
+            or threshold_value > 1.0
+        ):
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid must contain finite values between 0.0 and 1.0."
+            )
+        validated_prob100_threshold_grid.append(threshold_value)
+    ml_tuning.allocation_score_policy_prob100_threshold_grid = (
+        validated_prob100_threshold_grid
+    )
+    seen_score_transform_names: set[str] = set()
+    for transform in ml_tuning.allocation_score_transforms:
+        transform.name = str(transform.name).strip()
+        if transform.name == "":
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.allocation_score_transforms names must be non-empty."
+            )
+        if transform.name in seen_score_transform_names:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.allocation_score_transforms must not contain duplicate names."
+            )
+        seen_score_transform_names.add(transform.name)
+        transform.bull_multiplier = _validate_score_transform_float(
+            f"evaluation.ml_strategy_tuning.allocation_score_transforms[{transform.name}].bull_multiplier",
+            transform.bull_multiplier,
+        )
+        if transform.bull_multiplier < 0.0:
+            raise ValueError(
+                "evaluation.ml_strategy_tuning.allocation_score_transforms bull_multiplier must be non-negative."
+            )
+        transform.bull_addend = _validate_score_transform_float(
+            f"evaluation.ml_strategy_tuning.allocation_score_transforms[{transform.name}].bull_addend",
+            transform.bull_addend,
+        )
+        transform.risk_off_score_cap = _validate_optional_score_cap(
+            f"evaluation.ml_strategy_tuning.allocation_score_transforms[{transform.name}].risk_off_score_cap",
+            transform.risk_off_score_cap,
+        )
+        transform.non_bull_score_cap = _validate_optional_score_cap(
+            f"evaluation.ml_strategy_tuning.allocation_score_transforms[{transform.name}].non_bull_score_cap",
+            transform.non_bull_score_cap,
+        )
     seen_selection_benchmarks: set[str] = set()
     for benchmark_strategy in ml_tuning.selection_benchmark_strategies:
         benchmark_name = str(benchmark_strategy).strip()
@@ -1004,16 +1109,37 @@ def _validate_config(config: ExperimentConfig) -> None:
                 f"evaluation.ml_strategy_tuning.regime_participation_policies[{policy.name}].risk_off_cap",
                 policy.risk_off_cap,
             )
-    if ml_tuning.no_candidate_fallback_regime_policy is not None:
-        fallback_policy_name = str(ml_tuning.no_candidate_fallback_regime_policy).strip()
+        if policy.gate_bull_floor is not None:
+            policy.gate_bull_floor = _validate_regime_policy_tier(
+                f"evaluation.ml_strategy_tuning.regime_participation_policies[{policy.name}].gate_bull_floor",
+                policy.gate_bull_floor,
+            )
+    configured_fallback_names = [
+        str(value).strip()
+        for value in (
+            ml_tuning.no_candidate_fallback_regime_policy,
+            ml_tuning.no_valid_candidate_regime_fallback,
+        )
+        if value is not None
+    ]
+    if (
+        len(configured_fallback_names) == 2
+        and configured_fallback_names[0] != configured_fallback_names[1]
+    ):
+        raise ValueError(
+            "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy "
+            "and no_valid_candidate_regime_fallback must match when both are configured."
+        )
+    fallback_policy_name = configured_fallback_names[0] if configured_fallback_names else None
+    if fallback_policy_name is not None:
         if fallback_policy_name == "":
             raise ValueError(
-                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy must be non-empty when configured."
+                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy/no_valid_candidate_regime_fallback must be non-empty when configured."
             )
         if fallback_policy_name not in seen_policy_names:
             allowed = ", ".join(sorted(seen_policy_names))
             raise ValueError(
-                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy "
+                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy/no_valid_candidate_regime_fallback "
                 f"must reference one of regime_participation_policies: {allowed}."
             )
         fallback_policy = next(
@@ -1023,10 +1149,11 @@ def _validate_config(config: ExperimentConfig) -> None:
         )
         if fallback_policy.risk_off_cap is None:
             raise ValueError(
-                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy "
+                "evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy/no_valid_candidate_regime_fallback "
                 "requires the referenced policy to define risk_off_cap."
             )
         ml_tuning.no_candidate_fallback_regime_policy = fallback_policy_name
+        ml_tuning.no_valid_candidate_regime_fallback = fallback_policy_name
     if ml_tuning.allocation_class_weighting not in ALLOCATION_CLASS_WEIGHTING_MODES:
         allowed = ", ".join(sorted(ALLOCATION_CLASS_WEIGHTING_MODES))
         raise ValueError(

--- a/src/marketlab/features/engineering.py
+++ b/src/marketlab/features/engineering.py
@@ -188,6 +188,25 @@ def _add_crypto_regime_features(
     return featured
 
 
+def _add_crypto_regime_signal_features(featured: pd.DataFrame) -> pd.DataFrame:
+    if not {"crypto_regime_risk_off", "crypto_regime_trend_state"}.issubset(
+        featured.columns
+    ):
+        raise ValueError(
+            "Crypto regime signal features require crypto regime state columns."
+        )
+
+    risk_off = featured["crypto_regime_risk_off"].fillna(0).astype(int).eq(1)
+    trend_state = featured["crypto_regime_trend_state"].fillna(0).astype(int)
+    featured["crypto_regime_bull_participation_signal"] = (
+        trend_state.gt(0) & ~risk_off
+    ).astype(int)
+    featured["crypto_regime_drawdown_defense_signal"] = (
+        risk_off | trend_state.lt(0)
+    ).astype(int)
+    return featured
+
+
 def add_feature_set(
     panel: pd.DataFrame,
     return_windows: list[int],
@@ -213,6 +232,7 @@ def add_feature_set(
     crypto_regime_percentile_window: int = 252,
     crypto_regime_drawdown_window: int = 252,
     crypto_regime_volume_window: int = 42,
+    crypto_regime_signal_features_enabled: bool = False,
 ) -> pd.DataFrame:
     featured = panel.sort_values(["symbol", "timestamp"]).copy()
     grouped_close = featured.groupby("symbol")["adj_close"]
@@ -258,7 +278,7 @@ def add_feature_set(
             volume_window=crypto_volume_window,
             time_features=crypto_time_features,
         )
-    if crypto_regime_features_enabled:
+    if crypto_regime_features_enabled or crypto_regime_signal_features_enabled:
         featured = _add_crypto_regime_features(
             featured,
             trend_windows=crypto_regime_trend_windows or [],
@@ -267,4 +287,6 @@ def add_feature_set(
             drawdown_window=crypto_regime_drawdown_window,
             volume_window=crypto_regime_volume_window,
         )
+    if crypto_regime_signal_features_enabled:
+        featured = _add_crypto_regime_signal_features(featured)
     return featured

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -49,6 +49,7 @@ from marketlab.reports.analytics import (
     build_turnover_costs,
 )
 from marketlab.reports.markdown import write_markdown_report
+from marketlab.reports.phase8_methodology import build_phase8_methodology_review
 from marketlab.reports.phase8_summary import build_phase8_run_summary
 from marketlab.reports.plots import (
     plot_calibration_curves,
@@ -197,6 +198,7 @@ class ExperimentArtifacts:
     regime_slice_diagnostics_path: Path | None = None
     strict_research_gate_path: Path | None = None
     phase8_run_summary_path: Path | None = None
+    phase8_methodology_review_path: Path | None = None
     pattern_price_overlay_plot_path: Path | None = None
     pattern_detections_plot_path: Path | None = None
     pattern_detection_windows_plot_path: Path | None = None
@@ -1241,6 +1243,8 @@ def _persist_experiment_outputs(
 
     phase8_run_summary: pd.DataFrame | None = None
     phase8_run_summary_path: Path | None = None
+    phase8_methodology_review: pd.DataFrame | None = None
+    phase8_methodology_review_path: Path | None = None
     if (
         config.evaluation.strict_research_gate.enabled
         or ml_strategy_tuning_candidates is not None
@@ -1250,6 +1254,9 @@ def _persist_experiment_outputs(
         phase8_run_summary = build_phase8_run_summary(artifact_run_dir)
         phase8_run_summary_path = artifact_run_dir / "phase8_run_summary.csv"
         phase8_run_summary.to_csv(phase8_run_summary_path, index=False)
+        phase8_methodology_review = build_phase8_methodology_review(artifact_run_dir)
+        phase8_methodology_review_path = artifact_run_dir / "phase8_methodology_review.csv"
+        phase8_methodology_review.to_csv(phase8_methodology_review_path, index=False)
 
     cumulative_plot_path: Path | None = None
     drawdown_plot_path: Path | None = None
@@ -1379,6 +1386,7 @@ def _persist_experiment_outputs(
             regime_slice_diagnostics=regime_slice_diagnostics,
             strict_research_gate=strict_research_gate,
             phase8_run_summary=phase8_run_summary,
+            phase8_methodology_review=phase8_methodology_review,
             fold_diagnostics=fold_diagnostics,
             threshold_diagnostics=threshold_diagnostics,
             calibration_curves_plot_path=calibration_curves_plot_path,
@@ -1415,6 +1423,7 @@ def _persist_experiment_outputs(
             regime_slice_diagnostics_path=regime_slice_diagnostics_path,
             strict_research_gate_path=strict_research_gate_path,
             phase8_run_summary_path=phase8_run_summary_path,
+            phase8_methodology_review_path=phase8_methodology_review_path,
             pattern_price_overlay_plot_path=pattern_price_overlay_plot_path,
             pattern_detections_plot_path=pattern_detections_plot_path,
             pattern_detection_windows_plot_path=pattern_detection_windows_plot_path,
@@ -1473,6 +1482,7 @@ def _persist_experiment_outputs(
         regime_slice_diagnostics_path=regime_slice_diagnostics_path,
         strict_research_gate_path=strict_research_gate_path,
         phase8_run_summary_path=phase8_run_summary_path,
+        phase8_methodology_review_path=phase8_methodology_review_path,
         pattern_price_overlay_plot_path=pattern_price_overlay_plot_path,
         pattern_detections_plot_path=pattern_detections_plot_path,
         pattern_detection_windows_plot_path=pattern_detection_windows_plot_path,

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -49,6 +49,7 @@ from marketlab.reports.analytics import (
     build_monthly_returns,
     build_strategy_summary,
     build_turnover_costs,
+    reprice_performance,
 )
 from marketlab.reports.markdown import write_markdown_report
 from marketlab.reports.phase8_methodology import build_phase8_methodology_review
@@ -144,6 +145,7 @@ ML_TUNED_STRATEGY_NAME = "ml_indicator_tuned__long_only__cash"
 BENCHMARK_SELECTION_FAILURE_REASONS = {
     "non_positive_buy_hold_excess",
     "non_positive_required_benchmark_excess",
+    "non_positive_validation_cost_benchmark_excess",
 }
 SCORE_VALIDITY_FAILURE_REASONS = {
     "negative_score_forward_return_correlation",
@@ -2925,6 +2927,23 @@ def _score_policy_repair_authorization(
     return True, ""
 
 
+def _guarded_gate_bull_risk_off_override_authorization(
+    *,
+    enabled: bool,
+    validation_raw_score_forward_return_correlation: object,
+) -> tuple[bool, str]:
+    if not enabled:
+        return False, ""
+    if pd.isna(validation_raw_score_forward_return_correlation):
+        return False, "non_finite_validation_raw_score_forward_return_correlation"
+    correlation = float(validation_raw_score_forward_return_correlation)
+    if not math.isfinite(correlation):
+        return False, "non_finite_validation_raw_score_forward_return_correlation"
+    if correlation < 0.0:
+        return False, "negative_validation_raw_score_forward_return_correlation"
+    return True, ""
+
+
 def _apply_allocation_score_transform(
     *,
     rows: pd.DataFrame,
@@ -3426,6 +3445,11 @@ def _allocation_score_policy_prob100_threshold_candidates(
     return [float(tuning.allocation_score_policy_prob100_threshold)]
 
 
+def _selection_validation_cost_bps(config: ExperimentConfig) -> list[float]:
+    configured = config.evaluation.ml_strategy_tuning.selection_validation_cost_bps
+    return configured or [float(config.portfolio.costs.bps_per_trade)]
+
+
 def _allocation_score_transform_candidates(
     config: ExperimentConfig,
 ) -> list[AllocationScoreTransformConfig]:
@@ -3440,6 +3464,9 @@ def _prediction_frame_with_allocation_score_policy(
     prob100_threshold: float,
     score_policy_repair_authorized: bool = False,
     score_policy_repair_denied_reason: str = "",
+    guarded_gate_bull_risk_off_override_enabled: bool = False,
+    guarded_gate_bull_risk_off_override_authorized: bool = False,
+    guarded_gate_bull_risk_off_override_denied_reason: str = "",
     score_transform: AllocationScoreTransformConfig | None = None,
 ) -> pd.DataFrame:
     working = predictions.copy()
@@ -3488,6 +3515,27 @@ def _prediction_frame_with_allocation_score_policy(
         working["predicted_tier_weight"] = working["score"].map(
             lambda value: nearest_tier(float(value))
         )
+    working["guarded_gate_bull_risk_off_override_authorized"] = bool(
+        guarded_gate_bull_risk_off_override_authorized
+    )
+    working["guarded_gate_bull_risk_off_override_denied_reason"] = (
+        guarded_gate_bull_risk_off_override_denied_reason
+    )
+    guarded_override_triggered = pd.Series(False, index=working.index, dtype=bool)
+    if (
+        guarded_gate_bull_risk_off_override_enabled
+        and guarded_gate_bull_risk_off_override_authorized
+    ):
+        guarded_override_triggered = (
+            working.get(
+                "gate_bull",
+                pd.Series(False, index=working.index, dtype=bool),
+            ).map(_truthy)
+            & working.apply(_allocation_regime_label, axis=1).eq("risk_off")
+        )
+    working["guarded_gate_bull_risk_off_override_triggered"] = (
+        guarded_override_triggered.to_numpy(dtype=bool)
+    )
     return working
 
 
@@ -3600,6 +3648,7 @@ def _candidate_failure_reasons(
     benchmark_relative_selection: bool,
     missing_selection_benchmarks: list[str],
     benchmark_excess_values: list[float],
+    validation_cost_benchmark_gate_ok: bool,
     risk_gate_ok: bool,
     score_validity_ok: bool = True,
 ) -> str:
@@ -3618,6 +3667,8 @@ def _candidate_failure_reasons(
                 reasons.append("non_positive_required_benchmark_excess")
         else:
             reasons.append("non_positive_buy_hold_excess")
+    if not validation_cost_benchmark_gate_ok:
+        reasons.append("non_positive_validation_cost_benchmark_excess")
     if not risk_gate_ok:
         reasons.append("risk_not_improved")
     if not score_validity_ok:
@@ -3784,11 +3835,20 @@ def _select_ml_strategy_candidate(candidates: list[dict[str, object]]) -> dict[s
     if not candidates:
         raise ValueError("ML strategy candidate selection requires at least one candidate.")
 
-    def _selection_score(row: dict[str, object]) -> tuple[float, float, float, float, float]:
+    def _selection_score(
+        row: dict[str, object],
+    ) -> tuple[float, float, float, float, float, float]:
+        min_validation_cost_benchmark_excess = row.get(
+            "min_selection_validation_cost_benchmark_excess_cumulative_return",
+            pd.NA,
+        )
         min_benchmark_excess = row.get("min_benchmark_excess_cumulative_return", pd.NA)
         if pd.isna(min_benchmark_excess):
             min_benchmark_excess = row["excess_cumulative_return"]
+        if pd.isna(min_validation_cost_benchmark_excess):
+            min_validation_cost_benchmark_excess = min_benchmark_excess
         return (
+            float(min_validation_cost_benchmark_excess),
             float(min_benchmark_excess),
             float(row["excess_cumulative_return"]),
             float(row["drawdown_delta"]),
@@ -3859,6 +3919,9 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
+        "guarded_gate_bull_risk_off_override_triggered",
         "score_transform_applied",
         "score",
         *probability_columns,
@@ -3873,6 +3936,8 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         "fold_predicted_100_fraction",
         "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_guarded_gate_bull_risk_off_override_authorized_fraction",
+        "fold_guarded_gate_bull_risk_off_override_triggered_fraction",
         "fold_score_transform_applied_fraction",
     ]
     if predictions.empty:
@@ -3896,6 +3961,12 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         working["score_policy_repair_authorized"] = False
     if "score_policy_repair_denied_reason" not in working.columns:
         working["score_policy_repair_denied_reason"] = ""
+    if "guarded_gate_bull_risk_off_override_authorized" not in working.columns:
+        working["guarded_gate_bull_risk_off_override_authorized"] = False
+    if "guarded_gate_bull_risk_off_override_denied_reason" not in working.columns:
+        working["guarded_gate_bull_risk_off_override_denied_reason"] = ""
+    if "guarded_gate_bull_risk_off_override_triggered" not in working.columns:
+        working["guarded_gate_bull_risk_off_override_triggered"] = False
     if "score_transform_applied" not in working.columns:
         working["score_transform_applied"] = False
     for column, value in _score_transform_metadata(AllocationScoreTransformConfig()).items():
@@ -3949,6 +4020,26 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         .reset_index()
     )
     working = working.merge(trigger_support, on="fold_id", how="left")
+    guarded_override_authorization = (
+        working.groupby("fold_id")["guarded_gate_bull_risk_off_override_authorized"]
+        .agg(
+            fold_guarded_gate_bull_risk_off_override_authorized_fraction=lambda values: float(
+                values.astype(bool).mean()
+            )
+        )
+        .reset_index()
+    )
+    working = working.merge(guarded_override_authorization, on="fold_id", how="left")
+    guarded_override_trigger_support = (
+        working.groupby("fold_id")["guarded_gate_bull_risk_off_override_triggered"]
+        .agg(
+            fold_guarded_gate_bull_risk_off_override_triggered_fraction=lambda values: float(
+                values.astype(bool).mean()
+            )
+        )
+        .reset_index()
+    )
+    working = working.merge(guarded_override_trigger_support, on="fold_id", how="left")
     transform_support = (
         working.groupby("fold_id")["score_transform_applied"]
         .agg(
@@ -4139,6 +4230,9 @@ def _build_ml_strategy_tuning_outputs(
         "selection_benchmark_strategies",
         "selection_benchmark_excess_cumulative_returns",
         "min_benchmark_excess_cumulative_return",
+        "selection_validation_cost_bps",
+        "selection_validation_cost_benchmark_excess_cumulative_returns",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
         "validation_predicted_25_fraction",
         "validation_predicted_50_fraction",
         "validation_predicted_100_fraction",
@@ -4148,10 +4242,14 @@ def _build_ml_strategy_tuning_outputs(
         "validation_score_policy_repair_authorized",
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
+        "validation_guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
         "validation_gate_bull_average_exposure",
         "validation_gate_bull_underexposed_positive_benchmark_fraction",
         "validation_gate_bull_underexposed_positive_benchmark_return_sum",
         "validation_score_policy_triggered_100_fraction",
+        "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
         "validation_score_transform_applied_fraction",
         "min_validation_predicted_target_fraction",
         "sharpe_like_delta",
@@ -4203,6 +4301,9 @@ def _build_ml_strategy_tuning_outputs(
         "selection_benchmark_strategies",
         "selection_benchmark_excess_cumulative_returns",
         "min_benchmark_excess_cumulative_return",
+        "selection_validation_cost_bps",
+        "selection_validation_cost_benchmark_excess_cumulative_returns",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
         "validation_predicted_25_fraction",
         "validation_predicted_50_fraction",
         "validation_predicted_100_fraction",
@@ -4212,10 +4313,14 @@ def _build_ml_strategy_tuning_outputs(
         "validation_score_policy_repair_authorized",
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
+        "validation_guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
         "validation_gate_bull_average_exposure",
         "validation_gate_bull_underexposed_positive_benchmark_fraction",
         "validation_gate_bull_underexposed_positive_benchmark_return_sum",
         "validation_score_policy_triggered_100_fraction",
+        "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
         "validation_score_transform_applied_fraction",
         "min_validation_predicted_target_fraction",
         "sharpe_like_delta",
@@ -4253,6 +4358,9 @@ def _build_ml_strategy_tuning_outputs(
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
+        "guarded_gate_bull_risk_off_override_triggered",
         "score_transform_applied",
         "score",
         "prob_tier_0",
@@ -4270,6 +4378,8 @@ def _build_ml_strategy_tuning_outputs(
         "fold_predicted_100_fraction",
         "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_guarded_gate_bull_risk_off_override_authorized_fraction",
+        "fold_guarded_gate_bull_risk_off_override_triggered_fraction",
         "fold_score_transform_applied_fraction",
     ]
     feature_importance_columns = [
@@ -4348,6 +4458,14 @@ def _build_ml_strategy_tuning_outputs(
     feature_importance_frames: list[pd.DataFrame] = []
     panel_timestamps = pd.to_datetime(panel["timestamp"])
     fallback_regime_policy = _no_candidate_fallback_regime_policy(config)
+    selection_validation_cost_bps = _selection_validation_cost_bps(config)
+    baseline_performance_by_cost = {
+        float(cost_bps): reprice_performance(baseline_performance, float(cost_bps))
+        for cost_bps in {
+            float(config.portfolio.costs.bps_per_trade),
+            *selection_validation_cost_bps,
+        }
+    }
 
     def _deterministic_fallback_selection(
         *,
@@ -4423,6 +4541,11 @@ def _build_ml_strategy_tuning_outputs(
             "selection_benchmark_strategies": ",".join(selection_benchmark_names),
             "selection_benchmark_excess_cumulative_returns": pd.NA,
             "min_benchmark_excess_cumulative_return": pd.NA,
+            "selection_validation_cost_bps": ",".join(
+                f"{cost_bps:g}" for cost_bps in selection_validation_cost_bps
+            ),
+            "selection_validation_cost_benchmark_excess_cumulative_returns": pd.NA,
+            "min_selection_validation_cost_benchmark_excess_cumulative_return": pd.NA,
             "validation_predicted_25_fraction": pd.NA,
             "validation_predicted_50_fraction": pd.NA,
             "validation_predicted_100_fraction": pd.NA,
@@ -4436,10 +4559,18 @@ def _build_ml_strategy_tuning_outputs(
                 if tuning.allocation_score_policy == "gate_bull_prob100_threshold"
                 else ""
             ),
+            "validation_guarded_gate_bull_risk_off_override_authorized": False,
+            "guarded_gate_bull_risk_off_override_authorized": False,
+            "guarded_gate_bull_risk_off_override_denied_reason": (
+                "regime_policy_fallback_no_valid_candidate"
+                if tuning.guarded_gate_bull_risk_off_override
+                else ""
+            ),
             "validation_gate_bull_average_exposure": pd.NA,
             "validation_gate_bull_underexposed_positive_benchmark_fraction": pd.NA,
             "validation_gate_bull_underexposed_positive_benchmark_return_sum": pd.NA,
             "validation_score_policy_triggered_100_fraction": pd.NA,
+            "validation_guarded_gate_bull_risk_off_override_triggered_fraction": pd.NA,
             "validation_score_transform_applied_fraction": pd.NA,
             "min_validation_predicted_target_fraction": pd.NA,
             "sharpe_like_delta": pd.NA,
@@ -4499,6 +4630,32 @@ def _build_ml_strategy_tuning_outputs(
                     continue
                 selection_benchmark_returns[benchmark_name] = float(
                     benchmark_window_metrics["cumulative_return"]
+                )
+            selection_benchmark_returns_by_cost: dict[float, dict[str, float]] = {}
+            missing_selection_benchmarks_by_cost: dict[float, list[str]] = {}
+            for cost_bps in selection_validation_cost_bps:
+                cost_benchmark_returns: dict[str, float] = {}
+                cost_missing_benchmarks: list[str] = []
+                cost_performance = baseline_performance_by_cost[float(cost_bps)]
+                for benchmark_name in selection_benchmark_names:
+                    try:
+                        benchmark_window_metrics = _strategy_metrics_for_window(
+                            performance=cost_performance,
+                            strategy_name=benchmark_name,
+                            window_dates=validation_dates,
+                            periods_per_year=config.evaluation.periods_per_year,
+                        )
+                    except RuntimeError:
+                        cost_missing_benchmarks.append(benchmark_name)
+                        continue
+                    cost_benchmark_returns[benchmark_name] = float(
+                        benchmark_window_metrics["cumulative_return"]
+                    )
+                selection_benchmark_returns_by_cost[float(cost_bps)] = (
+                    cost_benchmark_returns
+                )
+                missing_selection_benchmarks_by_cost[float(cost_bps)] = (
+                    cost_missing_benchmarks
                 )
 
             for model_spec in config.models:
@@ -4563,6 +4720,17 @@ def _build_ml_strategy_tuning_outputs(
                                 ]
                             ),
                         )
+                        (
+                            guarded_gate_bull_risk_off_override_authorized,
+                            guarded_gate_bull_risk_off_override_denied_reason,
+                        ) = _guarded_gate_bull_risk_off_override_authorization(
+                            enabled=tuning.guarded_gate_bull_risk_off_override,
+                            validation_raw_score_forward_return_correlation=(
+                                base_score_validity_metrics[
+                                    "validation_raw_score_forward_return_correlation"
+                                ]
+                            ),
+                        )
                         candidate_thresholds: list[
                             tuple[
                                 float,
@@ -4613,6 +4781,15 @@ def _build_ml_strategy_tuning_outputs(
                                     score_policy_repair_denied_reason=(
                                         score_policy_repair_denied_reason
                                     ),
+                                    guarded_gate_bull_risk_off_override_enabled=(
+                                        tuning.guarded_gate_bull_risk_off_override
+                                    ),
+                                    guarded_gate_bull_risk_off_override_authorized=(
+                                        guarded_gate_bull_risk_off_override_authorized
+                                    ),
+                                    guarded_gate_bull_risk_off_override_denied_reason=(
+                                        guarded_gate_bull_risk_off_override_denied_reason
+                                    ),
                                     score_transform=score_transform,
                                 )
                             )
@@ -4650,6 +4827,13 @@ def _build_ml_strategy_tuning_outputs(
                                 )
                             else:
                                 validation_score_policy_triggered_100_fraction = pd.NA
+                            validation_guarded_gate_bull_risk_off_override_triggered_fraction = float(
+                                validation_predictions[
+                                    "guarded_gate_bull_risk_off_override_triggered"
+                                ]
+                                .astype(bool)
+                                .mean()
+                            )
                             if "score_transform_applied" in validation_predictions.columns:
                                 validation_score_transform_applied_fraction = float(
                                     validation_predictions[
@@ -4698,11 +4882,20 @@ def _build_ml_strategy_tuning_outputs(
                                         )
                                         if weights.empty:
                                             continue
-                                        performance = run_backtest(
-                                            panel=validation_panel,
-                                            weights=weights,
-                                            cost_bps=config.portfolio.costs.bps_per_trade,
-                                        )
+                                        performance_by_cost = {
+                                            float(cost_bps): run_backtest(
+                                                panel=validation_panel,
+                                                weights=weights,
+                                                cost_bps=float(cost_bps),
+                                            )
+                                            for cost_bps in {
+                                                float(config.portfolio.costs.bps_per_trade),
+                                                *selection_validation_cost_bps,
+                                            }
+                                        }
+                                        performance = performance_by_cost[
+                                            float(config.portfolio.costs.bps_per_trade)
+                                        ]
                                         metrics = compute_strategy_metrics(
                                             performance,
                                             periods_per_year=config.evaluation.periods_per_year,
@@ -4757,6 +4950,63 @@ def _build_ml_strategy_tuning_outputs(
                                                 ]
                                                 if value
                                             )
+                                        validation_cost_benchmark_excess_values: list[float] = []
+                                        validation_cost_benchmark_excess_summary_parts: list[
+                                            str
+                                        ] = []
+                                        for cost_bps in selection_validation_cost_bps:
+                                            cost_metrics = compute_strategy_metrics(
+                                                performance_by_cost[float(cost_bps)],
+                                                periods_per_year=(
+                                                    config.evaluation.periods_per_year
+                                                ),
+                                            ).iloc[0]
+                                            cost_excess_returns = {
+                                                name: float(
+                                                    cost_metrics["cumulative_return"]
+                                                )
+                                                - benchmark_return
+                                                for name, benchmark_return in (
+                                                    selection_benchmark_returns_by_cost[
+                                                        float(cost_bps)
+                                                    ].items()
+                                                )
+                                            }
+                                            validation_cost_benchmark_excess_values.extend(
+                                                cost_excess_returns.values()
+                                            )
+                                            validation_cost_benchmark_excess_summary_parts.extend(
+                                                f"{float(cost_bps):g}:{name}:{cost_excess_returns[name]:.12g}"
+                                                for name in selection_benchmark_names
+                                                if name in cost_excess_returns
+                                            )
+                                            validation_cost_benchmark_excess_summary_parts.extend(
+                                                f"{float(cost_bps):g}:{name}:missing"
+                                                for name in missing_selection_benchmarks_by_cost[
+                                                    float(cost_bps)
+                                                ]
+                                            )
+                                        min_validation_cost_benchmark_excess_return = (
+                                            min(
+                                                validation_cost_benchmark_excess_values
+                                            )
+                                            if validation_cost_benchmark_excess_values
+                                            else pd.NA
+                                        )
+                                        validation_cost_benchmark_gate_ok = (
+                                            not any(
+                                                missing_selection_benchmarks_by_cost.values()
+                                            )
+                                            and bool(
+                                                validation_cost_benchmark_excess_values
+                                            )
+                                            and all(
+                                                excess > 0.0
+                                                for excess in (
+                                                    validation_cost_benchmark_excess_values
+                                                )
+                                            )
+                                        )
                                         sharpe_delta = (
                                             float(metrics["sharpe_like"]) - buy_hold_sharpe
                                         )
@@ -4806,6 +5056,9 @@ def _build_ml_strategy_tuning_outputs(
                                                 missing_selection_benchmarks
                                             ),
                                             benchmark_excess_values=benchmark_excess_values,
+                                            validation_cost_benchmark_gate_ok=(
+                                                validation_cost_benchmark_gate_ok
+                                            ),
                                             risk_gate_ok=risk_gate_ok,
                                             score_validity_ok=score_validity_ok,
                                         )
@@ -4814,6 +5067,7 @@ def _build_ml_strategy_tuning_outputs(
                                             and turnover_budget_ok
                                             and predicted_support_ok
                                             and benchmark_gate_ok
+                                            and validation_cost_benchmark_gate_ok
                                             and risk_gate_ok
                                             and score_validity_ok
                                         )
@@ -4920,6 +5174,16 @@ def _build_ml_strategy_tuning_outputs(
                                             "min_benchmark_excess_cumulative_return": (
                                                 min_benchmark_excess_return
                                             ),
+                                            "selection_validation_cost_bps": ",".join(
+                                                f"{cost_bps:g}"
+                                                for cost_bps in selection_validation_cost_bps
+                                            ),
+                                            "selection_validation_cost_benchmark_excess_cumulative_returns": ";".join(
+                                                validation_cost_benchmark_excess_summary_parts
+                                            ),
+                                            "min_selection_validation_cost_benchmark_excess_cumulative_return": (
+                                                min_validation_cost_benchmark_excess_return
+                                            ),
                                             "validation_predicted_25_fraction": (
                                                 validation_predicted_25_fraction
                                             ),
@@ -4939,9 +5203,21 @@ def _build_ml_strategy_tuning_outputs(
                                             "score_policy_repair_denied_reason": (
                                                 score_policy_repair_denied_reason
                                             ),
+                                            "validation_guarded_gate_bull_risk_off_override_authorized": (
+                                                guarded_gate_bull_risk_off_override_authorized
+                                            ),
+                                            "guarded_gate_bull_risk_off_override_authorized": (
+                                                guarded_gate_bull_risk_off_override_authorized
+                                            ),
+                                            "guarded_gate_bull_risk_off_override_denied_reason": (
+                                                guarded_gate_bull_risk_off_override_denied_reason
+                                            ),
                                             **gate_bull_metrics,
                                             "validation_score_policy_triggered_100_fraction": (
                                                 validation_score_policy_triggered_100_fraction
+                                            ),
+                                            "validation_guarded_gate_bull_risk_off_override_triggered_fraction": (
+                                                validation_guarded_gate_bull_risk_off_override_triggered_fraction
                                             ),
                                             "validation_score_transform_applied_fraction": (
                                                 validation_score_transform_applied_fraction
@@ -5032,6 +5308,11 @@ def _build_ml_strategy_tuning_outputs(
                     "selection_benchmark_strategies": ",".join(selection_benchmark_names),
                     "selection_benchmark_excess_cumulative_returns": pd.NA,
                     "min_benchmark_excess_cumulative_return": pd.NA,
+                    "selection_validation_cost_bps": ",".join(
+                        f"{cost_bps:g}" for cost_bps in selection_validation_cost_bps
+                    ),
+                    "selection_validation_cost_benchmark_excess_cumulative_returns": pd.NA,
+                    "min_selection_validation_cost_benchmark_excess_cumulative_return": pd.NA,
                     "validation_predicted_25_fraction": pd.NA,
                     "validation_predicted_50_fraction": pd.NA,
                     "validation_predicted_100_fraction": pd.NA,
@@ -5046,10 +5327,18 @@ def _build_ml_strategy_tuning_outputs(
                         == "gate_bull_prob100_threshold"
                         else ""
                     ),
+                    "validation_guarded_gate_bull_risk_off_override_authorized": False,
+                    "guarded_gate_bull_risk_off_override_authorized": False,
+                    "guarded_gate_bull_risk_off_override_denied_reason": (
+                        "no_valid_candidate"
+                        if tuning.guarded_gate_bull_risk_off_override
+                        else ""
+                    ),
                     "validation_gate_bull_average_exposure": pd.NA,
                     "validation_gate_bull_underexposed_positive_benchmark_fraction": pd.NA,
                     "validation_gate_bull_underexposed_positive_benchmark_return_sum": pd.NA,
                     "validation_score_policy_triggered_100_fraction": pd.NA,
+                    "validation_guarded_gate_bull_risk_off_override_triggered_fraction": pd.NA,
                     "validation_score_transform_applied_fraction": pd.NA,
                     "min_validation_predicted_target_fraction": pd.NA,
                     "sharpe_like_delta": pd.NA,
@@ -5079,6 +5368,16 @@ def _build_ml_strategy_tuning_outputs(
         selected_score_policy_repair_denied_reason = (
             str(selected["score_policy_repair_denied_reason"])
             if pd.notna(selected["score_policy_repair_denied_reason"])
+            else ""
+        )
+        selected_guarded_gate_bull_risk_off_override_authorized = bool(
+            selected["validation_guarded_gate_bull_risk_off_override_authorized"]
+        )
+        selected_guarded_gate_bull_risk_off_override_denied_reason = (
+            str(selected["guarded_gate_bull_risk_off_override_denied_reason"])
+            if pd.notna(
+                selected["guarded_gate_bull_risk_off_override_denied_reason"]
+            )
             else ""
         )
         selected_score_transform = AllocationScoreTransformConfig(
@@ -5191,6 +5490,15 @@ def _build_ml_strategy_tuning_outputs(
                 ),
                 score_policy_repair_denied_reason=(
                     selected_score_policy_repair_denied_reason
+                ),
+                guarded_gate_bull_risk_off_override_enabled=(
+                    tuning.guarded_gate_bull_risk_off_override
+                ),
+                guarded_gate_bull_risk_off_override_authorized=(
+                    selected_guarded_gate_bull_risk_off_override_authorized
+                ),
+                guarded_gate_bull_risk_off_override_denied_reason=(
+                    selected_guarded_gate_bull_risk_off_override_denied_reason
                 ),
                 score_transform=selected_score_transform,
             )
@@ -5349,6 +5657,15 @@ def _build_ml_strategy_tuning_outputs(
                 "min_benchmark_excess_cumulative_return": selected[
                     "min_benchmark_excess_cumulative_return"
                 ],
+                "selection_validation_cost_bps": selected[
+                    "selection_validation_cost_bps"
+                ],
+                "selection_validation_cost_benchmark_excess_cumulative_returns": selected[
+                    "selection_validation_cost_benchmark_excess_cumulative_returns"
+                ],
+                "min_selection_validation_cost_benchmark_excess_cumulative_return": selected[
+                    "min_selection_validation_cost_benchmark_excess_cumulative_return"
+                ],
                 "validation_predicted_25_fraction": selected[
                     "validation_predicted_25_fraction"
                 ],
@@ -5380,6 +5697,19 @@ def _build_ml_strategy_tuning_outputs(
                     if selection_status == "selected"
                     else ""
                 ),
+                "validation_guarded_gate_bull_risk_off_override_authorized": selected[
+                    "validation_guarded_gate_bull_risk_off_override_authorized"
+                ],
+                "guarded_gate_bull_risk_off_override_authorized": (
+                    selected_guarded_gate_bull_risk_off_override_authorized
+                    if selection_status == "selected"
+                    else False
+                ),
+                "guarded_gate_bull_risk_off_override_denied_reason": (
+                    selected_guarded_gate_bull_risk_off_override_denied_reason
+                    if selection_status == "selected"
+                    else ""
+                ),
                 "validation_gate_bull_average_exposure": selected[
                     "validation_gate_bull_average_exposure"
                 ],
@@ -5391,6 +5721,9 @@ def _build_ml_strategy_tuning_outputs(
                 ],
                 "validation_score_policy_triggered_100_fraction": selected[
                     "validation_score_policy_triggered_100_fraction"
+                ],
+                "validation_guarded_gate_bull_risk_off_override_triggered_fraction": selected[
+                    "validation_guarded_gate_bull_risk_off_override_triggered_fraction"
                 ],
                 "validation_score_transform_applied_fraction": selected[
                     "validation_score_transform_applied_fraction"
@@ -5417,6 +5750,7 @@ def _build_ml_strategy_tuning_outputs(
             [
                 "fold_id",
                 "passed_gate",
+                "min_selection_validation_cost_benchmark_excess_cumulative_return",
                 "min_benchmark_excess_cumulative_return",
                 "excess_cumulative_return",
                 "drawdown_delta",
@@ -5430,6 +5764,7 @@ def _build_ml_strategy_tuning_outputs(
             ],
             ascending=[
                 True,
+                False,
                 False,
                 False,
                 False,

--- a/src/marketlab/pipeline.py
+++ b/src/marketlab/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -17,6 +18,7 @@ from marketlab.backtest.engine import (
 )
 from marketlab.backtest.metrics import compute_strategy_metrics
 from marketlab.config import (
+    AllocationScoreTransformConfig,
     AllocationUtilityProfileConfig,
     ExperimentConfig,
     RegimeParticipationPolicyConfig,
@@ -142,6 +144,9 @@ ML_TUNED_STRATEGY_NAME = "ml_indicator_tuned__long_only__cash"
 BENCHMARK_SELECTION_FAILURE_REASONS = {
     "non_positive_buy_hold_excess",
     "non_positive_required_benchmark_excess",
+}
+SCORE_VALIDITY_FAILURE_REASONS = {
+    "negative_score_forward_return_correlation",
 }
 
 
@@ -401,6 +406,14 @@ def _last_percentile(values: pd.Series) -> float:
     return float(values.rank(pct=True).iloc[-1])
 
 
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
 def _btc_regime_masks(panel: pd.DataFrame, config: ExperimentConfig) -> dict[str, pd.Index]:
     if panel.empty:
         return {}
@@ -444,6 +457,22 @@ def _btc_regime_masks(panel: pd.DataFrame, config: ExperimentConfig) -> dict[str
         "high_volatility": dates[high_volatility.fillna(False).to_numpy()],
         "recent": dates[dates >= recent_start],
     }
+
+
+def _with_completed_bar_gate_labels(
+    rows: pd.DataFrame,
+    *,
+    panel: pd.DataFrame,
+    config: ExperimentConfig,
+) -> pd.DataFrame:
+    if rows.empty or "signal_date" not in rows.columns:
+        return rows.copy()
+
+    working = rows.copy()
+    signal_dates = pd.to_datetime(working["signal_date"], errors="coerce")
+    for slice_name, dates in _btc_regime_masks(panel, config).items():
+        working[f"gate_{slice_name}"] = signal_dates.isin(pd.to_datetime(list(dates)))
+    return working
 
 
 def _regime_slice_diagnostics(
@@ -531,7 +560,10 @@ def _gate_benchmark_strategies(config: ExperimentConfig) -> list[str]:
 
 def _selection_benchmark_strategies(config: ExperimentConfig) -> list[str]:
     tuning = config.evaluation.ml_strategy_tuning
-    if tuning.objective == "net_return_and_risk_vs_required_benchmarks":
+    if tuning.objective in {
+        "net_return_and_risk_vs_required_benchmarks",
+        "net_return_risk_score_validity_vs_required_benchmarks",
+    }:
         benchmark_names = [str(value) for value in tuning.selection_benchmark_strategies]
     else:
         benchmark_names = ["buy_hold"]
@@ -2618,6 +2650,9 @@ def _prediction_frame_for_rows(
     regime_columns = [column for column in rows.columns if str(column).startswith("crypto_regime_")]
     for column in regime_columns:
         prediction_frame[column] = rows[column].to_numpy()
+    gate_columns = [column for column in rows.columns if str(column).startswith("gate_")]
+    for column in gate_columns:
+        prediction_frame[column] = rows[column].to_numpy()
     return prediction_frame
 
 
@@ -2837,28 +2872,134 @@ def _apply_allocation_score_policy(
     probability_frame: pd.DataFrame,
     allocation_score_policy: str,
     prob100_threshold: float,
+    score_policy_repair_authorized: bool = False,
 ) -> tuple[pd.Series, pd.Series]:
     final_scores = score_series.astype(float).copy()
     triggered_100 = pd.Series(False, index=score_series.index, dtype=bool)
     if allocation_score_policy == "expected_allocation":
         return final_scores.rename("score"), triggered_100
-    if allocation_score_policy != "bull_prob100_threshold":
+    if allocation_score_policy not in {
+        "bull_prob100_threshold",
+        "gate_bull_prob100_threshold",
+    }:
         raise ValueError(f"Unsupported allocation score policy: {allocation_score_policy}")
 
     required_columns = {"prob_tier_0", "prob_tier_100"}
     if not required_columns.issubset(probability_frame.columns):
         return final_scores.rename("score"), triggered_100
 
-    runtime_regime = rows.apply(_allocation_regime_label, axis=1)
     prob_tier_100 = probability_frame["prob_tier_100"].astype(float)
     prob_tier_0 = probability_frame["prob_tier_0"].astype(float)
+    if allocation_score_policy == "gate_bull_prob100_threshold":
+        if not score_policy_repair_authorized:
+            return final_scores.rename("score"), triggered_100
+        eligible_rows = rows.get(
+            "gate_bull",
+            pd.Series(False, index=rows.index, dtype=bool),
+        ).map(_truthy)
+    else:
+        eligible_rows = rows.apply(_allocation_regime_label, axis=1).eq("bull")
     triggered_100 = (
-        runtime_regime.eq("bull")
+        eligible_rows
         & prob_tier_100.ge(float(prob100_threshold))
         & prob_tier_100.ge(prob_tier_0)
     )
     final_scores.loc[triggered_100] = 1.0
     return final_scores.rename("score"), triggered_100.rename("score_policy_triggered_100")
+
+
+def _score_policy_repair_authorization(
+    *,
+    allocation_score_policy: str,
+    validation_raw_score_forward_return_correlation: object,
+) -> tuple[bool, str]:
+    if allocation_score_policy != "gate_bull_prob100_threshold":
+        return False, ""
+    if pd.isna(validation_raw_score_forward_return_correlation):
+        return False, "non_finite_validation_raw_score_forward_return_correlation"
+    correlation = float(validation_raw_score_forward_return_correlation)
+    if not math.isfinite(correlation):
+        return False, "non_finite_validation_raw_score_forward_return_correlation"
+    if correlation < 0.0:
+        return False, "negative_validation_raw_score_forward_return_correlation"
+    return True, ""
+
+
+def _apply_allocation_score_transform(
+    *,
+    rows: pd.DataFrame,
+    score_series: pd.Series,
+    score_transform: AllocationScoreTransformConfig,
+) -> tuple[pd.Series, pd.Series]:
+    base_scores = pd.to_numeric(score_series, errors="coerce").fillna(0.0).astype(float)
+    transformed = base_scores.copy()
+    runtime_regime = rows.apply(_allocation_regime_label, axis=1)
+    bull_rows = runtime_regime.eq("bull")
+    transformed.loc[bull_rows] = (
+        transformed.loc[bull_rows].mul(float(score_transform.bull_multiplier))
+        + float(score_transform.bull_addend)
+    )
+    if score_transform.risk_off_score_cap is not None:
+        risk_off_rows = runtime_regime.eq("risk_off")
+        transformed.loc[risk_off_rows] = transformed.loc[risk_off_rows].clip(
+            upper=float(score_transform.risk_off_score_cap)
+        )
+    if score_transform.non_bull_score_cap is not None:
+        non_bull_rows = ~bull_rows
+        transformed.loc[non_bull_rows] = transformed.loc[non_bull_rows].clip(
+            upper=float(score_transform.non_bull_score_cap)
+        )
+    transformed = transformed.clip(lower=0.0, upper=1.0)
+    applied = transformed.sub(base_scores).abs().gt(1e-12)
+    return transformed.rename("score"), applied.rename("score_transform_applied")
+
+
+def _score_transform_metadata(
+    score_transform: AllocationScoreTransformConfig,
+) -> dict[str, object]:
+    return {
+        "allocation_score_transform": score_transform.name,
+        "score_transform_bull_multiplier": float(score_transform.bull_multiplier),
+        "score_transform_bull_addend": float(score_transform.bull_addend),
+        "score_transform_risk_off_score_cap": (
+            float(score_transform.risk_off_score_cap)
+            if score_transform.risk_off_score_cap is not None
+            else pd.NA
+        ),
+        "score_transform_non_bull_score_cap": (
+            float(score_transform.non_bull_score_cap)
+            if score_transform.non_bull_score_cap is not None
+            else pd.NA
+        ),
+    }
+
+
+def _selected_score_transform_metadata(
+    score_transform: AllocationScoreTransformConfig | None,
+) -> dict[str, object]:
+    if score_transform is None:
+        return {
+            "selected_allocation_score_transform": pd.NA,
+            "selected_score_transform_bull_multiplier": pd.NA,
+            "selected_score_transform_bull_addend": pd.NA,
+            "selected_score_transform_risk_off_score_cap": pd.NA,
+            "selected_score_transform_non_bull_score_cap": pd.NA,
+        }
+    return {
+        "selected_allocation_score_transform": score_transform.name,
+        "selected_score_transform_bull_multiplier": float(score_transform.bull_multiplier),
+        "selected_score_transform_bull_addend": float(score_transform.bull_addend),
+        "selected_score_transform_risk_off_score_cap": (
+            float(score_transform.risk_off_score_cap)
+            if score_transform.risk_off_score_cap is not None
+            else pd.NA
+        ),
+        "selected_score_transform_non_bull_score_cap": (
+            float(score_transform.non_bull_score_cap)
+            if score_transform.non_bull_score_cap is not None
+            else pd.NA
+        ),
+    }
 
 
 def _score_model_rows(
@@ -2875,6 +3016,9 @@ def _score_model_rows(
     allocation_calibration_cv: int = 3,
     allocation_score_policy: str = "expected_allocation",
     allocation_score_policy_prob100_threshold: float = 0.20,
+    score_policy_repair_authorized: bool = False,
+    score_policy_repair_denied_reason: str = "",
+    allocation_score_transform: AllocationScoreTransformConfig | None = None,
     utility_profile: AllocationUtilityProfileConfig | None = None,
 ) -> ModelScoreOutput | None:
     train_target = train_rows["target"].astype(int)
@@ -2941,7 +3085,9 @@ def _score_model_rows(
     raw_expected_allocation_score = score_series.astype(float).rename(
         "raw_expected_allocation_score"
     )
+    selected_score_transform = allocation_score_transform or AllocationScoreTransformConfig()
     score_policy_triggered_100 = pd.Series(False, index=score_series.index, dtype=bool)
+    score_transform_applied = pd.Series(False, index=score_series.index, dtype=bool)
     if probability_frame is not None:
         score_series, score_policy_triggered_100 = _apply_allocation_score_policy(
             rows=score_rows,
@@ -2949,6 +3095,12 @@ def _score_model_rows(
             probability_frame=probability_frame,
             allocation_score_policy=allocation_score_policy,
             prob100_threshold=allocation_score_policy_prob100_threshold,
+            score_policy_repair_authorized=score_policy_repair_authorized,
+        )
+        score_series, score_transform_applied = _apply_allocation_score_transform(
+            rows=score_rows,
+            score_series=score_series,
+            score_transform=selected_score_transform,
         )
     predicted_target = pd.Series(
         estimator.predict(score_features),
@@ -2970,9 +3122,20 @@ def _score_model_rows(
         predictions["allocation_score_policy_prob100_threshold"] = float(
             allocation_score_policy_prob100_threshold
         )
+        predictions["score_policy_repair_authorized"] = bool(
+            score_policy_repair_authorized
+        )
+        predictions["score_policy_repair_denied_reason"] = (
+            score_policy_repair_denied_reason
+        )
+        for column, value in _score_transform_metadata(selected_score_transform).items():
+            predictions[column] = value
         predictions["raw_expected_allocation_score"] = raw_expected_allocation_score.to_numpy()
         predictions["final_allocation_score"] = predictions["score"].to_numpy()
         predictions["score_policy_triggered_100"] = score_policy_triggered_100.to_numpy(
+            dtype=bool
+        )
+        predictions["score_transform_applied"] = score_transform_applied.to_numpy(
             dtype=bool
         )
         predictions["predicted_weight"] = predictions["predicted_target"].map(
@@ -3212,6 +3375,11 @@ def _strategy_regime_policy(
             if policy.risk_off_cap is not None
             else None
         ),
+        gate_bull_floor=(
+            float(policy.gate_bull_floor)
+            if policy.gate_bull_floor is not None
+            else None
+        ),
     )
 
 
@@ -3243,6 +3411,86 @@ def _no_candidate_fallback_regime_policy(
     )
 
 
+def _allocation_score_policy_prob100_threshold_candidates(
+    config: ExperimentConfig,
+) -> list[float]:
+    tuning = config.evaluation.ml_strategy_tuning
+    if (
+        tuning.allocation_score_policy
+        in {"bull_prob100_threshold", "gate_bull_prob100_threshold"}
+        and tuning.allocation_score_policy_prob100_threshold_grid
+    ):
+        return sorted(
+            {float(value) for value in tuning.allocation_score_policy_prob100_threshold_grid}
+        )
+    return [float(tuning.allocation_score_policy_prob100_threshold)]
+
+
+def _allocation_score_transform_candidates(
+    config: ExperimentConfig,
+) -> list[AllocationScoreTransformConfig]:
+    transforms = config.evaluation.ml_strategy_tuning.allocation_score_transforms
+    return transforms or [AllocationScoreTransformConfig()]
+
+
+def _prediction_frame_with_allocation_score_policy(
+    *,
+    predictions: pd.DataFrame,
+    allocation_score_policy: str,
+    prob100_threshold: float,
+    score_policy_repair_authorized: bool = False,
+    score_policy_repair_denied_reason: str = "",
+    score_transform: AllocationScoreTransformConfig | None = None,
+) -> pd.DataFrame:
+    working = predictions.copy()
+    selected_score_transform = score_transform or AllocationScoreTransformConfig()
+    working["allocation_score_policy"] = allocation_score_policy
+    working["allocation_score_policy_prob100_threshold"] = float(prob100_threshold)
+    working["score_policy_repair_authorized"] = bool(score_policy_repair_authorized)
+    working["score_policy_repair_denied_reason"] = score_policy_repair_denied_reason
+    for column, value in _score_transform_metadata(selected_score_transform).items():
+        working[column] = value
+    probability_columns = {"prob_tier_0", "prob_tier_100"}
+    if probability_columns.issubset(working.columns):
+        raw_score = pd.Series(
+            pd.to_numeric(
+                working.get("raw_expected_allocation_score", working["score"]),
+                errors="coerce",
+            ).fillna(0.0),
+            index=working.index,
+            dtype=float,
+        )
+        score_series, triggered_100 = _apply_allocation_score_policy(
+            rows=working,
+            score_series=raw_score,
+            probability_frame=working,
+            allocation_score_policy=allocation_score_policy,
+            prob100_threshold=prob100_threshold,
+            score_policy_repair_authorized=score_policy_repair_authorized,
+        )
+        score_series, transform_applied = _apply_allocation_score_transform(
+            rows=working,
+            score_series=score_series,
+            score_transform=selected_score_transform,
+        )
+        working["score"] = score_series.to_numpy()
+        working["final_allocation_score"] = score_series.to_numpy()
+        working["score_policy_triggered_100"] = triggered_100.to_numpy(dtype=bool)
+        working["score_transform_applied"] = transform_applied.to_numpy(dtype=bool)
+    else:
+        working["score_policy_triggered_100"] = False
+        working["score_transform_applied"] = False
+        if "final_allocation_score" not in working.columns:
+            working["final_allocation_score"] = working["score"]
+    if "raw_expected_allocation_score" not in working.columns:
+        working["raw_expected_allocation_score"] = working["score"]
+    if "score" in working.columns:
+        working["predicted_tier_weight"] = working["score"].map(
+            lambda value: nearest_tier(float(value))
+        )
+    return working
+
+
 def _regime_policy_weight_for_row(
     row: pd.Series,
     policy: RegimeParticipationPolicyConfig,
@@ -3253,12 +3501,16 @@ def _regime_policy_weight_for_row(
             raise ValueError(
                 "Deterministic regime fallback requires the referenced policy to define risk_off_cap."
             )
-        return float(policy.risk_off_cap)
-    if regime == "bull":
-        return float(policy.bull_floor)
-    if regime == "bear":
-        return float(policy.bear_floor)
-    return float(policy.sideways_floor)
+        weight = float(policy.risk_off_cap)
+    elif regime == "bull":
+        weight = float(policy.bull_floor)
+    elif regime == "bear":
+        weight = float(policy.bear_floor)
+    else:
+        weight = float(policy.sideways_floor)
+    if policy.gate_bull_floor is not None and _truthy(row.get("gate_bull", False)):
+        weight = max(weight, float(policy.gate_bull_floor))
+    return weight
 
 
 def _deterministic_regime_fallback_weights_for_rows(
@@ -3349,6 +3601,7 @@ def _candidate_failure_reasons(
     missing_selection_benchmarks: list[str],
     benchmark_excess_values: list[float],
     risk_gate_ok: bool,
+    score_validity_ok: bool = True,
 ) -> str:
     reasons: list[str] = []
     if not active_candidate:
@@ -3367,6 +3620,8 @@ def _candidate_failure_reasons(
             reasons.append("non_positive_buy_hold_excess")
     if not risk_gate_ok:
         reasons.append("risk_not_improved")
+    if not score_validity_ok:
+        reasons.append("negative_score_forward_return_correlation")
     return ";".join(reasons)
 
 
@@ -3379,14 +3634,19 @@ def _candidate_failure_reason_set(row: dict[str, object]) -> set[str]:
 
 def _benchmark_only_fallback_candidates(
     candidates: list[dict[str, object]],
+    *,
+    allow_score_validity_fallback: bool = False,
 ) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
+    allowed_reasons = set(BENCHMARK_SELECTION_FAILURE_REASONS)
+    if allow_score_validity_fallback:
+        allowed_reasons.update(SCORE_VALIDITY_FAILURE_REASONS)
     for row in candidates:
         reasons = _candidate_failure_reason_set(row)
         if (
             not bool(row.get("passed_gate"))
             and reasons
-            and reasons.issubset(BENCHMARK_SELECTION_FAILURE_REASONS)
+            and reasons.issubset(allowed_reasons)
         ):
             rows.append(row)
     return rows
@@ -3411,6 +3671,113 @@ def _annualized_turnover(
 ) -> float:
     periods = max(1, int(pd.to_datetime(performance["date"]).nunique()))
     return float(total_turnover) / periods * periods_per_year
+
+
+def _safe_correlation(left: pd.Series, right: pd.Series) -> object:
+    frame = pd.DataFrame(
+        {
+            "left": pd.to_numeric(left, errors="coerce"),
+            "right": pd.to_numeric(right, errors="coerce"),
+        }
+    ).dropna()
+    if len(frame) < 2:
+        return pd.NA
+    if frame["left"].nunique() < 2 or frame["right"].nunique() < 2:
+        return pd.NA
+    value = float(frame["left"].corr(frame["right"]))
+    return value if math.isfinite(value) else pd.NA
+
+
+def _score_validity_metrics(predictions: pd.DataFrame) -> dict[str, object]:
+    if predictions.empty or "score" not in predictions.columns:
+        return {
+            "validation_score_forward_return_correlation": pd.NA,
+            "validation_raw_score_forward_return_correlation": pd.NA,
+            "validation_score_target_correlation": pd.NA,
+        }
+    target_column = "target_weight" if "target_weight" in predictions.columns else "target"
+    raw_score_column = (
+        "raw_expected_allocation_score"
+        if "raw_expected_allocation_score" in predictions.columns
+        else "score"
+    )
+    return {
+        "validation_score_forward_return_correlation": (
+            _safe_correlation(predictions["score"], predictions["forward_return"])
+            if "forward_return" in predictions.columns
+            else pd.NA
+        ),
+        "validation_raw_score_forward_return_correlation": (
+            _safe_correlation(predictions[raw_score_column], predictions["forward_return"])
+            if "forward_return" in predictions.columns
+            else pd.NA
+        ),
+        "validation_score_target_correlation": (
+            _safe_correlation(predictions["score"], predictions[target_column])
+            if target_column in predictions.columns
+            else pd.NA
+        ),
+    }
+
+
+def _gate_bull_underexposure_metrics(
+    *,
+    predictions: pd.DataFrame,
+    weights: pd.DataFrame,
+) -> dict[str, object]:
+    empty_metrics = {
+        "validation_gate_bull_average_exposure": pd.NA,
+        "validation_gate_bull_underexposed_positive_benchmark_fraction": pd.NA,
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum": pd.NA,
+    }
+    if (
+        predictions.empty
+        or weights.empty
+        or "gate_bull" not in predictions.columns
+        or "forward_return" not in predictions.columns
+    ):
+        return empty_metrics
+
+    exposure = (
+        weights.copy()
+        .assign(effective_date=lambda frame: pd.to_datetime(frame["effective_date"]))
+        .groupby("effective_date", as_index=False)["weight"]
+        .sum()
+        .rename(columns={"weight": "candidate_exposure"})
+    )
+    working = predictions.copy()
+    working["effective_date"] = pd.to_datetime(working["effective_date"], errors="coerce")
+    working = working.merge(exposure, on="effective_date", how="left")
+    gate_bull = working.loc[working["gate_bull"].map(_truthy)].copy()
+    if gate_bull.empty:
+        return empty_metrics
+
+    gate_bull["candidate_exposure"] = (
+        pd.to_numeric(gate_bull["candidate_exposure"], errors="coerce")
+        .fillna(0.0)
+        .clip(0.0, 1.0)
+    )
+    forward_return = pd.to_numeric(gate_bull["forward_return"], errors="coerce")
+    positive_benchmark = forward_return.gt(0.0)
+    underexposed_positive = positive_benchmark & gate_bull["candidate_exposure"].lt(
+        1.0 - 1e-9
+    )
+    positive_count = int(positive_benchmark.sum())
+    return {
+        "validation_gate_bull_average_exposure": float(
+            gate_bull["candidate_exposure"].mean()
+        ),
+        "validation_gate_bull_underexposed_positive_benchmark_fraction": (
+            float(underexposed_positive.sum() / positive_count)
+            if positive_count
+            else pd.NA
+        ),
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum": (
+            float(forward_return.loc[underexposed_positive].sum())
+            if bool(underexposed_positive.any())
+            else 0.0
+        ),
+    }
 
 
 def _select_ml_strategy_candidate(candidates: list[dict[str, object]]) -> dict[str, object]:
@@ -3440,12 +3807,18 @@ def _select_ml_strategy_candidate_for_policy(
     candidates: list[dict[str, object]],
     *,
     selection_policy: str,
+    allow_score_validity_fallback: bool = False,
 ) -> tuple[dict[str, object] | None, str]:
     valid_candidates = [row for row in candidates if row["passed_gate"]]
     if valid_candidates:
         return _select_ml_strategy_candidate(valid_candidates), "strict"
     if selection_policy == "best_active_fallback":
         fallback_candidates = _benchmark_only_fallback_candidates(candidates)
+        if not fallback_candidates and allow_score_validity_fallback:
+            fallback_candidates = _benchmark_only_fallback_candidates(
+                candidates,
+                allow_score_validity_fallback=True,
+            )
         if fallback_candidates:
             return _select_ml_strategy_candidate(fallback_candidates), "best_active_fallback"
     return None, "none"
@@ -3465,6 +3838,7 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         "effective_date",
         "symbol",
         "runtime_regime",
+        "gate_bull",
         "crypto_regime_risk_off",
         "crypto_regime_trend_state",
         "target",
@@ -3474,9 +3848,18 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         "predicted_tier_weight",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "selected_regime_gate_bull_floor",
+        "allocation_score_transform",
+        "score_transform_bull_multiplier",
+        "score_transform_bull_addend",
+        "score_transform_risk_off_score_cap",
+        "score_transform_non_bull_score_cap",
         "raw_expected_allocation_score",
         "final_allocation_score",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "score_transform_applied",
         "score",
         *probability_columns,
         "forward_return",
@@ -3488,7 +3871,9 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         "fold_predicted_25_fraction",
         "fold_predicted_50_fraction",
         "fold_predicted_100_fraction",
+        "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_score_transform_applied_fraction",
     ]
     if predictions.empty:
         return pd.DataFrame(columns=columns)
@@ -3507,10 +3892,23 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         working["raw_expected_allocation_score"] = working["score"]
     if "score_policy_triggered_100" not in working.columns:
         working["score_policy_triggered_100"] = False
+    if "score_policy_repair_authorized" not in working.columns:
+        working["score_policy_repair_authorized"] = False
+    if "score_policy_repair_denied_reason" not in working.columns:
+        working["score_policy_repair_denied_reason"] = ""
+    if "score_transform_applied" not in working.columns:
+        working["score_transform_applied"] = False
+    for column, value in _score_transform_metadata(AllocationScoreTransformConfig()).items():
+        if column not in working.columns:
+            working[column] = value
     if {"crypto_regime_risk_off", "crypto_regime_trend_state"}.issubset(
         working.columns
     ):
         working["runtime_regime"] = working.apply(_allocation_regime_label, axis=1)
+    if "gate_bull" not in working.columns:
+        working["gate_bull"] = False
+    if "selected_regime_gate_bull_floor" not in working.columns:
+        working["selected_regime_gate_bull_floor"] = pd.NA
     for column in probability_columns:
         if column not in working.columns:
             working[column] = 0.0
@@ -3531,6 +3929,16 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         .reset_index()
     )
     working = working.merge(fold_support, on="fold_id", how="left")
+    repair_authorization = (
+        working.groupby("fold_id")["score_policy_repair_authorized"]
+        .agg(
+            fold_score_policy_repair_authorized_fraction=lambda values: float(
+                values.astype(bool).mean()
+            )
+        )
+        .reset_index()
+    )
+    working = working.merge(repair_authorization, on="fold_id", how="left")
     trigger_support = (
         working.groupby("fold_id")["score_policy_triggered_100"]
         .agg(
@@ -3541,6 +3949,16 @@ def _allocation_probability_diagnostics(predictions: pd.DataFrame) -> pd.DataFra
         .reset_index()
     )
     working = working.merge(trigger_support, on="fold_id", how="left")
+    transform_support = (
+        working.groupby("fold_id")["score_transform_applied"]
+        .agg(
+            fold_score_transform_applied_fraction=lambda values: float(
+                values.astype(bool).mean()
+            )
+        )
+        .reset_index()
+    )
+    working = working.merge(transform_support, on="fold_id", how="left")
 
     utility_columns = {
         0.0: "allocation_utility_0",
@@ -3685,6 +4103,11 @@ def _build_ml_strategy_tuning_outputs(
         "allocation_class_weighting",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "allocation_score_transform",
+        "score_transform_bull_multiplier",
+        "score_transform_bull_addend",
+        "score_transform_risk_off_score_cap",
+        "score_transform_non_bull_score_cap",
         "calibration_status",
         "rolling_train_bars",
         "min_holding_period_bars",
@@ -3694,6 +4117,7 @@ def _build_ml_strategy_tuning_outputs(
         "regime_sideways_floor",
         "regime_bear_floor",
         "regime_risk_off_cap",
+        "regime_gate_bull_floor",
         "threshold",
         "tier_min_threshold",
         "tier_half_threshold",
@@ -3718,7 +4142,17 @@ def _build_ml_strategy_tuning_outputs(
         "validation_predicted_25_fraction",
         "validation_predicted_50_fraction",
         "validation_predicted_100_fraction",
+        "validation_score_forward_return_correlation",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_target_correlation",
+        "validation_score_policy_repair_authorized",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
+        "validation_gate_bull_average_exposure",
+        "validation_gate_bull_underexposed_positive_benchmark_fraction",
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum",
         "validation_score_policy_triggered_100_fraction",
+        "validation_score_transform_applied_fraction",
         "min_validation_predicted_target_fraction",
         "sharpe_like_delta",
         "drawdown_delta",
@@ -3740,6 +4174,11 @@ def _build_ml_strategy_tuning_outputs(
         "allocation_class_weighting",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "selected_allocation_score_transform",
+        "selected_score_transform_bull_multiplier",
+        "selected_score_transform_bull_addend",
+        "selected_score_transform_risk_off_score_cap",
+        "selected_score_transform_non_bull_score_cap",
         "calibration_status",
         "selected_rolling_train_bars",
         "selected_min_holding_period_bars",
@@ -3749,6 +4188,7 @@ def _build_ml_strategy_tuning_outputs(
         "selected_regime_sideways_floor",
         "selected_regime_bear_floor",
         "selected_regime_risk_off_cap",
+        "selected_regime_gate_bull_floor",
         "selected_threshold",
         "selected_tier_min_threshold",
         "selected_tier_half_threshold",
@@ -3766,13 +4206,24 @@ def _build_ml_strategy_tuning_outputs(
         "validation_predicted_25_fraction",
         "validation_predicted_50_fraction",
         "validation_predicted_100_fraction",
+        "validation_score_forward_return_correlation",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_target_correlation",
+        "validation_score_policy_repair_authorized",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
+        "validation_gate_bull_average_exposure",
+        "validation_gate_bull_underexposed_positive_benchmark_fraction",
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum",
         "validation_score_policy_triggered_100_fraction",
+        "validation_score_transform_applied_fraction",
         "min_validation_predicted_target_fraction",
         "sharpe_like_delta",
         "drawdown_delta",
         "annualized_turnover",
         "exposure_changes",
         "average_exposure",
+        "selected_candidate_failure_reasons",
     ]
     allocation_probability_columns = [
         "model_name",
@@ -3781,6 +4232,7 @@ def _build_ml_strategy_tuning_outputs(
         "effective_date",
         "symbol",
         "runtime_regime",
+        "gate_bull",
         "crypto_regime_risk_off",
         "crypto_regime_trend_state",
         "target",
@@ -3790,9 +4242,18 @@ def _build_ml_strategy_tuning_outputs(
         "predicted_tier_weight",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "selected_regime_gate_bull_floor",
+        "allocation_score_transform",
+        "score_transform_bull_multiplier",
+        "score_transform_bull_addend",
+        "score_transform_risk_off_score_cap",
+        "score_transform_non_bull_score_cap",
         "raw_expected_allocation_score",
         "final_allocation_score",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "score_transform_applied",
         "score",
         "prob_tier_0",
         "prob_tier_25",
@@ -3807,7 +4268,9 @@ def _build_ml_strategy_tuning_outputs(
         "fold_predicted_25_fraction",
         "fold_predicted_50_fraction",
         "fold_predicted_100_fraction",
+        "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_score_transform_applied_fraction",
     ]
     feature_importance_columns = [
         "model_name",
@@ -3820,8 +4283,12 @@ def _build_ml_strategy_tuning_outputs(
     tuning = config.evaluation.ml_strategy_tuning
     allocation_mode = tuning.allocation_mode
     selection_benchmark_names = _selection_benchmark_strategies(config)
-    benchmark_relative_selection = (
-        tuning.objective == "net_return_and_risk_vs_required_benchmarks"
+    benchmark_relative_selection = tuning.objective in {
+        "net_return_and_risk_vs_required_benchmarks",
+        "net_return_risk_score_validity_vs_required_benchmarks",
+    }
+    score_validity_selection = (
+        tuning.objective == "net_return_risk_score_validity_vs_required_benchmarks"
     )
     threshold_candidates = sorted(set(float(value) for value in tuning.thresholds))
     tier_threshold_candidates = _tier_threshold_sets(config)
@@ -3844,6 +4311,10 @@ def _build_ml_strategy_tuning_outputs(
         if allocation_mode in {"direct_tiered", "tiered"}
         else [0.0]
     )
+    prob100_threshold_candidates = _allocation_score_policy_prob100_threshold_candidates(
+        config
+    )
+    score_transform_candidates = _allocation_score_transform_candidates(config)
     regime_policy_candidates = (
         _regime_participation_policy_candidates(config)
         if allocation_mode in {"direct_tiered", "tiered"}
@@ -3864,6 +4335,11 @@ def _build_ml_strategy_tuning_outputs(
         )
 
     feature_columns = modeling_feature_columns(modeling_dataset)
+    modeling_dataset = _with_completed_bar_gate_labels(
+        modeling_dataset,
+        panel=panel,
+        config=config,
+    )
     frequency = config.portfolio.ranking.rebalance_frequency
     candidate_rows: list[dict[str, object]] = []
     selection_rows: list[dict[str, object]] = []
@@ -3894,7 +4370,7 @@ def _build_ml_strategy_tuning_outputs(
             "fold_id": fold_id,
             "selection_status": "selected",
             "selection_policy": tuning.selection_policy,
-            "selection_source": "deterministic_regime_fallback",
+            "selection_source": "regime_policy_fallback",
             "allocation_mode": allocation_mode,
             "selected_model_name": pd.NA,
             "selected_utility_profile": pd.NA,
@@ -3906,6 +4382,7 @@ def _build_ml_strategy_tuning_outputs(
             "allocation_score_policy_prob100_threshold": (
                 tuning.allocation_score_policy_prob100_threshold
             ),
+            **_selected_score_transform_metadata(None),
             "calibration_status": pd.NA,
             "selected_rolling_train_bars": pd.NA,
             "selected_min_holding_period_bars": pd.NA,
@@ -3919,6 +4396,11 @@ def _build_ml_strategy_tuning_outputs(
             "selected_regime_risk_off_cap": float(fallback_regime_policy.risk_off_cap)
             if fallback_regime_policy.risk_off_cap is not None
             else pd.NA,
+            "selected_regime_gate_bull_floor": (
+                float(fallback_regime_policy.gate_bull_floor)
+                if fallback_regime_policy.gate_bull_floor is not None
+                else pd.NA
+            ),
             "selected_threshold": pd.NA,
             "selected_tier_min_threshold": pd.NA,
             "selected_tier_half_threshold": pd.NA,
@@ -3944,13 +4426,28 @@ def _build_ml_strategy_tuning_outputs(
             "validation_predicted_25_fraction": pd.NA,
             "validation_predicted_50_fraction": pd.NA,
             "validation_predicted_100_fraction": pd.NA,
+            "validation_score_forward_return_correlation": pd.NA,
+            "validation_raw_score_forward_return_correlation": pd.NA,
+            "validation_score_target_correlation": pd.NA,
+            "validation_score_policy_repair_authorized": False,
+            "score_policy_repair_authorized": False,
+            "score_policy_repair_denied_reason": (
+                "regime_policy_fallback_no_valid_candidate"
+                if tuning.allocation_score_policy == "gate_bull_prob100_threshold"
+                else ""
+            ),
+            "validation_gate_bull_average_exposure": pd.NA,
+            "validation_gate_bull_underexposed_positive_benchmark_fraction": pd.NA,
+            "validation_gate_bull_underexposed_positive_benchmark_return_sum": pd.NA,
             "validation_score_policy_triggered_100_fraction": pd.NA,
+            "validation_score_transform_applied_fraction": pd.NA,
             "min_validation_predicted_target_fraction": pd.NA,
             "sharpe_like_delta": pd.NA,
             "drawdown_delta": pd.NA,
             "annualized_turnover": pd.NA,
             "exposure_changes": exposure_changes,
             "average_exposure": average_exposure,
+            "selected_candidate_failure_reasons": "regime_policy_fallback_no_valid_candidate",
         }
         return weights, row
 
@@ -4051,67 +4548,137 @@ def _build_ml_strategy_tuning_outputs(
                         )
                         if validation_output is None:
                             continue
-                        validation_predictions = validation_output.predictions
+                        base_validation_predictions = validation_output.predictions
+                        base_score_validity_metrics = _score_validity_metrics(
+                            base_validation_predictions
+                        )
                         (
-                            predicted_support_ok,
-                            predicted_support_fractions,
-                        ) = _predicted_tier_support(
-                            predictions=validation_predictions,
-                            required_weights=(
-                                required_predicted_weights
-                                if _is_allocation_target(config.target.type)
-                                else []
+                            score_policy_repair_authorized,
+                            score_policy_repair_denied_reason,
+                        ) = _score_policy_repair_authorization(
+                            allocation_score_policy=tuning.allocation_score_policy,
+                            validation_raw_score_forward_return_correlation=(
+                                base_score_validity_metrics[
+                                    "validation_raw_score_forward_return_correlation"
+                                ]
                             ),
-                            min_fraction=min_predicted_fraction,
                         )
-                        validation_predicted_25_fraction = predicted_support_fractions.get(
-                            0.25,
-                            pd.NA,
-                        )
-                        validation_predicted_50_fraction = predicted_support_fractions.get(
-                            0.50,
-                            pd.NA,
-                        )
-                        validation_predicted_100_fraction = float(
-                            validation_predictions["score"]
-                            .map(lambda value: nearest_tier(float(value)))
-                            .sub(1.0)
-                            .abs()
-                            .le(1e-9)
-                            .mean()
-                        )
-                        if "score_policy_triggered_100" in validation_predictions.columns:
-                            validation_score_policy_triggered_100_fraction = float(
-                                validation_predictions[
-                                    "score_policy_triggered_100"
-                                ].astype(bool).mean()
-                            )
-                        else:
-                            validation_score_policy_triggered_100_fraction = pd.NA
-                        predicted_fraction_values = [
-                            value
-                            for value in predicted_support_fractions.values()
-                            if pd.notna(value)
+                        candidate_thresholds: list[
+                            tuple[
+                                float,
+                                tuple[float, float, float] | None,
+                                float,
+                                AllocationScoreTransformConfig,
+                            ]
                         ]
-                        min_validation_predicted_target_fraction = (
-                            min(predicted_fraction_values)
-                            if predicted_fraction_values
-                            else pd.NA
-                        )
-                        candidate_thresholds: list[tuple[float, tuple[float, float, float] | None]]
                         if allocation_mode == "tiered":
                             candidate_thresholds = [
-                                (threshold_set[0], threshold_set)
+                                (
+                                    threshold_set[0],
+                                    threshold_set,
+                                    prob100_threshold,
+                                    score_transform,
+                                )
                                 for threshold_set in tier_threshold_candidates
+                                for prob100_threshold in prob100_threshold_candidates
+                                for score_transform in score_transform_candidates
                             ]
                         elif allocation_mode == "direct_tiered":
-                            candidate_thresholds = [(0.0, None)]
+                            candidate_thresholds = [
+                                (0.0, None, prob100_threshold, score_transform)
+                                for prob100_threshold in prob100_threshold_candidates
+                                for score_transform in score_transform_candidates
+                            ]
                         else:
                             candidate_thresholds = [
-                                (threshold, None)
+                                (threshold, None, prob100_threshold, score_transform)
                                 for threshold in threshold_candidates
+                                for prob100_threshold in prob100_threshold_candidates
+                                for score_transform in score_transform_candidates
                             ]
-                        for threshold, tier_thresholds in candidate_thresholds:
+                        for (
+                            threshold,
+                            tier_thresholds,
+                            prob100_threshold,
+                            score_transform,
+                        ) in candidate_thresholds:
+                            validation_predictions = (
+                                _prediction_frame_with_allocation_score_policy(
+                                    predictions=base_validation_predictions,
+                                    allocation_score_policy=tuning.allocation_score_policy,
+                                    prob100_threshold=prob100_threshold,
+                                    score_policy_repair_authorized=(
+                                        score_policy_repair_authorized
+                                    ),
+                                    score_policy_repair_denied_reason=(
+                                        score_policy_repair_denied_reason
+                                    ),
+                                    score_transform=score_transform,
+                                )
+                            )
+                            (
+                                predicted_support_ok,
+                                predicted_support_fractions,
+                            ) = _predicted_tier_support(
+                                predictions=validation_predictions,
+                                required_weights=(
+                                    required_predicted_weights
+                                    if _is_allocation_target(config.target.type)
+                                    else []
+                                ),
+                                min_fraction=min_predicted_fraction,
+                            )
+                            validation_predicted_25_fraction = (
+                                predicted_support_fractions.get(0.25, pd.NA)
+                            )
+                            validation_predicted_50_fraction = (
+                                predicted_support_fractions.get(0.50, pd.NA)
+                            )
+                            validation_predicted_100_fraction = float(
+                                validation_predictions["score"]
+                                .map(lambda value: nearest_tier(float(value)))
+                                .sub(1.0)
+                                .abs()
+                                .le(1e-9)
+                                .mean()
+                            )
+                            if "score_policy_triggered_100" in validation_predictions.columns:
+                                validation_score_policy_triggered_100_fraction = float(
+                                    validation_predictions[
+                                        "score_policy_triggered_100"
+                                    ].astype(bool).mean()
+                                )
+                            else:
+                                validation_score_policy_triggered_100_fraction = pd.NA
+                            if "score_transform_applied" in validation_predictions.columns:
+                                validation_score_transform_applied_fraction = float(
+                                    validation_predictions[
+                                        "score_transform_applied"
+                                    ].astype(bool).mean()
+                                )
+                            else:
+                                validation_score_transform_applied_fraction = pd.NA
+                            predicted_fraction_values = [
+                                value
+                                for value in predicted_support_fractions.values()
+                                if pd.notna(value)
+                            ]
+                            min_validation_predicted_target_fraction = (
+                                min(predicted_fraction_values)
+                                if predicted_fraction_values
+                                else pd.NA
+                            )
+                            score_validity_metrics = _score_validity_metrics(
+                                validation_predictions
+                            )
+                            score_forward_correlation = score_validity_metrics[
+                                "validation_score_forward_return_correlation"
+                            ]
+                            score_validity_ok = not (
+                                score_validity_selection
+                                and pd.notna(score_forward_correlation)
+                                and float(score_forward_correlation) < 0.0
+                            )
                             for regime_policy in regime_policy_candidates:
                                 strategy_regime_policy = _strategy_regime_policy(
                                     regime_policy
@@ -4148,6 +4715,12 @@ def _build_ml_strategy_tuning_outputs(
                                         )
                                         exposure_changes, average_exposure = _weight_activity(
                                             weights
+                                        )
+                                        gate_bull_metrics = (
+                                            _gate_bull_underexposure_metrics(
+                                                predictions=validation_predictions,
+                                                weights=weights,
+                                            )
                                         )
                                         excess_return = (
                                             float(metrics["cumulative_return"])
@@ -4234,6 +4807,7 @@ def _build_ml_strategy_tuning_outputs(
                                             ),
                                             benchmark_excess_values=benchmark_excess_values,
                                             risk_gate_ok=risk_gate_ok,
+                                            score_validity_ok=score_validity_ok,
                                         )
                                         passed_gate = (
                                             active_candidate
@@ -4241,6 +4815,7 @@ def _build_ml_strategy_tuning_outputs(
                                             and predicted_support_ok
                                             and benchmark_gate_ok
                                             and risk_gate_ok
+                                            and score_validity_ok
                                         )
                                         row = {
                                             "fold_id": fold.fold_id,
@@ -4263,8 +4838,9 @@ def _build_ml_strategy_tuning_outputs(
                                                 tuning.allocation_score_policy
                                             ),
                                             "allocation_score_policy_prob100_threshold": (
-                                                tuning.allocation_score_policy_prob100_threshold
+                                                prob100_threshold
                                             ),
+                                            **_score_transform_metadata(score_transform),
                                             "calibration_status": (
                                                 validation_output.calibration_status
                                             ),
@@ -4290,6 +4866,11 @@ def _build_ml_strategy_tuning_outputs(
                                             "regime_risk_off_cap": (
                                                 float(regime_policy.risk_off_cap)
                                                 if regime_policy.risk_off_cap is not None
+                                                else pd.NA
+                                            ),
+                                            "regime_gate_bull_floor": (
+                                                float(regime_policy.gate_bull_floor)
+                                                if regime_policy.gate_bull_floor is not None
                                                 else pd.NA
                                             ),
                                             "threshold": threshold,
@@ -4348,8 +4929,22 @@ def _build_ml_strategy_tuning_outputs(
                                             "validation_predicted_100_fraction": (
                                                 validation_predicted_100_fraction
                                             ),
+                                            **score_validity_metrics,
+                                            "validation_score_policy_repair_authorized": (
+                                                score_policy_repair_authorized
+                                            ),
+                                            "score_policy_repair_authorized": (
+                                                score_policy_repair_authorized
+                                            ),
+                                            "score_policy_repair_denied_reason": (
+                                                score_policy_repair_denied_reason
+                                            ),
+                                            **gate_bull_metrics,
                                             "validation_score_policy_triggered_100_fraction": (
                                                 validation_score_policy_triggered_100_fraction
+                                            ),
+                                            "validation_score_transform_applied_fraction": (
+                                                validation_score_transform_applied_fraction
                                             ),
                                             "min_validation_predicted_target_fraction": (
                                                 min_validation_predicted_target_fraction
@@ -4366,6 +4961,7 @@ def _build_ml_strategy_tuning_outputs(
         selected, selected_source = _select_ml_strategy_candidate_for_policy(
             fold_candidates,
             selection_policy=tuning.selection_policy,
+            allow_score_validity_fallback=score_validity_selection,
         )
         if selected is None:
             if fallback_regime_policy is not None:
@@ -4403,6 +4999,7 @@ def _build_ml_strategy_tuning_outputs(
                     "allocation_score_policy_prob100_threshold": (
                         tuning.allocation_score_policy_prob100_threshold
                     ),
+                    **_selected_score_transform_metadata(None),
                     "calibration_status": pd.NA,
                     "selected_rolling_train_bars": pd.NA,
                     "selected_min_holding_period_bars": pd.NA,
@@ -4412,6 +5009,7 @@ def _build_ml_strategy_tuning_outputs(
                     "selected_regime_sideways_floor": pd.NA,
                     "selected_regime_bear_floor": pd.NA,
                     "selected_regime_risk_off_cap": pd.NA,
+                    "selected_regime_gate_bull_floor": pd.NA,
                     "selected_threshold": pd.NA,
                     "selected_tier_min_threshold": pd.NA,
                     "selected_tier_half_threshold": pd.NA,
@@ -4437,13 +5035,29 @@ def _build_ml_strategy_tuning_outputs(
                     "validation_predicted_25_fraction": pd.NA,
                     "validation_predicted_50_fraction": pd.NA,
                     "validation_predicted_100_fraction": pd.NA,
+                    "validation_score_forward_return_correlation": pd.NA,
+                    "validation_raw_score_forward_return_correlation": pd.NA,
+                    "validation_score_target_correlation": pd.NA,
+                    "validation_score_policy_repair_authorized": False,
+                    "score_policy_repair_authorized": False,
+                    "score_policy_repair_denied_reason": (
+                        "no_valid_candidate"
+                        if tuning.allocation_score_policy
+                        == "gate_bull_prob100_threshold"
+                        else ""
+                    ),
+                    "validation_gate_bull_average_exposure": pd.NA,
+                    "validation_gate_bull_underexposed_positive_benchmark_fraction": pd.NA,
+                    "validation_gate_bull_underexposed_positive_benchmark_return_sum": pd.NA,
                     "validation_score_policy_triggered_100_fraction": pd.NA,
+                    "validation_score_transform_applied_fraction": pd.NA,
                     "min_validation_predicted_target_fraction": pd.NA,
                     "sharpe_like_delta": pd.NA,
                     "drawdown_delta": pd.NA,
                     "annualized_turnover": pd.NA,
                     "exposure_changes": 0,
                     "average_exposure": 0.0,
+                    "selected_candidate_failure_reasons": pd.NA,
                 }
             )
             continue
@@ -4456,6 +5070,32 @@ def _build_ml_strategy_tuning_outputs(
         selected_min_holding_period_bars = int(selected["min_holding_period_bars"])
         selected_hysteresis_margin = float(selected["hysteresis_margin"])
         selected_threshold = float(selected["threshold"])
+        selected_prob100_threshold = float(
+            selected["allocation_score_policy_prob100_threshold"]
+        )
+        selected_score_policy_repair_authorized = bool(
+            selected["validation_score_policy_repair_authorized"]
+        )
+        selected_score_policy_repair_denied_reason = (
+            str(selected["score_policy_repair_denied_reason"])
+            if pd.notna(selected["score_policy_repair_denied_reason"])
+            else ""
+        )
+        selected_score_transform = AllocationScoreTransformConfig(
+            name=str(selected["allocation_score_transform"]),
+            bull_multiplier=float(selected["score_transform_bull_multiplier"]),
+            bull_addend=float(selected["score_transform_bull_addend"]),
+            risk_off_score_cap=(
+                float(selected["score_transform_risk_off_score_cap"])
+                if pd.notna(selected["score_transform_risk_off_score_cap"])
+                else None
+            ),
+            non_bull_score_cap=(
+                float(selected["score_transform_non_bull_score_cap"])
+                if pd.notna(selected["score_transform_non_bull_score_cap"])
+                else None
+            ),
+        )
         selected_regime_policy = RegimeParticipationPolicyConfig(
             name=str(selected["regime_policy"]),
             bull_floor=float(selected["regime_bull_floor"]),
@@ -4464,6 +5104,11 @@ def _build_ml_strategy_tuning_outputs(
             risk_off_cap=(
                 float(selected["regime_risk_off_cap"])
                 if pd.notna(selected["regime_risk_off_cap"])
+                else None
+            ),
+            gate_bull_floor=(
+                float(selected["regime_gate_bull_floor"])
+                if pd.notna(selected["regime_gate_bull_floor"])
                 else None
             ),
         )
@@ -4505,8 +5150,15 @@ def _build_ml_strategy_tuning_outputs(
             allocation_calibration_cv=tuning.allocation_calibration_cv,
             allocation_score_policy=tuning.allocation_score_policy,
             allocation_score_policy_prob100_threshold=(
-                tuning.allocation_score_policy_prob100_threshold
+                selected_prob100_threshold
             ),
+            score_policy_repair_authorized=(
+                selected_score_policy_repair_authorized
+            ),
+            score_policy_repair_denied_reason=(
+                selected_score_policy_repair_denied_reason
+            ),
+            allocation_score_transform=selected_score_transform,
             utility_profile=selected_utility_profile,
         )
         if selected_test_output is None:
@@ -4530,7 +5182,23 @@ def _build_ml_strategy_tuning_outputs(
             )
             selection_status = "no_valid_candidate"
         else:
-            selected_test_predictions = selected_test_output.predictions
+            selected_test_predictions = _prediction_frame_with_allocation_score_policy(
+                predictions=selected_test_output.predictions,
+                allocation_score_policy=tuning.allocation_score_policy,
+                prob100_threshold=selected_prob100_threshold,
+                score_policy_repair_authorized=(
+                    selected_score_policy_repair_authorized
+                ),
+                score_policy_repair_denied_reason=(
+                    selected_score_policy_repair_denied_reason
+                ),
+                score_transform=selected_score_transform,
+            )
+            selected_test_predictions["selected_regime_gate_bull_floor"] = (
+                float(selected_regime_policy.gate_bull_floor)
+                if selected_regime_policy.gate_bull_floor is not None
+                else pd.NA
+            )
             selected_weight_frames.append(
                 _weights_for_predictions(
                     config=config,
@@ -4586,7 +5254,12 @@ def _build_ml_strategy_tuning_outputs(
                 "allocation_class_weighting": tuning.allocation_class_weighting,
                 "allocation_score_policy": tuning.allocation_score_policy,
                 "allocation_score_policy_prob100_threshold": (
-                    tuning.allocation_score_policy_prob100_threshold
+                    selected_prob100_threshold
+                    if selection_status == "selected"
+                    else tuning.allocation_score_policy_prob100_threshold
+                ),
+                **_selected_score_transform_metadata(
+                    selected_score_transform if selection_status == "selected" else None
                 ),
                 "calibration_status": (
                     selected_test_output.calibration_status
@@ -4634,6 +5307,14 @@ def _build_ml_strategy_tuning_outputs(
                     )
                     else pd.NA
                 ),
+                "selected_regime_gate_bull_floor": (
+                    float(selected_regime_policy.gate_bull_floor)
+                    if (
+                        selection_status == "selected"
+                        and selected_regime_policy.gate_bull_floor is not None
+                    )
+                    else pd.NA
+                ),
                 "selected_threshold": (
                     selected_threshold if selection_status == "selected" else pd.NA
                 ),
@@ -4677,8 +5358,42 @@ def _build_ml_strategy_tuning_outputs(
                 "validation_predicted_100_fraction": selected[
                     "validation_predicted_100_fraction"
                 ],
+                "validation_score_forward_return_correlation": selected[
+                    "validation_score_forward_return_correlation"
+                ],
+                "validation_raw_score_forward_return_correlation": selected[
+                    "validation_raw_score_forward_return_correlation"
+                ],
+                "validation_score_target_correlation": selected[
+                    "validation_score_target_correlation"
+                ],
+                "validation_score_policy_repair_authorized": selected[
+                    "validation_score_policy_repair_authorized"
+                ],
+                "score_policy_repair_authorized": (
+                    selected_score_policy_repair_authorized
+                    if selection_status == "selected"
+                    else False
+                ),
+                "score_policy_repair_denied_reason": (
+                    selected_score_policy_repair_denied_reason
+                    if selection_status == "selected"
+                    else ""
+                ),
+                "validation_gate_bull_average_exposure": selected[
+                    "validation_gate_bull_average_exposure"
+                ],
+                "validation_gate_bull_underexposed_positive_benchmark_fraction": selected[
+                    "validation_gate_bull_underexposed_positive_benchmark_fraction"
+                ],
+                "validation_gate_bull_underexposed_positive_benchmark_return_sum": selected[
+                    "validation_gate_bull_underexposed_positive_benchmark_return_sum"
+                ],
                 "validation_score_policy_triggered_100_fraction": selected[
                     "validation_score_policy_triggered_100_fraction"
+                ],
+                "validation_score_transform_applied_fraction": selected[
+                    "validation_score_transform_applied_fraction"
                 ],
                 "min_validation_predicted_target_fraction": selected[
                     "min_validation_predicted_target_fraction"
@@ -4688,6 +5403,11 @@ def _build_ml_strategy_tuning_outputs(
                 "annualized_turnover": selected["annualized_turnover"],
                 "exposure_changes": selected["exposure_changes"],
                 "average_exposure": selected["average_exposure"],
+                "selected_candidate_failure_reasons": (
+                    selected["failure_reasons"]
+                    if selected_source == "best_active_fallback"
+                    else ""
+                ),
             }
         )
 
@@ -4703,6 +5423,7 @@ def _build_ml_strategy_tuning_outputs(
                 "sharpe_like_delta",
                 "annualized_turnover",
                 "model_name",
+                "allocation_score_transform",
                 "regime_policy",
                 "threshold",
                 "hysteresis_margin",
@@ -4714,6 +5435,7 @@ def _build_ml_strategy_tuning_outputs(
                 False,
                 False,
                 False,
+                True,
                 True,
                 True,
                 True,

--- a/src/marketlab/reports/analytics.py
+++ b/src/marketlab/reports/analytics.py
@@ -243,7 +243,7 @@ def _cost_sensitivity_grid(
     return sorted(grid)
 
 
-def _repriced_performance(working: pd.DataFrame, bps_per_trade: float) -> pd.DataFrame:
+def reprice_performance(working: pd.DataFrame, bps_per_trade: float) -> pd.DataFrame:
     repriced = working.loc[:, ["date", "strategy", "gross_return", "turnover"]].copy()
     repriced["net_return"] = repriced["gross_return"] - (repriced["turnover"] * (bps_per_trade / 10_000.0))
     repriced["equity"] = (
@@ -330,7 +330,7 @@ def build_cost_sensitivity(
 
     scenario_frames: list[pd.DataFrame] = []
     for bps_per_trade in _cost_sensitivity_grid(base_cost_bps, sensitivity_bps):
-        repriced = _repriced_performance(working, bps_per_trade)
+        repriced = reprice_performance(working, bps_per_trade)
         metrics = _compute_repriced_strategy_metrics_for_periods(
             repriced,
             periods_per_year=periods_per_year,

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -998,6 +998,52 @@ def _phase8_run_summary_lines(
     return lines
 
 
+def _phase8_methodology_review_lines(
+    phase8_methodology_review: pd.DataFrame | None,
+    report_path: Path,
+    phase8_methodology_review_path: Path | None,
+) -> list[str]:
+    if phase8_methodology_review is None or phase8_methodology_review.empty:
+        return []
+
+    display_columns = [
+        "methodology_gate",
+        "section",
+        "metric",
+        "passed",
+        "value",
+        "required",
+        "diagnostic_only",
+        "detail",
+    ]
+    lines = [
+        _markdown_table(
+            _display_frame(
+                phase8_methodology_review.loc[
+                    :,
+                    [
+                        column
+                        for column in display_columns
+                        if column in phase8_methodology_review.columns
+                    ],
+                ].head(100)
+            )
+        ),
+        "",
+        "- The deployment gate is still the unchanged `strict_research_gate.csv` overall row.",
+        "- Counterfactual rows are diagnostic only and do not approve BTC paper deployment.",
+    ]
+    if phase8_methodology_review_path is not None:
+        lines.append(
+            _relative_artifact_line(
+                report_path,
+                phase8_methodology_review_path,
+                "Phase 8 methodology review",
+            )
+        )
+    return lines
+
+
 def _signal_inspection_lines(
     config: ExperimentConfig,
     report_path: Path,
@@ -1171,6 +1217,7 @@ def write_markdown_report(
     regime_slice_diagnostics: pd.DataFrame | None = None,
     strict_research_gate: pd.DataFrame | None = None,
     phase8_run_summary: pd.DataFrame | None = None,
+    phase8_methodology_review: pd.DataFrame | None = None,
     fold_diagnostics: pd.DataFrame | None = None,
     threshold_diagnostics: pd.DataFrame | None = None,
     calibration_curves_plot_path: Path | None = None,
@@ -1204,6 +1251,7 @@ def write_markdown_report(
     regime_slice_diagnostics_path: Path | None = None,
     strict_research_gate_path: Path | None = None,
     phase8_run_summary_path: Path | None = None,
+    phase8_methodology_review_path: Path | None = None,
     pattern_price_overlay_plot_path: Path | None = None,
     pattern_detections_plot_path: Path | None = None,
     pattern_detection_windows_plot_path: Path | None = None,
@@ -1367,6 +1415,16 @@ def write_markdown_report(
     )
     if phase8_run_summary_lines:
         content_lines.extend(_section("Phase 8 Run Summary", phase8_run_summary_lines))
+
+    phase8_methodology_review_lines = _phase8_methodology_review_lines(
+        phase8_methodology_review,
+        output_path,
+        phase8_methodology_review_path,
+    )
+    if phase8_methodology_review_lines:
+        content_lines.extend(
+            _section("Phase 8 Methodology Review", phase8_methodology_review_lines)
+        )
 
     signal_inspection_lines = _signal_inspection_lines(
         config,

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -669,6 +669,8 @@ def _ml_strategy_tuning_lines(
             "passed_gate",
             "excess_cumulative_return",
             "min_benchmark_excess_cumulative_return",
+            "selection_validation_cost_bps",
+            "min_selection_validation_cost_benchmark_excess_cumulative_return",
             "validation_predicted_100_fraction",
             "validation_score_forward_return_correlation",
             "validation_raw_score_forward_return_correlation",
@@ -676,9 +678,13 @@ def _ml_strategy_tuning_lines(
             "validation_score_policy_repair_authorized",
             "score_policy_repair_authorized",
             "score_policy_repair_denied_reason",
+            "validation_guarded_gate_bull_risk_off_override_authorized",
+            "guarded_gate_bull_risk_off_override_authorized",
+            "guarded_gate_bull_risk_off_override_denied_reason",
             "validation_gate_bull_average_exposure",
             "validation_gate_bull_underexposed_positive_benchmark_fraction",
             "validation_score_policy_triggered_100_fraction",
+            "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
             "validation_score_transform_applied_fraction",
             "sharpe_like_delta",
             "drawdown_delta",
@@ -725,6 +731,8 @@ def _ml_strategy_tuning_lines(
             "annualized_turnover",
             "excess_cumulative_return",
             "min_benchmark_excess_cumulative_return",
+            "selection_validation_cost_bps",
+            "min_selection_validation_cost_benchmark_excess_cumulative_return",
             "validation_predicted_100_fraction",
             "validation_score_forward_return_correlation",
             "validation_raw_score_forward_return_correlation",
@@ -732,9 +740,13 @@ def _ml_strategy_tuning_lines(
             "validation_score_policy_repair_authorized",
             "score_policy_repair_authorized",
             "score_policy_repair_denied_reason",
+            "validation_guarded_gate_bull_risk_off_override_authorized",
+            "guarded_gate_bull_risk_off_override_authorized",
+            "guarded_gate_bull_risk_off_override_denied_reason",
             "validation_gate_bull_average_exposure",
             "validation_gate_bull_underexposed_positive_benchmark_fraction",
             "validation_score_policy_triggered_100_fraction",
+            "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
             "validation_score_transform_applied_fraction",
             "sharpe_like_delta",
             "drawdown_delta",
@@ -764,8 +776,10 @@ def _ml_strategy_tuning_lines(
             "- Rolling train candidates use only the latest configured bars inside the label-safe training slice.",
             "- Selected models are refit on the selected rolling training window before scoring the outer test fold.",
             "- The pass gate requires net excess return versus the configured selection benchmarks, activity guardrails, risk improvement, and any configured turnover budget after costs.",
+            "- Configured selection validation costs are evaluated on the same candidate weights; candidates rank by their worst benchmark excess across those costs.",
             "- `best_active_fallback` selections are diagnostic runtime selections; they keep `passed_gate=False` and do not relax the strict Phase 8 research gate.",
             "- `gate_bull_prob100_threshold` can promote a completed-bar `gate_bull` row to 100% only when the raw validation expected-allocation score has finite non-negative forward-return correlation. Repaired scores never authorize their own promotion.",
+            "- The research-only guarded gate-bull risk-off override can lift a completed-bar `gate_bull` conflict row to 100% after the risk-off cap only when raw validation score ordering is finite and non-negative.",
         ]
     )
     for artifact_path, label in [
@@ -853,6 +867,8 @@ def _allocation_utility_lines(
             "fold_predicted_100_fraction",
             "fold_score_policy_repair_authorized_fraction",
             "fold_score_policy_triggered_100_fraction",
+            "fold_guarded_gate_bull_risk_off_override_authorized_fraction",
+            "fold_guarded_gate_bull_risk_off_override_triggered_fraction",
             "fold_score_transform_applied_fraction",
             "selected_regime_gate_bull_floor",
         ]:
@@ -871,6 +887,16 @@ def _allocation_utility_lines(
         if "score_policy_repair_denied_reason" in allocation_probability_diagnostics.columns:
             probability_aggregations["score_policy_repair_denied_reason"] = (
                 "score_policy_repair_denied_reason",
+                "first",
+            )
+        if (
+            "guarded_gate_bull_risk_off_override_denied_reason"
+            in allocation_probability_diagnostics.columns
+        ):
+            probability_aggregations[
+                "guarded_gate_bull_risk_off_override_denied_reason"
+            ] = (
+                "guarded_gate_bull_risk_off_override_denied_reason",
                 "first",
             )
         if "selected_regime_gate_bull_floor" in allocation_probability_diagnostics.columns:
@@ -952,6 +978,7 @@ def _allocation_utility_lines(
             f"- Allocation score transforms are evaluated as research-only candidate score mappings: `{score_transform_names}`.",
             "- The default trading score is expected allocation: `sum(prob_tier * tier_weight)`. Diagnostic score policies may transform that score before tiering.",
             "- The `gate_bull_prob100_threshold` research repair is authorized only by finite non-negative raw validation score/forward-return correlation and only affects completed-bar `gate_bull` rows on the next effective allocation.",
+            f"- Guarded gate-bull risk-off override is `{config.evaluation.ml_strategy_tuning.guarded_gate_bull_risk_off_override}` and is authorized only by finite non-negative raw validation score ordering.",
             "- Direct-tier allocation still applies risk-off caps, minimum holding periods, hysteresis, costs, and the strict gate.",
             "- `regime_state` maps utility tiers into `risk_off`, `reduced`, and `risk_on` states before converting state probabilities back into expected allocation.",
         ]

--- a/src/marketlab/reports/markdown.py
+++ b/src/marketlab/reports/markdown.py
@@ -310,6 +310,14 @@ def _relative_artifact_line(report_path: Path, artifact_path: Path, label: str) 
     return f"- {label}: [{artifact_path.name}]({relative_path})"
 
 
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
 def _display_frame(frame: pd.DataFrame) -> pd.DataFrame:
     display = frame.copy()
     numeric_columns = display.select_dtypes(include="number").columns
@@ -639,6 +647,11 @@ def _ml_strategy_tuning_lines(
             "allocation_mode",
             "allocation_score_policy",
             "allocation_score_policy_prob100_threshold",
+            "selected_allocation_score_transform",
+            "selected_score_transform_bull_multiplier",
+            "selected_score_transform_bull_addend",
+            "selected_score_transform_risk_off_score_cap",
+            "selected_score_transform_non_bull_score_cap",
             "selected_model_name",
             "selected_rolling_train_bars",
             "selected_min_holding_period_bars",
@@ -648,6 +661,7 @@ def _ml_strategy_tuning_lines(
             "selected_regime_sideways_floor",
             "selected_regime_bear_floor",
             "selected_regime_risk_off_cap",
+            "selected_regime_gate_bull_floor",
             "selected_threshold",
             "selected_tier_min_threshold",
             "selected_tier_half_threshold",
@@ -656,12 +670,22 @@ def _ml_strategy_tuning_lines(
             "excess_cumulative_return",
             "min_benchmark_excess_cumulative_return",
             "validation_predicted_100_fraction",
+            "validation_score_forward_return_correlation",
+            "validation_raw_score_forward_return_correlation",
+            "validation_score_target_correlation",
+            "validation_score_policy_repair_authorized",
+            "score_policy_repair_authorized",
+            "score_policy_repair_denied_reason",
+            "validation_gate_bull_average_exposure",
+            "validation_gate_bull_underexposed_positive_benchmark_fraction",
             "validation_score_policy_triggered_100_fraction",
+            "validation_score_transform_applied_fraction",
             "sharpe_like_delta",
             "drawdown_delta",
             "annualized_turnover",
             "exposure_changes",
             "average_exposure",
+            "selected_candidate_failure_reasons",
         ]
         available_selection_columns = [
             column for column in selection_columns if column in tuning_selections.columns
@@ -677,6 +701,11 @@ def _ml_strategy_tuning_lines(
             "allocation_mode",
             "allocation_score_policy",
             "allocation_score_policy_prob100_threshold",
+            "allocation_score_transform",
+            "score_transform_bull_multiplier",
+            "score_transform_bull_addend",
+            "score_transform_risk_off_score_cap",
+            "score_transform_non_bull_score_cap",
             "rolling_train_bars",
             "min_holding_period_bars",
             "hysteresis_margin",
@@ -685,6 +714,7 @@ def _ml_strategy_tuning_lines(
             "regime_sideways_floor",
             "regime_bear_floor",
             "regime_risk_off_cap",
+            "regime_gate_bull_floor",
             "threshold",
             "tier_min_threshold",
             "tier_half_threshold",
@@ -696,7 +726,16 @@ def _ml_strategy_tuning_lines(
             "excess_cumulative_return",
             "min_benchmark_excess_cumulative_return",
             "validation_predicted_100_fraction",
+            "validation_score_forward_return_correlation",
+            "validation_raw_score_forward_return_correlation",
+            "validation_score_target_correlation",
+            "validation_score_policy_repair_authorized",
+            "score_policy_repair_authorized",
+            "score_policy_repair_denied_reason",
+            "validation_gate_bull_average_exposure",
+            "validation_gate_bull_underexposed_positive_benchmark_fraction",
             "validation_score_policy_triggered_100_fraction",
+            "validation_score_transform_applied_fraction",
             "sharpe_like_delta",
             "drawdown_delta",
             "active_candidate",
@@ -726,6 +765,7 @@ def _ml_strategy_tuning_lines(
             "- Selected models are refit on the selected rolling training window before scoring the outer test fold.",
             "- The pass gate requires net excess return versus the configured selection benchmarks, activity guardrails, risk improvement, and any configured turnover budget after costs.",
             "- `best_active_fallback` selections are diagnostic runtime selections; they keep `passed_gate=False` and do not relax the strict Phase 8 research gate.",
+            "- `gate_bull_prob100_threshold` can promote a completed-bar `gate_bull` row to 100% only when the raw validation expected-allocation score has finite non-negative forward-return correlation. Repaired scores never authorize their own promotion.",
         ]
     )
     for artifact_path, label in [
@@ -811,7 +851,10 @@ def _allocation_utility_lines(
             "fold_predicted_25_fraction",
             "fold_predicted_50_fraction",
             "fold_predicted_100_fraction",
+            "fold_score_policy_repair_authorized_fraction",
             "fold_score_policy_triggered_100_fraction",
+            "fold_score_transform_applied_fraction",
+            "selected_regime_gate_bull_floor",
         ]:
             if column in allocation_probability_diagnostics.columns:
                 probability_aggregations[column] = (column, "max")
@@ -819,6 +862,26 @@ def _allocation_utility_lines(
             probability_aggregations["selected_utility_profile"] = (
                 "utility_profile",
                 "first",
+            )
+        if "allocation_score_transform" in allocation_probability_diagnostics.columns:
+            probability_aggregations["selected_allocation_score_transform"] = (
+                "allocation_score_transform",
+                "first",
+            )
+        if "score_policy_repair_denied_reason" in allocation_probability_diagnostics.columns:
+            probability_aggregations["score_policy_repair_denied_reason"] = (
+                "score_policy_repair_denied_reason",
+                "first",
+            )
+        if "selected_regime_gate_bull_floor" in allocation_probability_diagnostics.columns:
+            probability_aggregations["selected_regime_gate_bull_floor"] = (
+                "selected_regime_gate_bull_floor",
+                "first",
+            )
+        if "gate_bull" in allocation_probability_diagnostics.columns:
+            probability_aggregations["gate_bull_fraction"] = (
+                "gate_bull",
+                lambda values: values.map(_truthy).mean(),
             )
         if "calibration_status" in allocation_probability_diagnostics.columns:
             probability_aggregations["calibration_status"] = (
@@ -873,6 +936,10 @@ def _allocation_utility_lines(
 
     if not lines:
         lines.append("Allocation-utility diagnostics were written as empty artifacts.")
+    score_transform_names = ", ".join(
+        transform.name
+        for transform in config.evaluation.ml_strategy_tuning.allocation_score_transforms
+    )
     lines.extend(
         [
             "",
@@ -882,7 +949,9 @@ def _allocation_utility_lines(
             f"- Predicted-support gate requires {', '.join(str(value) for value in config.evaluation.strict_research_gate.required_predicted_target_weights) or 'no configured partial tiers'} at OOS fraction >= {config.evaluation.strict_research_gate.min_predicted_target_fraction:g} and selected-fold fraction >= {config.evaluation.strict_research_gate.min_predicted_target_fold_fraction:g}.",
             f"- Candidate training uses `{config.evaluation.ml_strategy_tuning.allocation_class_weighting}` class weighting and `{config.evaluation.ml_strategy_tuning.allocation_probability_calibration}` probability calibration when training-slice support allows it.",
             f"- Allocation score policy is `{config.evaluation.ml_strategy_tuning.allocation_score_policy}` with `prob_tier_100` trigger threshold {config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold:g}.",
+            f"- Allocation score transforms are evaluated as research-only candidate score mappings: `{score_transform_names}`.",
             "- The default trading score is expected allocation: `sum(prob_tier * tier_weight)`. Diagnostic score policies may transform that score before tiering.",
+            "- The `gate_bull_prob100_threshold` research repair is authorized only by finite non-negative raw validation score/forward-return correlation and only affects completed-bar `gate_bull` rows on the next effective allocation.",
             "- Direct-tier allocation still applies risk-off caps, minimum holding periods, hysteresis, costs, and the strict gate.",
             "- `regime_state` maps utility tiers into `risk_off`, `reduced`, and `risk_on` states before converting state probabilities back into expected allocation.",
         ]

--- a/src/marketlab/reports/phase8_bull_participation.py
+++ b/src/marketlab/reports/phase8_bull_participation.py
@@ -724,7 +724,11 @@ def _selection_context_rows(
                 row_count=int(count),
             )
 
-    for column in ("selected_regime_bull_floor", "selected_regime_risk_off_cap"):
+    for column in (
+        "selected_regime_bull_floor",
+        "selected_regime_risk_off_cap",
+        "selected_regime_gate_bull_floor",
+    ):
         if column not in selections.columns:
             continue
         values = selections.loc[status.eq("selected"), column].map(_numeric).dropna()

--- a/src/marketlab/reports/phase8_grid_compare.py
+++ b/src/marketlab/reports/phase8_grid_compare.py
@@ -77,6 +77,10 @@ PHASE8_GRID_COMPARISON_COLUMNS = [
     "score_policy_triggered_100_fraction",
     "score_policy_repair_authorized_fraction",
     "selected_validation_score_policy_repair_authorized_fraction",
+    "guarded_gate_bull_risk_off_override_triggered_fraction",
+    "guarded_gate_bull_risk_off_override_authorized_fraction",
+    "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+    "candidate_min_selection_validation_cost_benchmark_excess_cumulative_return",
     "selected_regime_gate_bull_floor_mode",
     "score_target_weight_correlation",
     "score_forward_return_correlation",
@@ -443,6 +447,34 @@ def _run_row(run_dir: Path) -> dict[str, object]:
                 phase8_summary,
                 "selected_validation_score_policy_repair_authorized_fraction",
                 section="score_policy_repair",
+            )
+        ),
+        "guarded_gate_bull_risk_off_override_triggered_fraction": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "guarded_gate_bull_risk_off_override_triggered_fraction",
+                section="guarded_gate_bull_risk_off_override",
+            )
+        ),
+        "guarded_gate_bull_risk_off_override_authorized_fraction": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "guarded_gate_bull_risk_off_override_authorized_fraction",
+                section="guarded_gate_bull_risk_off_override",
+            )
+        ),
+        "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction": _numeric_or_na(
+            _summary_value(
+                phase8_summary,
+                "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+                section="guarded_gate_bull_risk_off_override",
+            )
+        ),
+        "candidate_min_selection_validation_cost_benchmark_excess_cumulative_return": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "min_selection_validation_cost_benchmark_excess_cumulative_return_min",
+                section="candidate_score_validity",
             )
         ),
         "selected_regime_gate_bull_floor_mode": _numeric_or_na(

--- a/src/marketlab/reports/phase8_grid_compare.py
+++ b/src/marketlab/reports/phase8_grid_compare.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+STRATEGY_NAME = "ml_indicator_tuned__long_only__cash"
+DEFAULT_RUNS_ROOT = Path("artifacts/runs")
+DEFAULT_EXPERIMENT_PREFIX = "btc_phase8"
+
+REQUIRED_COMPLETE_ARTIFACTS = (
+    "strategy_summary.csv",
+    "strict_research_gate.csv",
+    "ml_strategy_tuning_selections.csv",
+)
+DIAGNOSTIC_ARTIFACTS = (
+    "phase8_run_summary.csv",
+    "phase8_methodology_review.csv",
+    "phase8_bull_participation_summary.csv",
+    "phase8_score_diagnostic_summary.csv",
+    "phase8_bull_counterfactual_summary.csv",
+    "phase8_bull_counterfactual_gate.csv",
+)
+
+PHASE8_GRID_COMPARISON_COLUMNS = [
+    "experiment",
+    "run_id",
+    "run_dir",
+    "artifact_status",
+    "recommended_artifact_action",
+    "latest_complete_for_experiment",
+    "file_count",
+    "size_mb",
+    "strict_gate_present",
+    "strategy_summary_present",
+    "methodology_review_present",
+    "bull_participation_present",
+    "score_diagnostic_present",
+    "counterfactual_present",
+    "strict_gate_passed",
+    "deployment_gate_passed",
+    "risk_allocation_gate_passed",
+    "selection_coverage_gate_passed",
+    "target_support_gate_passed",
+    "signal_validity_gate_passed",
+    "bull_participation_gate_passed",
+    "counterfactual_pass_available",
+    "strategy_cumulative_return",
+    "buy_hold_cumulative_return",
+    "active_return_vs_buy_hold",
+    "active_return_vs_btc_static_25",
+    "active_return_vs_btc_static_50",
+    "active_return_vs_btc_static_75",
+    "active_return_vs_btc_rebalanced_25",
+    "active_return_vs_btc_rebalanced_50",
+    "active_return_vs_btc_rebalanced_75",
+    "strategy_sharpe_like",
+    "buy_hold_sharpe_like",
+    "strategy_max_drawdown",
+    "buy_hold_max_drawdown",
+    "strategy_avg_gross_exposure",
+    "strategy_avg_turnover",
+    "bull_upside_capture_ratio",
+    "downside_capture_ratio",
+    "selected_fold_fraction",
+    "no_valid_candidate_folds",
+    "target_tier_25_global_fraction",
+    "target_tier_50_global_fraction",
+    "predicted_tier_25_fraction",
+    "predicted_tier_50_fraction",
+    "predicted_tier_100_fraction",
+    "score_target_weight_correlation",
+    "score_forward_return_correlation",
+    "score_realized_utility_correlation",
+    "any_selected_oos_predicted_tier_100",
+    "gate_bull_average_long_exposure",
+    "gate_bull_active_return_sum",
+    "gate_bull_underexposed_positive_benchmark_fraction",
+    "gate_bull_underexposed_positive_benchmark_return_sum",
+    "force_runtime_bull_100_cumulative_return",
+    "force_runtime_bull_100_avg_long_exposure",
+    "buy_hold_gate_bull_model_elsewhere_cumulative_return",
+    "buy_hold_gate_bull_model_elsewhere_avg_long_exposure",
+]
+
+
+def _read_csv(run_dir: Path, name: str) -> pd.DataFrame:
+    path = run_dir / name
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(path)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _numeric(value: Any) -> float:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+    return numeric_value if math.isfinite(numeric_value) else float("nan")
+
+
+def _numeric_or_na(value: Any) -> float | object:
+    numeric_value = _numeric(value)
+    return numeric_value if math.isfinite(numeric_value) else pd.NA
+
+
+def _summary_value(
+    summary: pd.DataFrame,
+    metric: str,
+    *,
+    section: str | None = None,
+) -> object:
+    if summary.empty or "metric" not in summary.columns:
+        return pd.NA
+    matches = summary.loc[summary["metric"].astype(str).eq(metric)]
+    if section is not None and "section" in matches.columns:
+        matches = matches.loc[matches["section"].astype(str).eq(section)]
+    if matches.empty or "value" not in matches.columns:
+        return pd.NA
+    return matches.iloc[0]["value"]
+
+
+def _counterfactual_summary_value(
+    summary: pd.DataFrame,
+    *,
+    scenario: str,
+    metric: str,
+) -> object:
+    if summary.empty or not {"scenario", "metric", "value"}.issubset(summary.columns):
+        return pd.NA
+    matches = summary.loc[
+        summary["scenario"].astype(str).eq(scenario)
+        & summary["metric"].astype(str).eq(metric)
+    ]
+    if matches.empty:
+        return pd.NA
+    return matches.iloc[0]["value"]
+
+
+def _methodology_passed(
+    review: pd.DataFrame,
+    *,
+    methodology_gate: str,
+    metric: str = "overall",
+    section: str | None = "summary",
+) -> object:
+    if review.empty or not {"methodology_gate", "metric", "passed"}.issubset(review.columns):
+        return pd.NA
+    matches = review.loc[
+        review["methodology_gate"].astype(str).eq(methodology_gate)
+        & review["metric"].astype(str).eq(metric)
+    ]
+    if section is not None and "section" in matches.columns:
+        matches = matches.loc[matches["section"].astype(str).eq(section)]
+    if matches.empty:
+        return pd.NA
+    return _truthy(matches.iloc[0]["passed"])
+
+
+def _strict_condition_passed(strict_gate: pd.DataFrame, condition: str) -> object:
+    if strict_gate.empty or not {"condition", "passed"}.issubset(strict_gate.columns):
+        return pd.NA
+    matches = strict_gate.loc[strict_gate["condition"].astype(str).eq(condition)]
+    if matches.empty:
+        return pd.NA
+    return _truthy(matches.iloc[0]["passed"])
+
+
+def _strategy_row(strategy_summary: pd.DataFrame, strategy_name: str) -> pd.Series:
+    if strategy_summary.empty or "strategy" not in strategy_summary.columns:
+        return pd.Series(dtype=object)
+    matches = strategy_summary.loc[strategy_summary["strategy"].astype(str).eq(strategy_name)]
+    if matches.empty and strategy_name == STRATEGY_NAME:
+        matches = strategy_summary.loc[
+            strategy_summary["strategy"].astype(str).str.startswith("ml_")
+        ]
+    if matches.empty:
+        return pd.Series(dtype=object)
+    return matches.iloc[0]
+
+
+def _strategy_metric(strategy_summary: pd.DataFrame, strategy_name: str, metric: str) -> object:
+    row = _strategy_row(strategy_summary, strategy_name)
+    if row.empty:
+        return pd.NA
+    return _numeric_or_na(row.get(metric))
+
+
+def _active_return_vs(strategy_summary: pd.DataFrame, benchmark_name: str) -> object:
+    strategy_return = _numeric(_strategy_metric(strategy_summary, STRATEGY_NAME, "cumulative_return"))
+    benchmark_return = _numeric(
+        _strategy_metric(strategy_summary, benchmark_name, "cumulative_return")
+    )
+    if not math.isfinite(strategy_return) or not math.isfinite(benchmark_return):
+        return pd.NA
+    return strategy_return - benchmark_return
+
+
+def _artifact_inventory(run_dir: Path) -> tuple[int, int]:
+    if not run_dir.exists():
+        return 0, 0
+    file_count = 0
+    total_bytes = 0
+    for path in run_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        file_count += 1
+        total_bytes += path.stat().st_size
+    return file_count, total_bytes
+
+
+def _artifact_status(run_dir: Path, file_count: int) -> str:
+    if not run_dir.exists():
+        return "missing"
+    present = {name for name in REQUIRED_COMPLETE_ARTIFACTS if (run_dir / name).exists()}
+    if present == set(REQUIRED_COMPLETE_ARTIFACTS):
+        return "complete"
+    if file_count <= 2:
+        return "incomplete"
+    if any((run_dir / name).exists() for name in DIAGNOSTIC_ARTIFACTS):
+        return "summary_only"
+    return "incomplete"
+
+
+def discover_phase8_run_dirs(
+    runs_root: str | Path = DEFAULT_RUNS_ROOT,
+    *,
+    experiment_prefix: str = DEFAULT_EXPERIMENT_PREFIX,
+) -> list[Path]:
+    resolved_root = Path(runs_root)
+    if not resolved_root.exists():
+        return []
+
+    run_dirs: list[Path] = []
+    for experiment_dir in sorted(resolved_root.iterdir()):
+        if not experiment_dir.is_dir():
+            continue
+        if not experiment_dir.name.startswith(experiment_prefix):
+            continue
+        run_dirs.extend(sorted(path for path in experiment_dir.iterdir() if path.is_dir()))
+    return run_dirs
+
+
+def _run_row(run_dir: Path) -> dict[str, object]:
+    file_count, total_bytes = _artifact_inventory(run_dir)
+    strict_gate = _read_csv(run_dir, "strict_research_gate.csv")
+    strategy_summary = _read_csv(run_dir, "strategy_summary.csv")
+    phase8_summary = _read_csv(run_dir, "phase8_run_summary.csv")
+    methodology_review = _read_csv(run_dir, "phase8_methodology_review.csv")
+    bull_summary = _read_csv(run_dir, "phase8_bull_participation_summary.csv")
+    score_summary = _read_csv(run_dir, "phase8_score_diagnostic_summary.csv")
+    counterfactual_summary = _read_csv(run_dir, "phase8_bull_counterfactual_summary.csv")
+
+    status = _artifact_status(run_dir, file_count)
+    row: dict[str, object] = {
+        "experiment": run_dir.parent.name,
+        "run_id": run_dir.name,
+        "run_dir": str(run_dir),
+        "artifact_status": status,
+        "recommended_artifact_action": "review_before_pruning",
+        "latest_complete_for_experiment": False,
+        "file_count": file_count,
+        "size_mb": round(total_bytes / (1024 * 1024), 6),
+        "strict_gate_present": (run_dir / "strict_research_gate.csv").exists(),
+        "strategy_summary_present": (run_dir / "strategy_summary.csv").exists(),
+        "methodology_review_present": (run_dir / "phase8_methodology_review.csv").exists(),
+        "bull_participation_present": (
+            run_dir / "phase8_bull_participation_summary.csv"
+        ).exists(),
+        "score_diagnostic_present": (run_dir / "phase8_score_diagnostic_summary.csv").exists(),
+        "counterfactual_present": (
+            run_dir / "phase8_bull_counterfactual_summary.csv"
+        ).exists(),
+        "strict_gate_passed": _strict_condition_passed(strict_gate, "overall"),
+        "deployment_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="deployment_gate",
+            section="strict_gate",
+        ),
+        "risk_allocation_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="risk_allocation_gate",
+        ),
+        "selection_coverage_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="selection_coverage_gate",
+        ),
+        "target_support_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="target_support_gate",
+        ),
+        "signal_validity_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="signal_validity_gate",
+        ),
+        "bull_participation_gate_passed": _methodology_passed(
+            methodology_review,
+            methodology_gate="bull_participation_gate",
+        ),
+        "counterfactual_pass_available": _methodology_passed(
+            methodology_review,
+            methodology_gate="counterfactual_hypothesis",
+            metric="counterfactual_pass_available",
+        ),
+        "strategy_cumulative_return": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "cumulative_return",
+        ),
+        "buy_hold_cumulative_return": _strategy_metric(
+            strategy_summary,
+            "buy_hold",
+            "cumulative_return",
+        ),
+        "active_return_vs_buy_hold": _active_return_vs(strategy_summary, "buy_hold"),
+        "active_return_vs_btc_static_25": _active_return_vs(
+            strategy_summary,
+            "btc_static_25",
+        ),
+        "active_return_vs_btc_static_50": _active_return_vs(
+            strategy_summary,
+            "btc_static_50",
+        ),
+        "active_return_vs_btc_static_75": _active_return_vs(
+            strategy_summary,
+            "btc_static_75",
+        ),
+        "active_return_vs_btc_rebalanced_25": _active_return_vs(
+            strategy_summary,
+            "btc_rebalanced_25",
+        ),
+        "active_return_vs_btc_rebalanced_50": _active_return_vs(
+            strategy_summary,
+            "btc_rebalanced_50",
+        ),
+        "active_return_vs_btc_rebalanced_75": _active_return_vs(
+            strategy_summary,
+            "btc_rebalanced_75",
+        ),
+        "strategy_sharpe_like": _strategy_metric(strategy_summary, STRATEGY_NAME, "sharpe_like"),
+        "buy_hold_sharpe_like": _strategy_metric(strategy_summary, "buy_hold", "sharpe_like"),
+        "strategy_max_drawdown": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "max_drawdown",
+        ),
+        "buy_hold_max_drawdown": _strategy_metric(
+            strategy_summary,
+            "buy_hold",
+            "max_drawdown",
+        ),
+        "strategy_avg_gross_exposure": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "avg_gross_exposure",
+        ),
+        "strategy_avg_turnover": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "avg_turnover",
+        ),
+        "bull_upside_capture_ratio": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "up_capture",
+        ),
+        "downside_capture_ratio": _strategy_metric(
+            strategy_summary,
+            STRATEGY_NAME,
+            "down_capture",
+        ),
+        "selected_fold_fraction": _numeric_or_na(
+            _summary_value(phase8_summary, "selected_fold_fraction")
+        ),
+        "no_valid_candidate_folds": _numeric_or_na(
+            _summary_value(phase8_summary, "no_valid_candidate_folds")
+        ),
+        "target_tier_25_global_fraction": _numeric_or_na(
+            _summary_value(phase8_summary, "target_tier_25_global_fraction")
+        ),
+        "target_tier_50_global_fraction": _numeric_or_na(
+            _summary_value(phase8_summary, "target_tier_50_global_fraction")
+        ),
+        "predicted_tier_25_fraction": _numeric_or_na(
+            _summary_value(phase8_summary, "predicted_tier_25_fraction")
+        ),
+        "predicted_tier_50_fraction": _numeric_or_na(
+            _summary_value(phase8_summary, "predicted_tier_50_fraction")
+        ),
+        "predicted_tier_100_fraction": _numeric_or_na(
+            _summary_value(score_summary, "predicted_tier_100_fraction")
+        ),
+        "score_target_weight_correlation": _numeric_or_na(
+            _summary_value(score_summary, "score_target_weight_correlation")
+        ),
+        "score_forward_return_correlation": _numeric_or_na(
+            _summary_value(score_summary, "score_forward_return_correlation")
+        ),
+        "score_realized_utility_correlation": _numeric_or_na(
+            _summary_value(score_summary, "score_realized_utility_correlation")
+        ),
+        "any_selected_oos_predicted_tier_100": _summary_value(
+            score_summary,
+            "any_selected_oos_predicted_tier_100",
+        ),
+        "gate_bull_average_long_exposure": _numeric_or_na(
+            _summary_value(bull_summary, "gate_bull_average_long_exposure")
+        ),
+        "gate_bull_active_return_sum": _numeric_or_na(
+            _summary_value(bull_summary, "gate_bull_active_return_sum")
+        ),
+        "gate_bull_underexposed_positive_benchmark_fraction": _numeric_or_na(
+            _summary_value(
+                bull_summary,
+                "gate_bull_underexposed_positive_benchmark_fraction",
+            )
+        ),
+        "gate_bull_underexposed_positive_benchmark_return_sum": _numeric_or_na(
+            _summary_value(
+                bull_summary,
+                "gate_bull_underexposed_positive_benchmark_return_sum",
+            )
+        ),
+        "force_runtime_bull_100_cumulative_return": _numeric_or_na(
+            _counterfactual_summary_value(
+                counterfactual_summary,
+                scenario="force_runtime_bull_100",
+                metric="cumulative_return",
+            )
+        ),
+        "force_runtime_bull_100_avg_long_exposure": _numeric_or_na(
+            _counterfactual_summary_value(
+                counterfactual_summary,
+                scenario="force_runtime_bull_100",
+                metric="avg_long_exposure",
+            )
+        ),
+        "buy_hold_gate_bull_model_elsewhere_cumulative_return": _numeric_or_na(
+            _counterfactual_summary_value(
+                counterfactual_summary,
+                scenario="buy_hold_gate_bull_model_elsewhere",
+                metric="cumulative_return",
+            )
+        ),
+        "buy_hold_gate_bull_model_elsewhere_avg_long_exposure": _numeric_or_na(
+            _counterfactual_summary_value(
+                counterfactual_summary,
+                scenario="buy_hold_gate_bull_model_elsewhere",
+                metric="avg_long_exposure",
+            )
+        ),
+    }
+    if status in {"missing", "incomplete"}:
+        row["recommended_artifact_action"] = "archive_or_prune_after_manifest"
+    elif status == "summary_only":
+        row["recommended_artifact_action"] = "review_before_pruning"
+    return row
+
+
+def _mark_latest_complete(rows: list[dict[str, object]]) -> None:
+    latest_by_experiment: dict[str, dict[str, object]] = {}
+    for row in rows:
+        if row["artifact_status"] != "complete":
+            continue
+        experiment = str(row["experiment"])
+        current = latest_by_experiment.get(experiment)
+        if current is None or str(row["run_id"]) > str(current["run_id"]):
+            latest_by_experiment[experiment] = row
+
+    for row in rows:
+        if row["artifact_status"] != "complete":
+            continue
+        latest = latest_by_experiment.get(str(row["experiment"]))
+        is_latest = latest is row
+        row["latest_complete_for_experiment"] = is_latest
+        row["recommended_artifact_action"] = (
+            "keep_latest_complete" if is_latest else "keep_for_grid_comparison"
+        )
+
+
+def build_phase8_grid_comparison(
+    *,
+    runs_root: str | Path = DEFAULT_RUNS_ROOT,
+    run_dirs: Sequence[str | Path] | None = None,
+    experiment_prefix: str = DEFAULT_EXPERIMENT_PREFIX,
+) -> pd.DataFrame:
+    resolved_run_dirs = (
+        [Path(path) for path in run_dirs]
+        if run_dirs
+        else discover_phase8_run_dirs(runs_root, experiment_prefix=experiment_prefix)
+    )
+    rows = [_run_row(path) for path in resolved_run_dirs]
+    _mark_latest_complete(rows)
+    return pd.DataFrame(rows, columns=PHASE8_GRID_COMPARISON_COLUMNS)
+
+
+def write_phase8_grid_comparison(
+    *,
+    runs_root: str | Path = DEFAULT_RUNS_ROOT,
+    run_dirs: Sequence[str | Path] | None = None,
+    output_path: str | Path | None = None,
+    experiment_prefix: str = DEFAULT_EXPERIMENT_PREFIX,
+) -> Path:
+    resolved_output_path = (
+        Path(output_path)
+        if output_path is not None
+        else Path(runs_root) / "phase8_btc_grid_comparison.csv"
+    )
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+    build_phase8_grid_comparison(
+        runs_root=runs_root,
+        run_dirs=run_dirs,
+        experiment_prefix=experiment_prefix,
+    ).to_csv(resolved_output_path, index=False)
+    return resolved_output_path

--- a/src/marketlab/reports/phase8_grid_compare.py
+++ b/src/marketlab/reports/phase8_grid_compare.py
@@ -72,8 +72,19 @@ PHASE8_GRID_COMPARISON_COLUMNS = [
     "predicted_tier_25_fraction",
     "predicted_tier_50_fraction",
     "predicted_tier_100_fraction",
+    "selected_score_transform_mode",
+    "score_transform_applied_fraction",
+    "score_policy_triggered_100_fraction",
+    "score_policy_repair_authorized_fraction",
+    "selected_validation_score_policy_repair_authorized_fraction",
+    "selected_regime_gate_bull_floor_mode",
     "score_target_weight_correlation",
     "score_forward_return_correlation",
+    "candidate_validation_score_forward_return_correlation_mean",
+    "candidate_validation_score_forward_return_correlation_min",
+    "candidate_validation_raw_score_forward_return_correlation_min",
+    "negative_validation_score_forward_return_correlation_candidates",
+    "validation_gate_bull_underexposed_positive_benchmark_fraction_mean",
     "score_realized_utility_correlation",
     "any_selected_oos_predicted_tier_100",
     "gate_bull_average_long_exposure",
@@ -401,11 +412,86 @@ def _run_row(run_dir: Path) -> dict[str, object]:
         "predicted_tier_100_fraction": _numeric_or_na(
             _summary_value(score_summary, "predicted_tier_100_fraction")
         ),
+        "selected_score_transform_mode": _summary_value(
+            phase8_summary,
+            "selected_score_transform_mode",
+            section="score_transform",
+        ),
+        "score_transform_applied_fraction": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "score_transform_applied_fraction",
+                section="score_transform",
+            )
+        ),
+        "score_policy_triggered_100_fraction": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "score_policy_triggered_100_fraction",
+                section="score_policy_repair",
+            )
+        ),
+        "score_policy_repair_authorized_fraction": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "score_policy_repair_authorized_fraction",
+                section="score_policy_repair",
+            )
+        ),
+        "selected_validation_score_policy_repair_authorized_fraction": _numeric_or_na(
+            _summary_value(
+                phase8_summary,
+                "selected_validation_score_policy_repair_authorized_fraction",
+                section="score_policy_repair",
+            )
+        ),
+        "selected_regime_gate_bull_floor_mode": _numeric_or_na(
+            _summary_value(
+                phase8_summary,
+                "selected_regime_gate_bull_floor_mode",
+                section="fold_selection",
+            )
+        ),
         "score_target_weight_correlation": _numeric_or_na(
             _summary_value(score_summary, "score_target_weight_correlation")
         ),
         "score_forward_return_correlation": _numeric_or_na(
             _summary_value(score_summary, "score_forward_return_correlation")
+        ),
+        "candidate_validation_score_forward_return_correlation_mean": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "validation_score_forward_return_correlation_mean",
+                section="candidate_score_validity",
+            )
+        ),
+        "candidate_validation_score_forward_return_correlation_min": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "validation_score_forward_return_correlation_min",
+                section="candidate_score_validity",
+            )
+        ),
+        "candidate_validation_raw_score_forward_return_correlation_min": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "validation_raw_score_forward_return_correlation_min",
+                section="candidate_score_validity",
+            )
+        ),
+        "negative_validation_score_forward_return_correlation_candidates": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "negative_validation_score_forward_return_correlation_candidates",
+                section="candidate_score_validity",
+            )
+        ),
+        "validation_gate_bull_underexposed_positive_benchmark_fraction_mean": _numeric_or_na(
+            _summary_value(
+                score_summary,
+                "validation_gate_bull_underexposed_positive_benchmark_fraction_mean",
+                section="candidate_score_validity",
+            )
         ),
         "score_realized_utility_correlation": _numeric_or_na(
             _summary_value(score_summary, "score_realized_utility_correlation")

--- a/src/marketlab/reports/phase8_methodology.py
+++ b/src/marketlab/reports/phase8_methodology.py
@@ -1,0 +1,737 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+STRATEGY_NAME = "ml_indicator_tuned__long_only__cash"
+
+PHASE8_METHODOLOGY_REVIEW_COLUMNS = [
+    "methodology_gate",
+    "section",
+    "metric",
+    "passed",
+    "value",
+    "required",
+    "diagnostic_only",
+    "source_artifact",
+    "detail",
+]
+
+
+def _read_csv(run_dir: Path, name: str) -> pd.DataFrame:
+    path = run_dir / name
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(path)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _numeric(value: Any) -> float:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+    return numeric_value if math.isfinite(numeric_value) else float("nan")
+
+
+def _append(
+    rows: list[dict[str, object]],
+    *,
+    methodology_gate: str,
+    section: str,
+    metric: str,
+    passed: bool,
+    value: object = pd.NA,
+    required: object = "",
+    diagnostic_only: bool = False,
+    source_artifact: str = "",
+    detail: str = "",
+) -> None:
+    rows.append(
+        {
+            "methodology_gate": methodology_gate,
+            "section": section,
+            "metric": metric,
+            "passed": bool(passed),
+            "value": value,
+            "required": required,
+            "diagnostic_only": bool(diagnostic_only),
+            "source_artifact": source_artifact,
+            "detail": detail,
+        }
+    )
+
+
+def _artifact_presence_rows(
+    rows: list[dict[str, object]],
+    *,
+    run_dir: Path,
+) -> None:
+    for name in (
+        "strict_research_gate.csv",
+        "phase8_run_summary.csv",
+        "strategy_summary.csv",
+        "phase8_score_diagnostic_summary.csv",
+        "phase8_bull_participation_summary.csv",
+        "phase8_bull_counterfactual_gate.csv",
+    ):
+        _append(
+            rows,
+            methodology_gate="artifact_presence",
+            section="inputs",
+            metric=name,
+            passed=(run_dir / name).exists(),
+            value="present" if (run_dir / name).exists() else "missing",
+            required="present when this diagnostic is available",
+            source_artifact=name,
+        )
+
+
+def _strict_condition(strict_gate: pd.DataFrame, condition: str) -> pd.Series | None:
+    if strict_gate.empty or "condition" not in strict_gate.columns:
+        return None
+    matches = strict_gate.loc[strict_gate["condition"].astype(str).eq(condition)]
+    if matches.empty:
+        return None
+    return matches.iloc[0]
+
+
+def _append_strict_condition(
+    rows: list[dict[str, object]],
+    *,
+    strict_gate: pd.DataFrame,
+    methodology_gate: str,
+    section: str,
+    condition: str,
+    source_artifact: str = "strict_research_gate.csv",
+) -> bool:
+    row = _strict_condition(strict_gate, condition)
+    if row is None:
+        _append(
+            rows,
+            methodology_gate=methodology_gate,
+            section=section,
+            metric=condition,
+            passed=False,
+            value="missing",
+            required="strict-gate condition present",
+            source_artifact=source_artifact,
+        )
+        return False
+    passed = _truthy(row.get("passed"))
+    _append(
+        rows,
+        methodology_gate=methodology_gate,
+        section=section,
+        metric=condition,
+        passed=passed,
+        value=row.get("observed", pd.NA),
+        required=row.get("required", ""),
+        source_artifact=source_artifact,
+    )
+    return passed
+
+
+def _deployment_gate_rows(rows: list[dict[str, object]], strict_gate: pd.DataFrame) -> None:
+    if strict_gate.empty:
+        _append(
+            rows,
+            methodology_gate="deployment_gate",
+            section="strict_gate",
+            metric="overall",
+            passed=False,
+            value="missing",
+            required="strict_research_gate.csv overall row",
+            source_artifact="strict_research_gate.csv",
+        )
+        return
+
+    overall = _strict_condition(strict_gate, "overall")
+    if overall is not None:
+        _append(
+            rows,
+            methodology_gate="deployment_gate",
+            section="strict_gate",
+            metric="overall",
+            passed=_truthy(overall.get("passed")),
+            value=overall.get("observed", ""),
+            required=overall.get("required", ""),
+            source_artifact="strict_research_gate.csv",
+            detail="unchanged Phase 8 blocker for any Phase 9 BTC deployment",
+        )
+
+    if "passed" not in strict_gate.columns:
+        return
+    failed = strict_gate.loc[~strict_gate["passed"].map(_truthy)].copy()
+    for _, row in failed.iterrows():
+        condition = str(row.get("condition", "unknown"))
+        if condition == "overall":
+            continue
+        _append(
+            rows,
+            methodology_gate="deployment_gate",
+            section="failed_strict_condition",
+            metric=condition,
+            passed=False,
+            value=row.get("observed", pd.NA),
+            required=row.get("required", ""),
+            source_artifact="strict_research_gate.csv",
+        )
+
+
+def _benchmark_family_rows(
+    rows: list[dict[str, object]],
+    strategy_summary: pd.DataFrame,
+) -> dict[str, bool]:
+    family_passes: dict[str, bool] = {
+        "buy_hold": False,
+        "static_partial": False,
+        "rebalanced_partial": False,
+    }
+    if strategy_summary.empty or not {"strategy", "cumulative_return"}.issubset(
+        strategy_summary.columns
+    ):
+        for family in family_passes:
+            _append(
+                rows,
+                methodology_gate="benchmark_family",
+                section=family,
+                metric=f"{family}_passed",
+                passed=False,
+                value="missing",
+                required="strategy_summary.csv with cumulative_return",
+                source_artifact="strategy_summary.csv",
+            )
+        return family_passes
+
+    strategy_rows = strategy_summary.loc[
+        strategy_summary["strategy"].astype(str).eq(STRATEGY_NAME)
+    ]
+    if strategy_rows.empty:
+        strategy_rows = strategy_summary.loc[
+            strategy_summary["strategy"].astype(str).str.startswith("ml_")
+        ]
+    if strategy_rows.empty:
+        for family in family_passes:
+            _append(
+                rows,
+                methodology_gate="benchmark_family",
+                section=family,
+                metric=f"{family}_passed",
+                passed=False,
+                value="missing",
+                required=STRATEGY_NAME,
+                source_artifact="strategy_summary.csv",
+            )
+        return family_passes
+
+    strategy_return = _numeric(strategy_rows.iloc[0].get("cumulative_return"))
+    families = {
+        "buy_hold": lambda name: name == "buy_hold",
+        "static_partial": lambda name: name.startswith("btc_static_"),
+        "rebalanced_partial": lambda name: name.startswith("btc_rebalanced_"),
+    }
+    for family, matcher in families.items():
+        family_results: list[bool] = []
+        for _, row in strategy_summary.iterrows():
+            benchmark_name = str(row.get("strategy", ""))
+            if benchmark_name == STRATEGY_NAME or not matcher(benchmark_name):
+                continue
+            benchmark_return = _numeric(row.get("cumulative_return"))
+            delta = strategy_return - benchmark_return
+            passed = math.isfinite(delta) and delta > 0.0
+            family_results.append(passed)
+            _append(
+                rows,
+                methodology_gate="benchmark_family",
+                section=family,
+                metric=f"active_return_vs_{benchmark_name}",
+                passed=passed,
+                value=delta if math.isfinite(delta) else "missing",
+                required="> 0",
+                source_artifact="strategy_summary.csv",
+                detail=f"{STRATEGY_NAME} cumulative_return minus {benchmark_name}",
+            )
+        family_passed = bool(family_results) and all(family_results)
+        family_passes[family] = family_passed
+        _append(
+            rows,
+            methodology_gate="benchmark_family",
+            section=family,
+            metric=f"{family}_passed",
+            passed=family_passed,
+            value=sum(1 for value in family_results if value),
+            required=f"{len(family_results)} benchmarks beat",
+            source_artifact="strategy_summary.csv",
+        )
+    return family_passes
+
+
+def _risk_allocation_gate_rows(
+    rows: list[dict[str, object]],
+    *,
+    strict_gate: pd.DataFrame,
+    family_passes: dict[str, bool],
+) -> None:
+    condition_passes = [
+        _append_strict_condition(
+            rows,
+            strict_gate=strict_gate,
+            methodology_gate="risk_allocation_gate",
+            section="risk_profile",
+            condition=condition,
+        )
+        for condition in (
+            "sharpe_like_matches_or_improves",
+            "max_drawdown_matches_or_improves",
+            "average_exposure_in_range",
+            "annualized_turnover_budget",
+        )
+    ]
+    rebalanced_passed = bool(family_passes.get("rebalanced_partial", False))
+    _append(
+        rows,
+        methodology_gate="risk_allocation_gate",
+        section="benchmark_family",
+        metric="rebalanced_partial_passed",
+        passed=rebalanced_passed,
+        value=rebalanced_passed,
+        required="beat all configured rebalanced BTC/cash benchmarks",
+        source_artifact="strategy_summary.csv",
+    )
+    overall = all(condition_passes) and rebalanced_passed
+    _append(
+        rows,
+        methodology_gate="risk_allocation_gate",
+        section="summary",
+        metric="overall",
+        passed=overall,
+        value=overall,
+        required="risk profile and rebalanced benchmark family pass",
+        detail="diagnostic risk-allocation view; does not replace strict deployment gate",
+    )
+
+
+def _selection_gate_rows(rows: list[dict[str, object]], strict_gate: pd.DataFrame) -> None:
+    passes = [
+        _append_strict_condition(
+            rows,
+            strict_gate=strict_gate,
+            methodology_gate="selection_coverage_gate",
+            section="walk_forward",
+            condition=condition,
+        )
+        for condition in (
+            "multiple_selected_walk_forward_folds",
+            "selected_walk_forward_fold_fraction",
+        )
+    ]
+    overall = all(passes)
+    _append(
+        rows,
+        methodology_gate="selection_coverage_gate",
+        section="summary",
+        metric="overall",
+        passed=overall,
+        value=overall,
+        required="walk-forward selection coverage passes",
+    )
+
+
+def _target_support_gate_rows(rows: list[dict[str, object]], strict_gate: pd.DataFrame) -> None:
+    if strict_gate.empty or "condition" not in strict_gate.columns:
+        _append(
+            rows,
+            methodology_gate="target_support_gate",
+            section="summary",
+            metric="overall",
+            passed=False,
+            value="missing",
+            required="partial and predicted target support rows",
+            source_artifact="strict_research_gate.csv",
+        )
+        return
+
+    support_rows = strict_gate.loc[
+        strict_gate["condition"].astype(str).str.startswith(("partial_target_", "predicted_target_"))
+    ].copy()
+    if support_rows.empty:
+        _append(
+            rows,
+            methodology_gate="target_support_gate",
+            section="summary",
+            metric="overall",
+            passed=False,
+            value="missing",
+            required="partial and predicted target support rows",
+            source_artifact="strict_research_gate.csv",
+        )
+        return
+
+    passes: list[bool] = []
+    for _, row in support_rows.iterrows():
+        condition = str(row.get("condition", "unknown"))
+        passed = _truthy(row.get("passed"))
+        passes.append(passed)
+        section = "predicted_support" if condition.startswith("predicted_") else "target_support"
+        _append(
+            rows,
+            methodology_gate="target_support_gate",
+            section=section,
+            metric=condition,
+            passed=passed,
+            value=row.get("observed", pd.NA),
+            required=row.get("required", ""),
+            source_artifact="strict_research_gate.csv",
+        )
+
+    overall = all(passes)
+    _append(
+        rows,
+        methodology_gate="target_support_gate",
+        section="summary",
+        metric="overall",
+        passed=overall,
+        value=overall,
+        required="all configured target and predicted-tier support rows pass",
+    )
+
+
+def _summary_value(summary: pd.DataFrame, metric: str) -> pd.Series | None:
+    if summary.empty or "metric" not in summary.columns:
+        return None
+    matches = summary.loc[summary["metric"].astype(str).eq(metric)]
+    if matches.empty:
+        return None
+    return matches.iloc[0]
+
+
+def _append_numeric_summary_condition(
+    rows: list[dict[str, object]],
+    *,
+    summary: pd.DataFrame,
+    methodology_gate: str,
+    section: str,
+    metric: str,
+    required: str,
+    predicate: Callable[[float], bool],
+    source_artifact: str,
+) -> bool:
+    row = _summary_value(summary, metric)
+    if row is None:
+        _append(
+            rows,
+            methodology_gate=methodology_gate,
+            section=section,
+            metric=metric,
+            passed=False,
+            value="missing",
+            required=required,
+            source_artifact=source_artifact,
+        )
+        return False
+    value = _numeric(row.get("value"))
+    passed = math.isfinite(value) and bool(predicate(value))
+    _append(
+        rows,
+        methodology_gate=methodology_gate,
+        section=section,
+        metric=metric,
+        passed=passed,
+        value=value if math.isfinite(value) else "missing",
+        required=required,
+        source_artifact=source_artifact,
+        detail=str(row.get("detail", "")),
+    )
+    return passed
+
+
+def _append_bool_summary_condition(
+    rows: list[dict[str, object]],
+    *,
+    summary: pd.DataFrame,
+    methodology_gate: str,
+    section: str,
+    metric: str,
+    source_artifact: str,
+) -> bool:
+    row = _summary_value(summary, metric)
+    if row is None:
+        _append(
+            rows,
+            methodology_gate=methodology_gate,
+            section=section,
+            metric=metric,
+            passed=False,
+            value="missing",
+            required=True,
+            source_artifact=source_artifact,
+        )
+        return False
+    passed = _truthy(row.get("value"))
+    _append(
+        rows,
+        methodology_gate=methodology_gate,
+        section=section,
+        metric=metric,
+        passed=passed,
+        value=passed,
+        required=True,
+        source_artifact=source_artifact,
+        detail=str(row.get("detail", "")),
+    )
+    return passed
+
+
+def _signal_validity_gate_rows(rows: list[dict[str, object]], score_summary: pd.DataFrame) -> None:
+    source = "phase8_score_diagnostic_summary.csv"
+    if score_summary.empty:
+        _append(
+            rows,
+            methodology_gate="signal_validity_gate",
+            section="summary",
+            metric="overall",
+            passed=False,
+            value="missing",
+            required=source,
+            source_artifact=source,
+        )
+        return
+
+    passes = [
+        _append_numeric_summary_condition(
+            rows,
+            summary=score_summary,
+            methodology_gate="signal_validity_gate",
+            section="score_relationship",
+            metric=metric,
+            required="> 0",
+            predicate=lambda value: value > 0.0,
+            source_artifact=source,
+        )
+        for metric in (
+            "score_target_weight_correlation",
+            "score_forward_return_correlation",
+            "score_realized_utility_correlation",
+        )
+    ]
+    passes.append(
+        _append_numeric_summary_condition(
+            rows,
+            summary=score_summary,
+            methodology_gate="signal_validity_gate",
+            section="tier_support",
+            metric="predicted_tier_100_fraction",
+            required="> 0",
+            predicate=lambda value: value > 0.0,
+            source_artifact=source,
+        )
+    )
+    passes.append(
+        _append_bool_summary_condition(
+            rows,
+            summary=score_summary,
+            methodology_gate="signal_validity_gate",
+            section="tier_support",
+            metric="any_selected_oos_predicted_tier_100",
+            source_artifact=source,
+        )
+    )
+    overall = all(passes)
+    _append(
+        rows,
+        methodology_gate="signal_validity_gate",
+        section="summary",
+        metric="overall",
+        passed=overall,
+        value=overall,
+        required="score relationships and selected OOS 100% support pass",
+        source_artifact=source,
+    )
+
+
+def _bull_participation_gate_rows(
+    rows: list[dict[str, object]],
+    bull_summary: pd.DataFrame,
+) -> None:
+    source = "phase8_bull_participation_summary.csv"
+    if bull_summary.empty:
+        _append(
+            rows,
+            methodology_gate="bull_participation_gate",
+            section="summary",
+            metric="overall",
+            passed=False,
+            value="missing",
+            required=source,
+            source_artifact=source,
+        )
+        return
+
+    passes = [
+        _append_numeric_summary_condition(
+            rows,
+            summary=bull_summary,
+            methodology_gate="bull_participation_gate",
+            section="exposure",
+            metric="gate_bull_average_long_exposure",
+            required=">= 0.50",
+            predicate=lambda value: value >= 0.50,
+            source_artifact=source,
+        ),
+        _append_numeric_summary_condition(
+            rows,
+            summary=bull_summary,
+            methodology_gate="bull_participation_gate",
+            section="active_return",
+            metric="gate_bull_active_return_sum",
+            required="> 0",
+            predicate=lambda value: value > 0.0,
+            source_artifact=source,
+        ),
+        _append_numeric_summary_condition(
+            rows,
+            summary=bull_summary,
+            methodology_gate="bull_participation_gate",
+            section="missed_upside",
+            metric="gate_bull_underexposed_positive_benchmark_return_sum",
+            required="<= 0",
+            predicate=lambda value: value <= 0.0,
+            source_artifact=source,
+        ),
+        _append_numeric_summary_condition(
+            rows,
+            summary=bull_summary,
+            methodology_gate="bull_participation_gate",
+            section="selection_context",
+            metric="selected_fold_fraction",
+            required=">= 0.75",
+            predicate=lambda value: value >= 0.75,
+            source_artifact=source,
+        ),
+    ]
+    overall = all(passes)
+    _append(
+        rows,
+        methodology_gate="bull_participation_gate",
+        section="summary",
+        metric="overall",
+        passed=overall,
+        value=overall,
+        required="bull exposure, bull active return, missed-upside, and fold coverage pass",
+        source_artifact=source,
+    )
+
+
+def _counterfactual_rows(rows: list[dict[str, object]], counterfactual_gate: pd.DataFrame) -> None:
+    source = "phase8_bull_counterfactual_gate.csv"
+    if counterfactual_gate.empty:
+        _append(
+            rows,
+            methodology_gate="counterfactual_hypothesis",
+            section="artifact",
+            metric="counterfactual_gate_present",
+            passed=False,
+            value="missing",
+            required=source,
+            diagnostic_only=True,
+            source_artifact=source,
+        )
+        return
+    if not {"scenario", "condition", "passed"}.issubset(counterfactual_gate.columns):
+        _append(
+            rows,
+            methodology_gate="counterfactual_hypothesis",
+            section="artifact",
+            metric="counterfactual_gate_schema",
+            passed=False,
+            value="missing",
+            required="scenario, condition, passed columns",
+            diagnostic_only=True,
+            source_artifact=source,
+        )
+        return
+
+    overall_rows = counterfactual_gate.loc[
+        counterfactual_gate["condition"].astype(str).eq("overall")
+    ]
+    any_passing = False
+    for _, row in overall_rows.iterrows():
+        scenario = str(row.get("scenario", "unknown"))
+        passed = _truthy(row.get("passed"))
+        any_passing = any_passing or passed
+        _append(
+            rows,
+            methodology_gate="counterfactual_hypothesis",
+            section=scenario,
+            metric="overall",
+            passed=passed,
+            value=passed,
+            required=row.get("required", "all diagnostic conditions pass"),
+            diagnostic_only=True,
+            source_artifact=source,
+            detail="diagnostic-only; does not approve deployment",
+        )
+    _append(
+        rows,
+        methodology_gate="counterfactual_hypothesis",
+        section="summary",
+        metric="counterfactual_pass_available",
+        passed=any_passing,
+        value=any_passing,
+        required=True,
+        diagnostic_only=True,
+        source_artifact=source,
+        detail="passing counterfactuals are hypotheses for validation-selected rules only",
+    )
+
+
+def build_phase8_methodology_review(run_dir: str | Path) -> pd.DataFrame:
+    resolved_run_dir = Path(run_dir)
+    strict_gate = _read_csv(resolved_run_dir, "strict_research_gate.csv")
+    strategy_summary = _read_csv(resolved_run_dir, "strategy_summary.csv")
+    score_summary = _read_csv(resolved_run_dir, "phase8_score_diagnostic_summary.csv")
+    bull_summary = _read_csv(resolved_run_dir, "phase8_bull_participation_summary.csv")
+    counterfactual_gate = _read_csv(resolved_run_dir, "phase8_bull_counterfactual_gate.csv")
+
+    rows: list[dict[str, object]] = []
+    _artifact_presence_rows(rows, run_dir=resolved_run_dir)
+    _deployment_gate_rows(rows, strict_gate)
+    family_passes = _benchmark_family_rows(rows, strategy_summary)
+    _risk_allocation_gate_rows(
+        rows,
+        strict_gate=strict_gate,
+        family_passes=family_passes,
+    )
+    _selection_gate_rows(rows, strict_gate)
+    _target_support_gate_rows(rows, strict_gate)
+    _signal_validity_gate_rows(rows, score_summary)
+    _bull_participation_gate_rows(rows, bull_summary)
+    _counterfactual_rows(rows, counterfactual_gate)
+    return pd.DataFrame(rows, columns=PHASE8_METHODOLOGY_REVIEW_COLUMNS)
+
+
+def write_phase8_methodology_review(
+    run_dir: str | Path,
+    output_path: str | Path | None = None,
+) -> Path:
+    resolved_run_dir = Path(run_dir)
+    resolved_output_path = (
+        Path(output_path)
+        if output_path is not None
+        else resolved_run_dir / "phase8_methodology_review.csv"
+    )
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+    build_phase8_methodology_review(resolved_run_dir).to_csv(resolved_output_path, index=False)
+    return resolved_output_path

--- a/src/marketlab/reports/phase8_regime_policy_sweep.py
+++ b/src/marketlab/reports/phase8_regime_policy_sweep.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+
+from marketlab.reports.phase8_bull_counterfactual import (
+    _base_counterfactual_frame,
+    _benchmark_cumulative_return,
+    _compound,
+    _gate_benchmark_strategies,
+    _scenario_metrics,
+)
+from marketlab.reports.phase8_bull_participation import _read_csv, _truthy
+
+BULL_EXPOSURES = (0.75, 1.0)
+SIDEWAYS_EXPOSURES = (0.0, 0.25, 0.50)
+BEAR_EXPOSURES = (0.0,)
+RISK_OFF_CAPS = (0.0, 0.25)
+GATE_BULL_OVERRIDES = (False, True)
+
+PHASE8_REGIME_POLICY_SWEEP_COLUMNS = [
+    "policy_name",
+    "section",
+    "metric",
+    "group",
+    "value",
+    "row_count",
+    "detail",
+]
+PHASE8_REGIME_POLICY_SWEEP_SUMMARY_COLUMNS = [
+    "policy_name",
+    "bull_exposure",
+    "sideways_exposure",
+    "bear_exposure",
+    "risk_off_cap",
+    "gate_bull_override",
+    "cumulative_return",
+    "active_return_vs_buy_hold",
+    "min_active_return_vs_required_benchmarks",
+    "sharpe_like",
+    "max_drawdown",
+    "avg_long_exposure",
+    "avg_turnover",
+    "annualized_turnover",
+    "total_turnover",
+    "mutated_days",
+    "gate_bull_average_long_exposure",
+    "gate_bull_active_return_sum",
+    "gate_bull_compound_active_return",
+    "gate_bull_underexposed_positive_benchmark_fraction",
+    "gate_bull_underexposed_positive_benchmark_return_sum",
+    "regime_source",
+]
+
+
+def _policy_name(
+    *,
+    bull_exposure: float,
+    sideways_exposure: float,
+    bear_exposure: float,
+    risk_off_cap: float,
+    gate_bull_override: bool,
+) -> str:
+    def tier(value: float) -> int:
+        return int(round(float(value) * 100))
+
+    suffix = "gate_bull_100" if gate_bull_override else "runtime_only"
+    return (
+        f"bull{tier(bull_exposure)}_sideways{tier(sideways_exposure)}_"
+        f"bear{tier(bear_exposure)}_riskoff{tier(risk_off_cap)}_{suffix}"
+    )
+
+
+def _append_detail(
+    rows: list[dict[str, object]],
+    *,
+    policy_name: str,
+    section: str,
+    metric: str,
+    value: object,
+    group: object = "",
+    row_count: object = pd.NA,
+    detail: str = "",
+) -> None:
+    rows.append(
+        {
+            "policy_name": policy_name,
+            "section": section,
+            "metric": metric,
+            "group": group,
+            "value": value,
+            "row_count": row_count,
+            "detail": detail,
+        }
+    )
+
+
+def _policy_exposure(
+    base: pd.DataFrame,
+    *,
+    bull_exposure: float,
+    sideways_exposure: float,
+    bear_exposure: float,
+    risk_off_cap: float,
+    gate_bull_override: bool,
+) -> pd.Series:
+    runtime_regime = base["runtime_regime"].astype(str)
+    exposure = pd.Series(float(sideways_exposure), index=base.index, dtype=float)
+    exposure.loc[runtime_regime.eq("bull")] = float(bull_exposure)
+    exposure.loc[runtime_regime.eq("bear")] = float(bear_exposure)
+    exposure.loc[runtime_regime.eq("risk_off")] = float(risk_off_cap)
+    if gate_bull_override and "gate_bull" in base.columns:
+        exposure.loc[base["gate_bull"].map(_truthy)] = 1.0
+    return exposure.clip(0.0, 1.0)
+
+
+def _policy_performance(
+    base: pd.DataFrame,
+    *,
+    policy_name: str,
+    exposure: pd.Series,
+    cost_bps: float,
+) -> pd.DataFrame:
+    turnover = exposure.diff().abs()
+    if not turnover.empty:
+        turnover.iloc[0] = abs(float(exposure.iloc[0]))
+    benchmark_return = pd.to_numeric(base["benchmark_net_return"], errors="coerce").fillna(0.0)
+    net_return = exposure * benchmark_return - (
+        turnover.fillna(0.0) * (float(cost_bps) / 10_000.0)
+    )
+    return pd.DataFrame(
+        {
+            "date": pd.to_datetime(base["date"], errors="coerce"),
+            "strategy": policy_name,
+            "gross_return": exposure * benchmark_return,
+            "net_return": net_return,
+            "turnover": turnover.fillna(0.0),
+            "equity": (1.0 + net_return).cumprod(),
+        }
+    )
+
+
+def _mutated_day_count(base: pd.DataFrame, exposure: pd.Series) -> int:
+    actual = pd.to_numeric(base["long_exposure"], errors="coerce").fillna(0.0).clip(0.0, 1.0)
+    return int(exposure.sub(actual).abs().gt(1e-9).sum())
+
+
+def _gate_bull_metrics(
+    base: pd.DataFrame,
+    performance: pd.DataFrame,
+    exposure: pd.Series,
+) -> dict[str, float]:
+    if "gate_bull" not in base.columns:
+        return {
+            "gate_bull_average_long_exposure": float("nan"),
+            "gate_bull_active_return_sum": float("nan"),
+            "gate_bull_compound_active_return": float("nan"),
+            "gate_bull_underexposed_positive_benchmark_fraction": float("nan"),
+            "gate_bull_underexposed_positive_benchmark_return_sum": float("nan"),
+        }
+    mask = base["gate_bull"].map(_truthy)
+    benchmark_return = pd.to_numeric(base["benchmark_net_return"], errors="coerce").fillna(0.0)
+    if not bool(mask.any()):
+        return {
+            "gate_bull_average_long_exposure": float("nan"),
+            "gate_bull_active_return_sum": float("nan"),
+            "gate_bull_compound_active_return": float("nan"),
+            "gate_bull_underexposed_positive_benchmark_fraction": float("nan"),
+            "gate_bull_underexposed_positive_benchmark_return_sum": float("nan"),
+        }
+    scenario_gate_return = performance.loc[mask, "net_return"]
+    benchmark_gate_return = benchmark_return.loc[mask]
+    positive_gate_bull = mask & benchmark_return.gt(0.0)
+    underexposed_positive = positive_gate_bull & exposure.lt(1.0 - 1e-9)
+    positive_count = int(positive_gate_bull.sum())
+    return {
+        "gate_bull_average_long_exposure": float(exposure.loc[mask].mean()),
+        "gate_bull_active_return_sum": float(
+            performance.loc[mask, "net_return"].sub(benchmark_return.loc[mask]).sum()
+        ),
+        "gate_bull_compound_active_return": _compound(scenario_gate_return)
+        - _compound(benchmark_gate_return),
+        "gate_bull_underexposed_positive_benchmark_fraction": (
+            float(underexposed_positive.sum() / positive_count)
+            if positive_count > 0
+            else float("nan")
+        ),
+        "gate_bull_underexposed_positive_benchmark_return_sum": float(
+            benchmark_return.loc[underexposed_positive].sum()
+        ),
+    }
+
+
+def _benchmark_deltas(
+    *,
+    cumulative_return: float,
+    strategy_summary: pd.DataFrame,
+    required_benchmarks: list[str],
+) -> dict[str, float]:
+    deltas: dict[str, float] = {}
+    for benchmark_name in required_benchmarks:
+        benchmark_return = _benchmark_cumulative_return(strategy_summary, benchmark_name)
+        deltas[benchmark_name] = (
+            cumulative_return - benchmark_return
+            if math.isfinite(benchmark_return)
+            else float("nan")
+        )
+    return deltas
+
+
+def _add_runtime_regime_details(
+    *,
+    rows: list[dict[str, object]],
+    policy_name: str,
+    base: pd.DataFrame,
+    performance: pd.DataFrame,
+    exposure: pd.Series,
+) -> None:
+    benchmark_return = pd.to_numeric(base["benchmark_net_return"], errors="coerce").fillna(0.0)
+    for regime, regime_rows in base.groupby(base["runtime_regime"].astype(str), sort=True):
+        mask = base.index.isin(regime_rows.index)
+        _append_detail(
+            rows,
+            policy_name=policy_name,
+            section="runtime_regime",
+            metric="average_long_exposure",
+            group=regime,
+            value=float(exposure.loc[mask].mean()) if bool(mask.any()) else float("nan"),
+            row_count=int(mask.sum()),
+        )
+        _append_detail(
+            rows,
+            policy_name=policy_name,
+            section="runtime_regime",
+            metric="active_return_sum",
+            group=regime,
+            value=float(performance.loc[mask, "net_return"].sub(benchmark_return.loc[mask]).sum()),
+            row_count=int(mask.sum()),
+        )
+
+
+def build_phase8_regime_policy_sweep(
+    run_dir: str | Path,
+    *,
+    config_path: str | Path,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    resolved_run_dir = Path(run_dir)
+    base, config, date_regime_source = _base_counterfactual_frame(
+        run_dir=resolved_run_dir,
+        config_path=config_path,
+    )
+    strategy_summary = _read_csv(resolved_run_dir, "strategy_summary.csv")
+    required_benchmarks = _gate_benchmark_strategies(config)
+    base_cost_bps = float(config.portfolio.costs.bps_per_trade)
+    periods_per_year = float(config.evaluation.periods_per_year)
+
+    detail_rows: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+    for bull_exposure in BULL_EXPOSURES:
+        for sideways_exposure in SIDEWAYS_EXPOSURES:
+            for bear_exposure in BEAR_EXPOSURES:
+                for risk_off_cap in RISK_OFF_CAPS:
+                    for gate_bull_override in GATE_BULL_OVERRIDES:
+                        policy_name = _policy_name(
+                            bull_exposure=bull_exposure,
+                            sideways_exposure=sideways_exposure,
+                            bear_exposure=bear_exposure,
+                            risk_off_cap=risk_off_cap,
+                            gate_bull_override=gate_bull_override,
+                        )
+                        exposure = _policy_exposure(
+                            base,
+                            bull_exposure=bull_exposure,
+                            sideways_exposure=sideways_exposure,
+                            bear_exposure=bear_exposure,
+                            risk_off_cap=risk_off_cap,
+                            gate_bull_override=gate_bull_override,
+                        )
+                        performance = _policy_performance(
+                            base,
+                            policy_name=policy_name,
+                            exposure=exposure,
+                            cost_bps=base_cost_bps,
+                        )
+                        metrics = _scenario_metrics(
+                            performance,
+                            exposure,
+                            periods_per_year=periods_per_year,
+                        )
+                        benchmark_deltas = _benchmark_deltas(
+                            cumulative_return=metrics["cumulative_return"],
+                            strategy_summary=strategy_summary,
+                            required_benchmarks=required_benchmarks,
+                        )
+                        gate_metrics = _gate_bull_metrics(base, performance, exposure)
+                        active_vs_buy_hold = benchmark_deltas.get("buy_hold", float("nan"))
+                        finite_deltas = [
+                            value for value in benchmark_deltas.values() if math.isfinite(value)
+                        ]
+                        min_active_required = min(finite_deltas) if finite_deltas else float("nan")
+                        annualized_turnover = metrics["avg_turnover"] * periods_per_year
+                        summary_rows.append(
+                            {
+                                "policy_name": policy_name,
+                                "bull_exposure": bull_exposure,
+                                "sideways_exposure": sideways_exposure,
+                                "bear_exposure": bear_exposure,
+                                "risk_off_cap": risk_off_cap,
+                                "gate_bull_override": gate_bull_override,
+                                "cumulative_return": metrics["cumulative_return"],
+                                "active_return_vs_buy_hold": active_vs_buy_hold,
+                                "min_active_return_vs_required_benchmarks": (
+                                    min_active_required
+                                ),
+                                "sharpe_like": metrics["sharpe_like"],
+                                "max_drawdown": metrics["max_drawdown"],
+                                "avg_long_exposure": metrics["avg_long_exposure"],
+                                "avg_turnover": metrics["avg_turnover"],
+                                "annualized_turnover": annualized_turnover,
+                                "total_turnover": metrics["total_turnover"],
+                                "mutated_days": _mutated_day_count(base, exposure),
+                                **gate_metrics,
+                                "regime_source": date_regime_source,
+                            }
+                        )
+                        for metric in (
+                            "cumulative_return",
+                            "sharpe_like",
+                            "max_drawdown",
+                            "avg_long_exposure",
+                            "avg_turnover",
+                            "total_turnover",
+                        ):
+                            _append_detail(
+                                detail_rows,
+                                policy_name=policy_name,
+                                section="policy_metrics",
+                                metric=metric,
+                                value=metrics[metric],
+                                row_count=len(performance),
+                            )
+                        for benchmark_name, delta in benchmark_deltas.items():
+                            _append_detail(
+                                detail_rows,
+                                policy_name=policy_name,
+                                section="benchmark_deltas",
+                                metric=f"active_return_vs_{benchmark_name}",
+                                group=benchmark_name,
+                                value=delta,
+                                row_count=len(performance),
+                            )
+                        for metric, value in gate_metrics.items():
+                            _append_detail(
+                                detail_rows,
+                                policy_name=policy_name,
+                                section="gate_bull",
+                                metric=metric,
+                                value=value,
+                                row_count=int(base.get("gate_bull", pd.Series(False)).map(_truthy).sum()),
+                            )
+                        _add_runtime_regime_details(
+                            rows=detail_rows,
+                            policy_name=policy_name,
+                            base=base,
+                            performance=performance,
+                            exposure=exposure,
+                        )
+
+    detail = pd.DataFrame(detail_rows, columns=PHASE8_REGIME_POLICY_SWEEP_COLUMNS)
+    summary = pd.DataFrame(
+        summary_rows,
+        columns=PHASE8_REGIME_POLICY_SWEEP_SUMMARY_COLUMNS,
+    )
+    if not summary.empty:
+        summary = summary.sort_values(
+            [
+                "active_return_vs_buy_hold",
+                "gate_bull_active_return_sum",
+                "cumulative_return",
+            ],
+            ascending=[False, False, False],
+        ).reset_index(drop=True)
+    return detail, summary
+
+
+def write_phase8_regime_policy_sweep(
+    run_dir: str | Path,
+    *,
+    config_path: str | Path,
+    output_dir: str | Path | None = None,
+) -> tuple[Path, Path]:
+    resolved_run_dir = Path(run_dir)
+    resolved_output_dir = Path(output_dir) if output_dir is not None else resolved_run_dir
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    detail, summary = build_phase8_regime_policy_sweep(
+        resolved_run_dir,
+        config_path=config_path,
+    )
+    detail_path = resolved_output_dir / "phase8_regime_policy_sweep.csv"
+    summary_path = resolved_output_dir / "phase8_regime_policy_sweep_summary.csv"
+    detail.to_csv(detail_path, index=False)
+    summary.to_csv(summary_path, index=False)
+    return detail_path, summary_path

--- a/src/marketlab/reports/phase8_score_diagnostic.py
+++ b/src/marketlab/reports/phase8_score_diagnostic.py
@@ -270,6 +270,30 @@ def _score_decile_rows(
             value=float(working["score_policy_repair_authorized"].map(_truthy).mean()),
             detail="selected OOS rows carrying validation-authorized repair context",
         )
+    if "guarded_gate_bull_risk_off_override_triggered" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="guarded_gate_bull_risk_off_override_triggered_fraction",
+            value=float(
+                working["guarded_gate_bull_risk_off_override_triggered"]
+                .map(_truthy)
+                .mean()
+            ),
+            detail="selected OOS rows lifted to 100% after the risk-off cap",
+        )
+    if "guarded_gate_bull_risk_off_override_authorized" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="guarded_gate_bull_risk_off_override_authorized_fraction",
+            value=float(
+                working["guarded_gate_bull_risk_off_override_authorized"]
+                .map(_truthy)
+                .mean()
+            ),
+            detail="selected OOS rows carrying validation-authorized override context",
+        )
 
 
 def _confusion_rows_for_group(
@@ -459,6 +483,7 @@ def _candidate_rows(
         "validation_gate_bull_average_exposure",
         "validation_gate_bull_underexposed_positive_benchmark_fraction",
         "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
         "validation_score_transform_applied_fraction",
     ):
         if column in working.columns:
@@ -486,6 +511,7 @@ def _candidate_rows(
             "validation_gate_bull_average_exposure",
             "validation_gate_bull_underexposed_positive_benchmark_fraction",
             "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+            "min_selection_validation_cost_benchmark_excess_cumulative_return",
             "validation_score_transform_applied_fraction",
         ):
             if column in group.columns:
@@ -559,6 +585,7 @@ def _candidate_rows(
         "validation_gate_bull_average_exposure",
         "validation_gate_bull_underexposed_positive_benchmark_fraction",
         "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
     ):
         if column not in working.columns:
             continue
@@ -595,6 +622,20 @@ def _candidate_rows(
             metric="validation_score_policy_repair_authorized_fraction",
             value=float(
                 working["validation_score_policy_repair_authorized"].map(_truthy).mean()
+            ),
+            detail="validation candidates authorized by raw score/forward-return ordering",
+        )
+    if "validation_guarded_gate_bull_risk_off_override_authorized" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+            value=float(
+                working[
+                    "validation_guarded_gate_bull_risk_off_override_authorized"
+                ]
+                .map(_truthy)
+                .mean()
             ),
             detail="validation candidates authorized by raw score/forward-return ordering",
         )

--- a/src/marketlab/reports/phase8_score_diagnostic.py
+++ b/src/marketlab/reports/phase8_score_diagnostic.py
@@ -236,6 +236,40 @@ def _score_decile_rows(
             value=float(predicted_100.mean()),
             detail="selected OOS prediction rows",
         )
+    if "allocation_score_transform" in working.columns:
+        transforms = working["allocation_score_transform"].dropna().astype(str)
+        if not transforms.empty:
+            _append_summary(
+                summary_rows,
+                section="score_transform",
+                metric="selected_score_transform_mode",
+                value=transforms.mode().iloc[0],
+                detail="mode among selected OOS prediction rows",
+            )
+    if "score_transform_applied" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="score_transform",
+            metric="score_transform_applied_fraction",
+            value=float(working["score_transform_applied"].map(_truthy).mean()),
+            detail="selected OOS prediction rows",
+        )
+    if "score_policy_triggered_100" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="score_policy_repair",
+            metric="score_policy_triggered_100_fraction",
+            value=float(working["score_policy_triggered_100"].map(_truthy).mean()),
+            detail="selected OOS rows promoted to the 100% tier by score policy",
+        )
+    if "score_policy_repair_authorized" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="score_policy_repair",
+            metric="score_policy_repair_authorized_fraction",
+            value=float(working["score_policy_repair_authorized"].map(_truthy).mean()),
+            detail="selected OOS rows carrying validation-authorized repair context",
+        )
 
 
 def _confusion_rows_for_group(
@@ -342,6 +376,21 @@ def _candidate_selected_mask(candidates: pd.DataFrame, selections: pd.DataFrame)
         ("min_holding_period_bars", "selected_min_holding_period_bars"),
         ("hysteresis_margin", "selected_hysteresis_margin"),
         ("regime_policy", "selected_regime_policy"),
+        ("regime_gate_bull_floor", "selected_regime_gate_bull_floor"),
+        ("allocation_score_transform", "selected_allocation_score_transform"),
+        (
+            "score_transform_bull_multiplier",
+            "selected_score_transform_bull_multiplier",
+        ),
+        ("score_transform_bull_addend", "selected_score_transform_bull_addend"),
+        (
+            "score_transform_risk_off_score_cap",
+            "selected_score_transform_risk_off_score_cap",
+        ),
+        (
+            "score_transform_non_bull_score_cap",
+            "selected_score_transform_non_bull_score_cap",
+        ),
         ("threshold", "selected_threshold"),
         ("tier_min_threshold", "selected_tier_min_threshold"),
         ("tier_half_threshold", "selected_tier_half_threshold"),
@@ -404,6 +453,13 @@ def _candidate_rows(
         "validation_predicted_100_fraction",
         "min_validation_predicted_target_fraction",
         "min_benchmark_excess_cumulative_return",
+        "validation_score_forward_return_correlation",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_target_correlation",
+        "validation_gate_bull_average_exposure",
+        "validation_gate_bull_underexposed_positive_benchmark_fraction",
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+        "validation_score_transform_applied_fraction",
     ):
         if column in working.columns:
             working[column] = working[column].map(_numeric)
@@ -424,6 +480,13 @@ def _candidate_rows(
             "validation_predicted_100_fraction",
             "min_validation_predicted_target_fraction",
             "min_benchmark_excess_cumulative_return",
+            "validation_score_forward_return_correlation",
+            "validation_raw_score_forward_return_correlation",
+            "validation_score_target_correlation",
+            "validation_gate_bull_average_exposure",
+            "validation_gate_bull_underexposed_positive_benchmark_fraction",
+            "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+            "validation_score_transform_applied_fraction",
         ):
             if column in group.columns:
                 values = group[column].dropna()
@@ -489,6 +552,52 @@ def _candidate_rows(
         value="validation_predicted_100_fraction" in working.columns,
         detail="current candidate artifacts may only persist required partial-tier support",
     )
+    for column in (
+        "validation_score_forward_return_correlation",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_target_correlation",
+        "validation_gate_bull_average_exposure",
+        "validation_gate_bull_underexposed_positive_benchmark_fraction",
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+    ):
+        if column not in working.columns:
+            continue
+        values = working[column].dropna()
+        if values.empty:
+            continue
+        _append_summary(
+            summary_rows,
+            section="candidate_score_validity",
+            metric=f"{column}_mean",
+            value=float(values.mean()),
+            detail="validation candidate mean",
+        )
+        _append_summary(
+            summary_rows,
+            section="candidate_score_validity",
+            metric=f"{column}_min",
+            value=float(values.min()),
+            detail="validation candidate minimum",
+        )
+    if "validation_score_forward_return_correlation" in working.columns:
+        correlations = working["validation_score_forward_return_correlation"]
+        _append_summary(
+            summary_rows,
+            section="candidate_score_validity",
+            metric="negative_validation_score_forward_return_correlation_candidates",
+            value=int(correlations.lt(0.0).sum()),
+            detail="validation candidates with score/forward-return correlation < 0",
+        )
+    if "validation_score_policy_repair_authorized" in working.columns:
+        _append_summary(
+            summary_rows,
+            section="score_policy_repair",
+            metric="validation_score_policy_repair_authorized_fraction",
+            value=float(
+                working["validation_score_policy_repair_authorized"].map(_truthy).mean()
+            ),
+            detail="validation candidates authorized by raw score/forward-return ordering",
+        )
 
 
 def _model_family_oos_rows(

--- a/src/marketlab/reports/phase8_summary.py
+++ b/src/marketlab/reports/phase8_summary.py
@@ -142,6 +142,56 @@ def _selection_rows(rows: list[dict[str, object]], selections: pd.DataFrame) -> 
         value=no_valid_folds,
         detail="folds that stayed cash because no candidate was selected",
     )
+    if "selected_regime_gate_bull_floor" in selections.columns:
+        values = (
+            selections.loc[statuses.eq("selected"), "selected_regime_gate_bull_floor"]
+            .map(_numeric)
+            .dropna()
+        )
+        if not values.empty:
+            _append(
+                rows,
+                section="fold_selection",
+                metric="selected_regime_gate_bull_floor_mode",
+                value=float(values.mode().iloc[0]),
+                detail="mode among selected walk-forward folds",
+            )
+    if "selected_allocation_score_transform" in selections.columns:
+        selected = selections.loc[statuses.eq("selected")].copy()
+        selected_transforms = (
+            selected["selected_allocation_score_transform"].dropna().astype(str)
+        )
+        if not selected_transforms.empty:
+            mode = selected_transforms.mode().iloc[0]
+            _append(
+                rows,
+                section="score_transform",
+                metric="selected_score_transform_mode",
+                value=mode,
+                detail="mode among selected walk-forward folds",
+            )
+            for transform_name, count in selected_transforms.value_counts().sort_index().items():
+                _append(
+                    rows,
+                    section="score_transform",
+                    metric=f"selected_score_transform_{transform_name}_folds",
+                    value=int(count),
+                    detail="selected walk-forward fold count",
+                )
+    if "validation_score_policy_repair_authorized" in selections.columns:
+        selected = selections.loc[statuses.eq("selected")]
+        if not selected.empty:
+            _append(
+                rows,
+                section="score_policy_repair",
+                metric="selected_validation_score_policy_repair_authorized_fraction",
+                value=float(
+                    selected["validation_score_policy_repair_authorized"]
+                    .map(_truthy)
+                    .mean()
+                ),
+                detail="selected walk-forward folds authorized by raw validation score ordering",
+            )
 
 
 def _fallback_candidate_reasons(row: pd.Series) -> list[str]:
@@ -202,6 +252,65 @@ def _candidate_reason_rows(rows: list[dict[str, object]], candidates: pd.DataFra
             value=int(count),
             detail="counted per failed candidate reason",
         )
+    for column in (
+        "validation_score_forward_return_correlation",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_target_correlation",
+        "validation_gate_bull_average_exposure",
+        "validation_gate_bull_underexposed_positive_benchmark_fraction",
+        "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+    ):
+        if column not in candidates.columns:
+            continue
+        values = candidates[column].map(_numeric).dropna()
+        if values.empty:
+            continue
+        _append(
+            rows,
+            section="score_validity",
+            metric=f"{column}_mean",
+            value=float(values.mean()),
+            detail="validation candidate mean",
+        )
+        _append(
+            rows,
+            section="score_validity",
+            metric=f"{column}_min",
+            value=float(values.min()),
+            detail="validation candidate minimum",
+        )
+    if "validation_score_forward_return_correlation" in candidates.columns:
+        correlations = candidates["validation_score_forward_return_correlation"].map(
+            _numeric
+        )
+        _append(
+            rows,
+            section="score_validity",
+            metric="negative_validation_score_forward_return_correlation_candidates",
+            value=int(correlations.lt(0.0).sum()),
+            detail="validation candidates with score/forward-return correlation < 0",
+        )
+    if "validation_score_policy_repair_authorized" in candidates.columns:
+        _append(
+            rows,
+            section="score_policy_repair",
+            metric="validation_score_policy_repair_authorized_fraction",
+            value=float(
+                candidates["validation_score_policy_repair_authorized"].map(_truthy).mean()
+            ),
+            detail="validation candidates authorized by raw score/forward-return ordering",
+        )
+    if "score_policy_repair_denied_reason" in candidates.columns:
+        denied_reasons = candidates["score_policy_repair_denied_reason"].dropna().astype(str)
+        denied_reasons = denied_reasons.loc[denied_reasons.str.strip().ne("")]
+        for reason, count in denied_reasons.value_counts().sort_index().items():
+            _append(
+                rows,
+                section="score_policy_repair",
+                metric=f"score_policy_repair_denied_reason_{reason}",
+                value=int(count),
+                detail="validation candidate denial count",
+            )
 
 
 def _target_support_rows(rows: list[dict[str, object]], target_diagnostics: pd.DataFrame) -> None:
@@ -264,6 +373,24 @@ def _predicted_support_rows(rows: list[dict[str, object]], probability_diagnosti
             metric=f"predicted_tier_{_tier_label(weight)}_fraction",
             value=fraction,
             detail="outer OOS predicted tier support",
+        )
+    if "score_policy_triggered_100" in probability_diagnostics.columns:
+        _append(
+            rows,
+            section="score_policy_repair",
+            metric="score_policy_triggered_100_fraction",
+            value=float(probability_diagnostics["score_policy_triggered_100"].map(_truthy).mean()),
+            detail="outer OOS rows promoted to the 100% tier by score policy",
+        )
+    if "score_policy_repair_authorized" in probability_diagnostics.columns:
+        _append(
+            rows,
+            section="score_policy_repair",
+            metric="score_policy_repair_authorized_fraction",
+            value=float(
+                probability_diagnostics["score_policy_repair_authorized"].map(_truthy).mean()
+            ),
+            detail="outer OOS rows carrying validation-authorized repair context",
         )
 
 

--- a/src/marketlab/reports/phase8_summary.py
+++ b/src/marketlab/reports/phase8_summary.py
@@ -192,6 +192,22 @@ def _selection_rows(rows: list[dict[str, object]], selections: pd.DataFrame) -> 
                 ),
                 detail="selected walk-forward folds authorized by raw validation score ordering",
             )
+    if "validation_guarded_gate_bull_risk_off_override_authorized" in selections.columns:
+        selected = selections.loc[statuses.eq("selected")]
+        if not selected.empty:
+            _append(
+                rows,
+                section="guarded_gate_bull_risk_off_override",
+                metric="selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+                value=float(
+                    selected[
+                        "validation_guarded_gate_bull_risk_off_override_authorized"
+                    ]
+                    .map(_truthy)
+                    .mean()
+                ),
+                detail="selected walk-forward folds authorized by raw validation score ordering",
+            )
 
 
 def _fallback_candidate_reasons(row: pd.Series) -> list[str]:
@@ -202,6 +218,15 @@ def _fallback_candidate_reasons(row: pd.Series) -> list[str]:
         reasons.append("non_positive_buy_hold_excess")
     if _numeric(row.get("min_benchmark_excess_cumulative_return")) <= 0.0:
         reasons.append("non_positive_required_benchmark_excess")
+    if (
+        _numeric(
+            row.get(
+                "min_selection_validation_cost_benchmark_excess_cumulative_return"
+            )
+        )
+        <= 0.0
+    ):
+        reasons.append("non_positive_validation_cost_benchmark_excess")
     if _numeric(row.get("min_validation_predicted_target_fraction")) <= 0.0:
         reasons.append("missing_predicted_partial_tier_support")
     if _numeric(row.get("sharpe_like_delta")) <= 0.0 and _numeric(row.get("drawdown_delta")) < 0.0:
@@ -259,6 +284,7 @@ def _candidate_reason_rows(rows: list[dict[str, object]], candidates: pd.DataFra
         "validation_gate_bull_average_exposure",
         "validation_gate_bull_underexposed_positive_benchmark_fraction",
         "validation_gate_bull_underexposed_positive_benchmark_return_sum",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
     ):
         if column not in candidates.columns:
             continue
@@ -308,6 +334,35 @@ def _candidate_reason_rows(rows: list[dict[str, object]], candidates: pd.DataFra
                 rows,
                 section="score_policy_repair",
                 metric=f"score_policy_repair_denied_reason_{reason}",
+                value=int(count),
+                detail="validation candidate denial count",
+            )
+    if "validation_guarded_gate_bull_risk_off_override_authorized" in candidates.columns:
+        _append(
+            rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+            value=float(
+                candidates[
+                    "validation_guarded_gate_bull_risk_off_override_authorized"
+                ]
+                .map(_truthy)
+                .mean()
+            ),
+            detail="validation candidates authorized by raw score/forward-return ordering",
+        )
+    if "guarded_gate_bull_risk_off_override_denied_reason" in candidates.columns:
+        denied_reasons = (
+            candidates["guarded_gate_bull_risk_off_override_denied_reason"]
+            .dropna()
+            .astype(str)
+        )
+        denied_reasons = denied_reasons.loc[denied_reasons.str.strip().ne("")]
+        for reason, count in denied_reasons.value_counts().sort_index().items():
+            _append(
+                rows,
+                section="guarded_gate_bull_risk_off_override",
+                metric=f"guarded_gate_bull_risk_off_override_denied_reason_{reason}",
                 value=int(count),
                 detail="validation candidate denial count",
             )
@@ -391,6 +446,34 @@ def _predicted_support_rows(rows: list[dict[str, object]], probability_diagnosti
                 probability_diagnostics["score_policy_repair_authorized"].map(_truthy).mean()
             ),
             detail="outer OOS rows carrying validation-authorized repair context",
+        )
+    if "guarded_gate_bull_risk_off_override_triggered" in probability_diagnostics.columns:
+        _append(
+            rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="guarded_gate_bull_risk_off_override_triggered_fraction",
+            value=float(
+                probability_diagnostics[
+                    "guarded_gate_bull_risk_off_override_triggered"
+                ]
+                .map(_truthy)
+                .mean()
+            ),
+            detail="outer OOS rows lifted to 100% after the risk-off cap",
+        )
+    if "guarded_gate_bull_risk_off_override_authorized" in probability_diagnostics.columns:
+        _append(
+            rows,
+            section="guarded_gate_bull_risk_off_override",
+            metric="guarded_gate_bull_risk_off_override_authorized_fraction",
+            value=float(
+                probability_diagnostics[
+                    "guarded_gate_bull_risk_off_override_authorized"
+                ]
+                .map(_truthy)
+                .mean()
+            ),
+            detail="outer OOS rows carrying validation-authorized override context",
         )
 
 

--- a/src/marketlab/reports/phase8_target_diagnostic.py
+++ b/src/marketlab/reports/phase8_target_diagnostic.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from marketlab.reports.phase8_bull_participation import _resolve_date_regime
+
+ALLOCATION_TIERS = (0.0, 0.25, 0.50, 1.0)
+DEFENSE_DRAWDOWN_THRESHOLD = -0.10
+
+PHASE8_TARGET_DIAGNOSTIC_COLUMNS = [
+    "section",
+    "metric",
+    "group",
+    "subgroup",
+    "value",
+    "row_count",
+    "detail",
+]
+PHASE8_TARGET_DIAGNOSTIC_SUMMARY_COLUMNS = ["section", "metric", "value", "detail"]
+
+
+def _read_csv(run_dir: Path, name: str) -> pd.DataFrame:
+    path = run_dir / name
+    if not path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(path)
+
+
+def _numeric(value: Any) -> float:
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+    return numeric_value if math.isfinite(numeric_value) else float("nan")
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _tier_label(value: Any) -> str:
+    numeric_value = _numeric(value)
+    if not math.isfinite(numeric_value):
+        return "missing"
+    return f"{int(round(numeric_value * 100))}"
+
+
+def _append_detail(
+    rows: list[dict[str, object]],
+    *,
+    section: str,
+    metric: str,
+    value: object,
+    group: object = "",
+    subgroup: object = "",
+    row_count: object = pd.NA,
+    detail: str = "",
+) -> None:
+    rows.append(
+        {
+            "section": section,
+            "metric": metric,
+            "group": group,
+            "subgroup": subgroup,
+            "value": value,
+            "row_count": row_count,
+            "detail": detail,
+        }
+    )
+
+
+def _append_summary(
+    rows: list[dict[str, object]],
+    *,
+    section: str,
+    metric: str,
+    value: object,
+    detail: str = "",
+) -> None:
+    rows.append(
+        {
+            "section": section,
+            "metric": metric,
+            "value": value,
+            "detail": detail,
+        }
+    )
+
+
+def _merge_date_regime(
+    probability: pd.DataFrame,
+    *,
+    config_path: str | Path | None,
+) -> tuple[pd.DataFrame, str]:
+    if probability.empty:
+        return probability.copy(), "missing"
+
+    date_regime, date_regime_source = _resolve_date_regime(
+        probability=probability,
+        config_path=config_path,
+    )
+    working = probability.copy()
+    date_column = "effective_date" if "effective_date" in working.columns else "signal_date"
+    if date_regime.empty or date_column not in working.columns:
+        if "runtime_regime" not in working.columns:
+            working["runtime_regime"] = "missing"
+        return working, date_regime_source
+
+    working[date_column] = pd.to_datetime(working[date_column], errors="coerce")
+    regime = date_regime.copy()
+    regime["date"] = pd.to_datetime(regime["date"], errors="coerce")
+    regime_columns = [
+        column
+        for column in regime.columns
+        if column == "runtime_regime" or str(column).startswith("gate_")
+    ]
+    joined = working.merge(
+        regime.loc[:, ["date", *regime_columns]],
+        left_on=date_column,
+        right_on="date",
+        how="left",
+        suffixes=("", "_regime"),
+    )
+    for column in regime_columns:
+        regime_column = f"{column}_regime"
+        if regime_column not in joined.columns:
+            continue
+        if date_regime_source == "config" or column not in working.columns:
+            joined[column] = joined[regime_column].combine_first(joined.get(column))
+        else:
+            joined[column] = joined.get(column).combine_first(joined[regime_column])
+        joined = joined.drop(columns=[regime_column])
+    return joined.drop(columns=["date"]), date_regime_source
+
+
+def _prepare_probability(
+    probability: pd.DataFrame,
+    *,
+    config_path: str | Path | None,
+) -> tuple[pd.DataFrame, str]:
+    working, date_regime_source = _merge_date_regime(
+        probability,
+        config_path=config_path,
+    )
+    if working.empty:
+        return working, date_regime_source
+
+    for column in (
+        "target_weight",
+        "predicted_tier_weight",
+        "score",
+        "forward_return",
+        "forward_drawdown",
+        "realized_utility",
+    ):
+        if column in working.columns:
+            working[column] = working[column].map(_numeric)
+
+    if "runtime_regime" not in working.columns:
+        working["runtime_regime"] = "missing"
+    working["runtime_regime"] = working["runtime_regime"].fillna("missing").astype(str)
+    if "forward_return" in working.columns:
+        forward_return = working["forward_return"]
+        working["forward_return_sign"] = "missing"
+        working.loc[forward_return.gt(0.0), "forward_return_sign"] = "positive"
+        working.loc[forward_return.le(0.0), "forward_return_sign"] = "zero_or_negative"
+    else:
+        working["forward_return_sign"] = "missing"
+
+    if "forward_drawdown" in working.columns:
+        forward_drawdown = working["forward_drawdown"]
+        working["forward_drawdown_bucket"] = "missing"
+        working.loc[forward_drawdown.gt(DEFENSE_DRAWDOWN_THRESHOLD), "forward_drawdown_bucket"] = (
+            "mild"
+        )
+        working.loc[forward_drawdown.le(DEFENSE_DRAWDOWN_THRESHOLD), "forward_drawdown_bucket"] = (
+            "defense"
+        )
+    else:
+        working["forward_drawdown_bucket"] = "missing"
+
+    working["target_tier"] = (
+        working["target_weight"].map(_tier_label)
+        if "target_weight" in working.columns
+        else "missing"
+    )
+    working["predicted_tier"] = (
+        working["predicted_tier_weight"].map(_tier_label)
+        if "predicted_tier_weight" in working.columns
+        else "missing"
+    )
+    working["bull_continuation"] = (
+        working["runtime_regime"].eq("bull")
+        & working.get("forward_return", pd.Series(index=working.index, dtype=float)).gt(0.0)
+    )
+    defense_return = (
+        working.get("forward_return", pd.Series(index=working.index, dtype=float)).le(0.0)
+    )
+    defense_drawdown = (
+        working.get("forward_drawdown", pd.Series(index=working.index, dtype=float)).le(
+            DEFENSE_DRAWDOWN_THRESHOLD
+        )
+    )
+    working["drawdown_defense"] = defense_return | defense_drawdown
+    return working, date_regime_source
+
+
+def _fraction(rows: pd.DataFrame, column: str, tier: float, *, below: bool = False) -> object:
+    if rows.empty or column not in rows.columns:
+        return pd.NA
+    values = rows[column].dropna()
+    if values.empty:
+        return pd.NA
+    if below:
+        return float(values.lt(tier - 1e-9).mean())
+    return float(values.sub(tier).abs().le(1e-9).mean())
+
+
+def _mean(rows: pd.DataFrame, column: str) -> object:
+    if rows.empty or column not in rows.columns:
+        return pd.NA
+    values = rows[column].dropna()
+    if values.empty:
+        return pd.NA
+    return float(values.mean())
+
+
+def _append_group_metrics(
+    rows: list[dict[str, object]],
+    *,
+    section: str,
+    group: object,
+    frame: pd.DataFrame,
+    detail: str,
+) -> None:
+    _append_detail(
+        rows,
+        section=section,
+        metric="row_count",
+        group=group,
+        value=int(len(frame)),
+        row_count=int(len(frame)),
+        detail=detail,
+    )
+    for metric, value in {
+        "full_target_fraction": _fraction(frame, "target_weight", 1.0),
+        "full_prediction_fraction": _fraction(frame, "predicted_tier_weight", 1.0),
+        "below_full_target_fraction": _fraction(
+            frame,
+            "target_weight",
+            1.0,
+            below=True,
+        ),
+        "below_full_prediction_fraction": _fraction(
+            frame,
+            "predicted_tier_weight",
+            1.0,
+            below=True,
+        ),
+        "avg_target_weight": _mean(frame, "target_weight"),
+        "avg_predicted_tier_weight": _mean(frame, "predicted_tier_weight"),
+        "avg_score": _mean(frame, "score"),
+        "avg_forward_return": _mean(frame, "forward_return"),
+        "avg_forward_drawdown": _mean(frame, "forward_drawdown"),
+        "avg_realized_utility": _mean(frame, "realized_utility"),
+    }.items():
+        _append_detail(
+            rows,
+            section=section,
+            metric=metric,
+            group=group,
+            value=value,
+            row_count=int(len(frame)),
+            detail=detail,
+        )
+
+
+def _grouped_detail_rows(
+    *,
+    detail_rows: list[dict[str, object]],
+    working: pd.DataFrame,
+) -> None:
+    group_columns = {
+        "runtime_regime": "runtime regime labels on selected OOS rows",
+        "forward_return_sign": "realized forward-return sign",
+        "forward_drawdown_bucket": f"forward_drawdown <= {DEFENSE_DRAWDOWN_THRESHOLD:g}",
+        "target_tier": "actual target tier",
+        "predicted_tier": "nearest traded prediction tier",
+    }
+    if "allocation_score_transform" in working.columns:
+        group_columns["allocation_score_transform"] = "selected score-transform profile"
+    if "gate_bull" in working.columns:
+        working["gate_bull_label"] = working["gate_bull"].map(_truthy).map(str)
+        group_columns["gate_bull_label"] = "strict-gate bull labels from config or artifacts"
+
+    for column, detail in group_columns.items():
+        for group_name, group in working.groupby(column, dropna=False, sort=True):
+            _append_group_metrics(
+                detail_rows,
+                section=column,
+                group=group_name,
+                frame=group,
+                detail=detail,
+            )
+
+    if {"target_tier", "predicted_tier"}.issubset(working.columns):
+        counts = (
+            working.groupby(["target_tier", "predicted_tier"], dropna=False)
+            .size()
+            .rename("row_count")
+            .reset_index()
+        )
+        totals = working.groupby("target_tier", dropna=False).size().rename("total")
+        counts = counts.merge(totals, on="target_tier", how="left")
+        for _, row in counts.iterrows():
+            total = int(row["total"])
+            count = int(row["row_count"])
+            _append_detail(
+                detail_rows,
+                section="target_prediction_matrix",
+                metric="predicted_tier_fraction_within_target",
+                group=str(row["target_tier"]),
+                subgroup=str(row["predicted_tier"]),
+                value=count / total if total else float("nan"),
+                row_count=count,
+                detail="fraction normalized within target tier",
+            )
+
+
+def _correlation(rows: pd.DataFrame, left: str, right: str) -> object:
+    if rows.empty or not {left, right}.issubset(rows.columns):
+        return pd.NA
+    valid = rows[[left, right]].dropna()
+    if len(valid) < 2:
+        return pd.NA
+    value = valid[left].corr(valid[right])
+    return float(value) if math.isfinite(value) else pd.NA
+
+
+def _append_summary_rows(
+    *,
+    summary_rows: list[dict[str, object]],
+    working: pd.DataFrame,
+    date_regime_source: str,
+) -> None:
+    _append_summary(
+        summary_rows,
+        section="artifact_context",
+        metric="allocation_probability_present",
+        value=True,
+        detail=f"rows={len(working)}",
+    )
+    _append_summary(
+        summary_rows,
+        section="artifact_context",
+        metric="runtime_regime_source",
+        value=date_regime_source,
+        detail="config is preferred when supplied",
+    )
+
+    for column in (
+        "score",
+        "target_weight",
+        "predicted_tier_weight",
+        "forward_return",
+        "forward_drawdown",
+        "realized_utility",
+        "allocation_score_transform",
+        "score_transform_applied",
+    ):
+        _append_summary(
+            summary_rows,
+            section="score_target_context",
+            metric=f"{column}_present",
+            value=column in working.columns,
+            detail="allocation_probability_diagnostics.csv column availability",
+        )
+
+    for tier in ALLOCATION_TIERS:
+        _append_summary(
+            summary_rows,
+            section="target_support",
+            metric=f"target_tier_{_tier_label(tier)}_fraction",
+            value=_fraction(working, "target_weight", tier),
+            detail="selected OOS prediction rows",
+        )
+        _append_summary(
+            summary_rows,
+            section="target_support",
+            metric=f"predicted_tier_{_tier_label(tier)}_fraction",
+            value=_fraction(working, "predicted_tier_weight", tier),
+            detail="selected OOS prediction rows",
+        )
+
+    bull_continuation = working.loc[working["bull_continuation"]].copy()
+    positive_return = working.loc[working["forward_return_sign"].eq("positive")].copy()
+    drawdown_defense = working.loc[working["drawdown_defense"]].copy()
+    for name, frame in {
+        "bull_continuation": bull_continuation,
+        "positive_return": positive_return,
+        "drawdown_defense": drawdown_defense,
+    }.items():
+        _append_summary(
+            summary_rows,
+            section="target_methodology",
+            metric=f"{name}_rows",
+            value=int(len(frame)),
+            detail="selected OOS prediction rows",
+        )
+
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="bull_continuation_full_target_fraction",
+        value=_fraction(bull_continuation, "target_weight", 1.0),
+        detail="runtime_regime=bull and forward_return > 0",
+    )
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="bull_continuation_full_prediction_fraction",
+        value=_fraction(bull_continuation, "predicted_tier_weight", 1.0),
+        detail="runtime_regime=bull and forward_return > 0",
+    )
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="positive_return_rows_assigned_below_100_fraction",
+        value=_fraction(positive_return, "target_weight", 1.0, below=True),
+        detail="target_weight < 1.0 among rows with forward_return > 0",
+    )
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="positive_return_rows_predicted_below_100_fraction",
+        value=_fraction(positive_return, "predicted_tier_weight", 1.0, below=True),
+        detail="predicted_tier_weight < 1.0 among rows with forward_return > 0",
+    )
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="drawdown_defense_rows_assigned_below_100_fraction",
+        value=_fraction(drawdown_defense, "target_weight", 1.0, below=True),
+        detail=(
+            "target_weight < 1.0 among rows with forward_return <= 0 "
+            f"or forward_drawdown <= {DEFENSE_DRAWDOWN_THRESHOLD:g}"
+        ),
+    )
+    _append_summary(
+        summary_rows,
+        section="target_methodology",
+        metric="drawdown_defense_rows_predicted_below_100_fraction",
+        value=_fraction(drawdown_defense, "predicted_tier_weight", 1.0, below=True),
+        detail=(
+            "predicted_tier_weight < 1.0 among rows with forward_return <= 0 "
+            f"or forward_drawdown <= {DEFENSE_DRAWDOWN_THRESHOLD:g}"
+        ),
+    )
+
+    if "gate_bull" in working.columns:
+        gate_bull = working.loc[working["gate_bull"].map(_truthy)].copy()
+        _append_summary(
+            summary_rows,
+            section="target_methodology",
+            metric="gate_bull_rows",
+            value=int(len(gate_bull)),
+            detail="strict-gate bull rows joined from config or artifacts",
+        )
+        _append_summary(
+            summary_rows,
+            section="target_methodology",
+            metric="gate_bull_full_target_fraction",
+            value=_fraction(gate_bull, "target_weight", 1.0),
+            detail="target_weight == 1.0 among strict-gate bull rows",
+        )
+        _append_summary(
+            summary_rows,
+            section="target_methodology",
+            metric="gate_bull_full_prediction_fraction",
+            value=_fraction(gate_bull, "predicted_tier_weight", 1.0),
+            detail="predicted_tier_weight == 1.0 among strict-gate bull rows",
+        )
+
+    for right in ("target_weight", "forward_return", "realized_utility"):
+        _append_summary(
+            summary_rows,
+            section="score_target_context",
+            metric=f"score_{right}_correlation",
+            value=_correlation(working, "score", right),
+            detail="selected OOS prediction rows",
+        )
+
+
+def build_phase8_target_diagnostic(
+    run_dir: str | Path,
+    *,
+    config_path: str | Path | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    resolved_run_dir = Path(run_dir)
+    probability = _read_csv(resolved_run_dir, "allocation_probability_diagnostics.csv")
+    detail_rows: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+
+    if probability.empty:
+        _append_summary(
+            summary_rows,
+            section="artifact_context",
+            metric="allocation_probability_present",
+            value=False,
+            detail="allocation_probability_diagnostics.csv was not found",
+        )
+        return (
+            pd.DataFrame(detail_rows, columns=PHASE8_TARGET_DIAGNOSTIC_COLUMNS),
+            pd.DataFrame(summary_rows, columns=PHASE8_TARGET_DIAGNOSTIC_SUMMARY_COLUMNS),
+        )
+
+    working, date_regime_source = _prepare_probability(
+        probability,
+        config_path=config_path,
+    )
+    _grouped_detail_rows(detail_rows=detail_rows, working=working)
+    _append_summary_rows(
+        summary_rows=summary_rows,
+        working=working,
+        date_regime_source=date_regime_source,
+    )
+    return (
+        pd.DataFrame(detail_rows, columns=PHASE8_TARGET_DIAGNOSTIC_COLUMNS),
+        pd.DataFrame(summary_rows, columns=PHASE8_TARGET_DIAGNOSTIC_SUMMARY_COLUMNS),
+    )
+
+
+def write_phase8_target_diagnostic(
+    run_dir: str | Path,
+    *,
+    config_path: str | Path | None = None,
+    output_dir: str | Path | None = None,
+) -> tuple[Path, Path]:
+    resolved_run_dir = Path(run_dir)
+    resolved_output_dir = Path(output_dir) if output_dir is not None else resolved_run_dir
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    detail, summary = build_phase8_target_diagnostic(
+        resolved_run_dir,
+        config_path=config_path,
+    )
+    detail_path = resolved_output_dir / "phase8_target_diagnostic.csv"
+    summary_path = resolved_output_dir / "phase8_target_diagnostic_summary.csv"
+    detail.to_csv(detail_path, index=False)
+    summary.to_csv(summary_path, index=False)
+    return detail_path, summary_path

--- a/src/marketlab/reports/phase8_target_profile_sweep.py
+++ b/src/marketlab/reports/phase8_target_profile_sweep.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pandas as pd
+
+from marketlab.config import ExperimentConfig
+from marketlab.targets import apply_allocation_utility_profile
+
+DEFAULT_OUTPUT_PATH = Path("artifacts/runs/phase8_btc_target_profile_sweep.csv")
+ALLOCATION_TIERS = (0.0, 0.25, 0.50, 1.0)
+PHASE8_TARGET_PROFILE_SWEEP_COLUMNS = [
+    "profile_name",
+    "drawdown_penalty",
+    "volatility_penalty",
+    "risk_penalty_power",
+    "target_tier_0_fraction",
+    "target_tier_25_fraction",
+    "target_tier_50_fraction",
+    "target_tier_100_fraction",
+    "passes_partial_target_support",
+    "selected",
+]
+
+
+def _profile_name(
+    *,
+    drawdown_penalty: float,
+    volatility_penalty: float,
+    risk_penalty_power: float,
+) -> str:
+    return (
+        f"dd{drawdown_penalty:g}_vol{volatility_penalty:g}_"
+        f"power{risk_penalty_power:g}"
+    )
+
+
+def build_phase8_target_profile_sweep(
+    rows: pd.DataFrame,
+    *,
+    target_type: str = "allocation_utility",
+    cost_bps: float = 0.0,
+    drawdown_penalties: Sequence[float] = (0.50, 0.75, 1.00),
+    volatility_penalties: Sequence[float] = (0.25,),
+    risk_penalty_powers: Sequence[float] = (2.0, 2.5),
+    min_partial_target_fraction: float = 0.05,
+) -> pd.DataFrame:
+    if target_type != "allocation_utility":
+        raise ValueError("Phase 8 target-profile sweep requires allocation_utility targets.")
+
+    sweep_rows: list[dict[str, object]] = []
+    for drawdown_penalty in drawdown_penalties:
+        for volatility_penalty in volatility_penalties:
+            for risk_penalty_power in risk_penalty_powers:
+                profiled = apply_allocation_utility_profile(
+                    rows,
+                    target_type=target_type,
+                    cost_bps=cost_bps,
+                    drawdown_penalty=float(drawdown_penalty),
+                    volatility_penalty=float(volatility_penalty),
+                    risk_penalty_power=float(risk_penalty_power),
+                )
+                fractions = {
+                    tier: float(
+                        profiled["target_weight"].sub(tier).abs().le(1e-9).mean()
+                    )
+                    for tier in ALLOCATION_TIERS
+                }
+                passes_support = (
+                    fractions[0.0] > 0.0
+                    and fractions[0.25] >= float(min_partial_target_fraction)
+                    and fractions[0.50] >= float(min_partial_target_fraction)
+                    and fractions[1.0] > 0.0
+                )
+                sweep_rows.append(
+                    {
+                        "profile_name": _profile_name(
+                            drawdown_penalty=float(drawdown_penalty),
+                            volatility_penalty=float(volatility_penalty),
+                            risk_penalty_power=float(risk_penalty_power),
+                        ),
+                        "drawdown_penalty": float(drawdown_penalty),
+                        "volatility_penalty": float(volatility_penalty),
+                        "risk_penalty_power": float(risk_penalty_power),
+                        "target_tier_0_fraction": fractions[0.0],
+                        "target_tier_25_fraction": fractions[0.25],
+                        "target_tier_50_fraction": fractions[0.50],
+                        "target_tier_100_fraction": fractions[1.0],
+                        "passes_partial_target_support": passes_support,
+                        "selected": False,
+                    }
+                )
+
+    sweep = pd.DataFrame(sweep_rows, columns=PHASE8_TARGET_PROFILE_SWEEP_COLUMNS)
+    passing = sweep.index[sweep["passes_partial_target_support"].astype(bool)]
+    if len(passing) > 0:
+        sweep.loc[passing[0], "selected"] = True
+    return sweep
+
+
+def write_phase8_target_profile_sweep(
+    rows: pd.DataFrame,
+    *,
+    config: ExperimentConfig,
+    output_path: str | Path = DEFAULT_OUTPUT_PATH,
+) -> Path:
+    resolved_output_path = Path(output_path)
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+    build_phase8_target_profile_sweep(
+        rows,
+        target_type=config.target.type,
+        cost_bps=config.portfolio.costs.bps_per_trade,
+        min_partial_target_fraction=(
+            config.evaluation.strict_research_gate.min_partial_target_fraction
+        ),
+    ).to_csv(resolved_output_path, index=False)
+    return resolved_output_path

--- a/src/marketlab/strategies/tiered_allocation.py
+++ b/src/marketlab/strategies/tiered_allocation.py
@@ -160,24 +160,25 @@ def _apply_regime_policy(
     row: pd.Series,
     policy: RegimeParticipationPolicy | None,
 ) -> float:
-    if policy is None:
-        return target_weight
-
-    regime = _regime_label(row)
-    if regime == "risk_off":
-        if policy.risk_off_cap is None:
-            adjusted_weight = target_weight
+    adjusted_weight = target_weight
+    if policy is not None:
+        regime = _regime_label(row)
+        if regime == "risk_off":
+            if policy.risk_off_cap is None:
+                adjusted_weight = target_weight
+            else:
+                adjusted_weight = min(target_weight, float(policy.risk_off_cap))
+        elif regime == "bull":
+            adjusted_weight = max(target_weight, float(policy.bull_floor))
+        elif regime == "bear":
+            adjusted_weight = max(target_weight, float(policy.bear_floor))
         else:
-            adjusted_weight = min(target_weight, float(policy.risk_off_cap))
-    elif regime == "bull":
-        adjusted_weight = max(target_weight, float(policy.bull_floor))
-    elif regime == "bear":
-        adjusted_weight = max(target_weight, float(policy.bear_floor))
-    else:
-        adjusted_weight = max(target_weight, float(policy.sideways_floor))
+            adjusted_weight = max(target_weight, float(policy.sideways_floor))
 
-    if policy.gate_bull_floor is not None and _truthy(row.get("gate_bull", False)):
-        adjusted_weight = max(adjusted_weight, float(policy.gate_bull_floor))
+        if policy.gate_bull_floor is not None and _truthy(row.get("gate_bull", False)):
+            adjusted_weight = max(adjusted_weight, float(policy.gate_bull_floor))
+    if _truthy(row.get("guarded_gate_bull_risk_off_override_triggered", False)):
+        adjusted_weight = max(adjusted_weight, 1.0)
     return adjusted_weight
 
 

--- a/src/marketlab/strategies/tiered_allocation.py
+++ b/src/marketlab/strategies/tiered_allocation.py
@@ -27,6 +27,7 @@ class RegimeParticipationPolicy:
     sideways_floor: float = 0.0
     bear_floor: float = 0.0
     risk_off_cap: float | None = 0.25
+    gate_bull_floor: float | None = None
 
 
 def _validate_thresholds(thresholds: tuple[float, float, float]) -> tuple[float, float, float]:
@@ -146,6 +147,14 @@ def _regime_label(row: pd.Series) -> str:
     return "sideways"
 
 
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
 def _apply_regime_policy(
     target_weight: float,
     row: pd.Series,
@@ -157,13 +166,19 @@ def _apply_regime_policy(
     regime = _regime_label(row)
     if regime == "risk_off":
         if policy.risk_off_cap is None:
-            return target_weight
-        return min(target_weight, float(policy.risk_off_cap))
-    if regime == "bull":
-        return max(target_weight, float(policy.bull_floor))
-    if regime == "bear":
-        return max(target_weight, float(policy.bear_floor))
-    return max(target_weight, float(policy.sideways_floor))
+            adjusted_weight = target_weight
+        else:
+            adjusted_weight = min(target_weight, float(policy.risk_off_cap))
+    elif regime == "bull":
+        adjusted_weight = max(target_weight, float(policy.bull_floor))
+    elif regime == "bear":
+        adjusted_weight = max(target_weight, float(policy.bear_floor))
+    else:
+        adjusted_weight = max(target_weight, float(policy.sideways_floor))
+
+    if policy.gate_bull_floor is not None and _truthy(row.get("gate_bull", False)):
+        adjusted_weight = max(adjusted_weight, float(policy.gate_bull_floor))
+    return adjusted_weight
 
 
 def _validate_predictions(predictions: pd.DataFrame) -> pd.DataFrame:

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -1193,6 +1193,8 @@ def test_run_experiment_writes_allocation_utility_outputs(
                 "allocation_partial_class_weight_multiplier": 2.0,
                 "allocation_probability_calibration": "sigmoid",
                 "allocation_calibration_cv": 3,
+                "selection_validation_cost_bps": [10, 25],
+                "guarded_gate_bull_risk_off_override": True,
             },
             "strict_research_gate": {
                 "enabled": True,
@@ -1240,6 +1242,9 @@ def test_run_experiment_writes_allocation_utility_outputs(
     )
     assert {
         "selection_benchmark_strategies",
+        "selection_validation_cost_bps",
+        "selection_validation_cost_benchmark_excess_cumulative_returns",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
         "min_benchmark_excess_cumulative_return",
         "utility_profile",
         "allocation_class_weighting",
@@ -1265,6 +1270,10 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
         "validation_score_policy_triggered_100_fraction",
+        "validation_guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
+        "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
         "validation_score_transform_applied_fraction",
     }.issubset(tuning_candidates.columns)
     assert {
@@ -1286,6 +1295,13 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "validation_score_policy_repair_authorized",
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
+        "selection_validation_cost_bps",
+        "selection_validation_cost_benchmark_excess_cumulative_returns",
+        "min_selection_validation_cost_benchmark_excess_cumulative_return",
+        "validation_guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
+        "validation_guarded_gate_bull_risk_off_override_triggered_fraction",
     }.issubset(tuning_selections.columns)
     assert "selected_fold_fraction" in set(phase8_summary["metric"])
     assert {
@@ -1317,6 +1333,9 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "score_policy_repair_authorized",
         "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "guarded_gate_bull_risk_off_override_authorized",
+        "guarded_gate_bull_risk_off_override_denied_reason",
+        "guarded_gate_bull_risk_off_override_triggered",
         "score_transform_applied",
         "prob_tier_0",
         "prob_tier_25",
@@ -1327,6 +1346,8 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "fold_predicted_100_fraction",
         "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_guarded_gate_bull_risk_off_override_authorized_fraction",
+        "fold_guarded_gate_bull_risk_off_override_triggered_fraction",
         "fold_score_transform_applied_fraction",
     }.issubset(probability_diagnostics.columns)
     assert {"feature", "importance_type", "importance"}.issubset(feature_importance.columns)
@@ -1338,6 +1359,8 @@ def test_run_experiment_writes_allocation_utility_outputs(
     assert "Allocation score policy" in report_text
     assert "Allocation score transforms" in report_text
     assert "Repaired scores never authorize their own promotion" in report_text
+    assert "Configured selection validation costs are evaluated" in report_text
+    assert "Guarded gate-bull risk-off override is `True`" in report_text
     assert "Allocation target diagnostics" in report_text
     assert "selection_policy" in report_text
 

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -1227,6 +1227,7 @@ def test_run_experiment_writes_allocation_utility_outputs(
     tuning_candidates = pd.read_csv(run_dir / "ml_strategy_tuning_candidates.csv")
     tuning_selections = pd.read_csv(run_dir / "ml_strategy_tuning_selections.csv")
     phase8_summary = pd.read_csv(run_dir / "phase8_run_summary.csv")
+    phase8_methodology = pd.read_csv(run_dir / "phase8_methodology_review.csv")
     strict_gate = pd.read_csv(run_dir / "strict_research_gate.csv")
     report_text = (run_dir / "report.md").read_text(encoding="utf-8")
 
@@ -1269,6 +1270,11 @@ def test_run_experiment_writes_allocation_utility_outputs(
     }.issubset(tuning_selections.columns)
     assert "selected_fold_fraction" in set(phase8_summary["metric"])
     assert {
+        "deployment_gate",
+        "risk_allocation_gate",
+        "target_support_gate",
+    }.issubset(set(phase8_methodology["methodology_gate"]))
+    assert {
         "partial_target_25_global_fraction",
         "partial_target_50_fold_fraction",
         "predicted_target_25_global_fraction",
@@ -1297,6 +1303,7 @@ def test_run_experiment_writes_allocation_utility_outputs(
     assert {"feature", "importance_type", "importance"}.issubset(feature_importance.columns)
     assert "## Allocation Utility Diagnostics" in report_text
     assert "## Phase 8 Run Summary" in report_text
+    assert "## Phase 8 Methodology Review" in report_text
     assert "Target-support gate requires" in report_text
     assert "Predicted-support gate requires" in report_text
     assert "Allocation score policy" in report_text

--- a/tests/integration/test_run_experiment.py
+++ b/tests/integration/test_run_experiment.py
@@ -1245,6 +1245,11 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "allocation_class_weighting",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "allocation_score_transform",
+        "score_transform_bull_multiplier",
+        "score_transform_bull_addend",
+        "score_transform_risk_off_score_cap",
+        "score_transform_non_bull_score_cap",
         "calibration_status",
         "regime_policy",
         "regime_bull_floor",
@@ -1255,18 +1260,32 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "validation_predicted_25_fraction",
         "validation_predicted_50_fraction",
         "validation_predicted_100_fraction",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_policy_repair_authorized",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
         "validation_score_policy_triggered_100_fraction",
+        "validation_score_transform_applied_fraction",
     }.issubset(tuning_candidates.columns)
     assert {
         "selection_policy",
         "selection_source",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "selected_allocation_score_transform",
+        "selected_score_transform_bull_multiplier",
+        "selected_score_transform_bull_addend",
+        "selected_score_transform_risk_off_score_cap",
+        "selected_score_transform_non_bull_score_cap",
         "selected_regime_policy",
         "selected_regime_bull_floor",
         "selected_regime_sideways_floor",
         "selected_regime_bear_floor",
         "selected_regime_risk_off_cap",
+        "validation_raw_score_forward_return_correlation",
+        "validation_score_policy_repair_authorized",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
     }.issubset(tuning_selections.columns)
     assert "selected_fold_fraction" in set(phase8_summary["metric"])
     assert {
@@ -1288,9 +1307,17 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "predicted_tier_weight",
         "allocation_score_policy",
         "allocation_score_policy_prob100_threshold",
+        "allocation_score_transform",
+        "score_transform_bull_multiplier",
+        "score_transform_bull_addend",
+        "score_transform_risk_off_score_cap",
+        "score_transform_non_bull_score_cap",
         "raw_expected_allocation_score",
         "final_allocation_score",
+        "score_policy_repair_authorized",
+        "score_policy_repair_denied_reason",
         "score_policy_triggered_100",
+        "score_transform_applied",
         "prob_tier_0",
         "prob_tier_25",
         "prob_tier_50",
@@ -1298,7 +1325,9 @@ def test_run_experiment_writes_allocation_utility_outputs(
         "fold_predicted_25_fraction",
         "fold_predicted_50_fraction",
         "fold_predicted_100_fraction",
+        "fold_score_policy_repair_authorized_fraction",
         "fold_score_policy_triggered_100_fraction",
+        "fold_score_transform_applied_fraction",
     }.issubset(probability_diagnostics.columns)
     assert {"feature", "importance_type", "importance"}.issubset(feature_importance.columns)
     assert "## Allocation Utility Diagnostics" in report_text
@@ -1307,6 +1336,8 @@ def test_run_experiment_writes_allocation_utility_outputs(
     assert "Target-support gate requires" in report_text
     assert "Predicted-support gate requires" in report_text
     assert "Allocation score policy" in report_text
+    assert "Allocation score transforms" in report_text
+    assert "Repaired scores never authorize their own promotion" in report_text
     assert "Allocation target diagnostics" in report_text
     assert "selection_policy" in report_text
 
@@ -1604,7 +1635,7 @@ def test_run_experiment_supports_no_candidate_regime_fallback_selection(
     strict_gate = pd.read_csv(run_dir / "strict_research_gate.csv")
 
     fallback_rows = selections.loc[
-        selections["selection_source"].eq("deterministic_regime_fallback")
+        selections["selection_source"].eq("regime_policy_fallback")
     ]
     assert not fallback_rows.empty
     assert fallback_rows["selection_status"].eq("selected").all()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1117,6 +1117,73 @@ def test_load_config_accepts_gate_bull_score_validity_repair_configs(
 
 
 @pytest.mark.parametrize(
+    ("path", "experiment_name", "guarded_override", "target_penalties"),
+    [
+        (
+            "configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml",
+            "btc_phase8_guarded_cost_robust_selector",
+            False,
+            (0.50, 0.25, 2.0),
+        ),
+        (
+            "configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml",
+            "btc_phase8_guarded_gate_bull_risk_off_override",
+            True,
+            (0.50, 0.25, 2.0),
+        ),
+        (
+            "configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml",
+            "btc_phase8_guarded_gate_bull_risk_off_override_partial_support",
+            True,
+            (0.75, 0.25, 2.0),
+        ),
+    ],
+)
+def test_load_config_accepts_guarded_gate_bull_cost_robustness_configs(
+    path: str,
+    experiment_name: str,
+    guarded_override: bool,
+    target_penalties: tuple[float, float, float],
+) -> None:
+    config = load_config(path)
+    tuning = config.evaluation.ml_strategy_tuning
+
+    assert config.experiment_name == experiment_name
+    assert config.paper.enabled is False
+    assert tuning.allocation_score_policy == "gate_bull_prob100_threshold"
+    assert tuning.selection_validation_cost_bps == [35.0, 50.0]
+    assert tuning.guarded_gate_bull_risk_off_override is guarded_override
+    assert (
+        config.target.allocation_utility_drawdown_penalty,
+        config.target.allocation_utility_volatility_penalty,
+        config.target.allocation_utility_risk_penalty_power,
+    ) == pytest.approx(target_penalties)
+    assert all(
+        policy.gate_bull_floor is None
+        for policy in tuning.regime_participation_policies
+    )
+
+
+def test_guarded_gate_bull_configs_leave_strict_gate_unchanged() -> None:
+    control_path = (
+        "configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml"
+    )
+    challenger_paths = [
+        "configs/experiment.btc_phase8_guarded_cost_robust_selector.yaml",
+        "configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override.yaml",
+        "configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml",
+    ]
+    control = yaml.safe_load(Path(control_path).read_text(encoding="utf-8"))
+
+    for challenger_path in challenger_paths:
+        challenger = yaml.safe_load(Path(challenger_path).read_text(encoding="utf-8"))
+        assert (
+            challenger["evaluation"]["strict_research_gate"]
+            == control["evaluation"]["strict_research_gate"]
+        )
+
+
+@pytest.mark.parametrize(
     ("path", "experiment_name", "fallback_policy"),
     [
         (
@@ -1268,6 +1335,15 @@ def test_load_config_accepts_isolated_btc_paper_daily_config() -> None:
         ({"hysteresis_margin_grid": [-0.01]}, "hysteresis_margin_grid"),
         ({"hysteresis_margin_grid": [0.50]}, "hysteresis_margin_grid"),
         ({"max_annualized_turnover": 0.0}, "max_annualized_turnover"),
+        ({"selection_validation_cost_bps": [-1.0]}, "selection_validation_cost_bps"),
+        (
+            {"selection_validation_cost_bps": [35.0, 35.0]},
+            "selection_validation_cost_bps",
+        ),
+        (
+            {"guarded_gate_bull_risk_off_override": "true"},
+            "guarded_gate_bull_risk_off_override",
+        ),
         ({"objective": "auc"}, "ml_strategy_tuning.objective"),
         ({"selection_policy": "loose"}, "ml_strategy_tuning.selection_policy"),
         ({"allocation_score_policy": "magic_score"}, "allocation_score_policy"),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -491,6 +491,12 @@ def test_load_config_accepts_btc_regime_state_long_history_config() -> None:
             "allocation_utility",
             "best_active_fallback",
         ),
+        (
+            "configs/experiment.btc_phase8_methodology_review.yaml",
+            "btc_phase8_methodology_review",
+            "allocation_utility",
+            "strict",
+        ),
     ],
 )
 def test_load_config_accepts_btc_long_history_challenger_configs(
@@ -529,17 +535,28 @@ def test_load_config_accepts_btc_long_history_challenger_configs(
     if "full_tier_score" in path:
         assert config.evaluation.ml_strategy_tuning.min_holding_period_bars_grid == [0]
         assert config.evaluation.ml_strategy_tuning.hysteresis_margin_grid == [0.0]
+    elif "methodology_review" in path:
+        assert config.evaluation.ml_strategy_tuning.min_holding_period_bars_grid == [
+            0,
+            18,
+        ]
+        assert config.evaluation.ml_strategy_tuning.hysteresis_margin_grid == [0.0, 0.02]
     else:
         assert config.evaluation.ml_strategy_tuning.min_holding_period_bars_grid == [
             18,
             36,
         ]
         assert config.evaluation.ml_strategy_tuning.hysteresis_margin_grid == [0.02, 0.04]
-    expected_policy_names = (
-        ["bull100_sideways25"]
-        if "full_tier_score" in path
-        else ["bull100_sideways25", "bull100_sideways50_bear25"]
-    )
+    if "full_tier_score" in path:
+        expected_policy_names = ["bull100_sideways25"]
+    elif "methodology_review" in path:
+        expected_policy_names = [
+            "model_only",
+            "bull50_sideways25",
+            "bull100_sideways25",
+        ]
+    else:
+        expected_policy_names = ["bull100_sideways25", "bull100_sideways50_bear25"]
     assert [
         policy.name
         for policy in config.evaluation.ml_strategy_tuning.regime_participation_policies
@@ -626,6 +643,82 @@ def test_load_config_accepts_btc_regime_fallback_challenger_configs(
     assert config.evaluation.strict_research_gate.required_benchmark_strategies == (
         strict_benchmarks
     )
+
+
+@pytest.mark.parametrize(
+    ("path", "experiment_name", "score_policy", "selection_benchmarks"),
+    [
+        (
+            "configs/experiment.btc_phase8_bull_capture_rebalanced_gate.yaml",
+            "btc_phase8_bull_capture_rebalanced_gate",
+            "expected_allocation",
+            ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"],
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_capture_prob100_grid.yaml",
+            "btc_phase8_bull_capture_prob100_grid",
+            "bull_prob100_threshold",
+            ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"],
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_capture_static_audit.yaml",
+            "btc_phase8_bull_capture_static_audit",
+            "expected_allocation",
+            [
+                "buy_hold",
+                "btc_static_25",
+                "btc_static_50",
+                "btc_static_75",
+                "btc_rebalanced_25",
+                "btc_rebalanced_50",
+                "btc_rebalanced_75",
+            ],
+        ),
+    ],
+)
+def test_load_config_accepts_phase8_btc_bull_capture_grid_configs(
+    path: str,
+    experiment_name: str,
+    score_policy: str,
+    selection_benchmarks: list[str],
+) -> None:
+    config = load_config(path)
+
+    strict_benchmarks = [
+        "buy_hold",
+        "btc_static_25",
+        "btc_static_50",
+        "btc_static_75",
+        "btc_rebalanced_25",
+        "btc_rebalanced_50",
+        "btc_rebalanced_75",
+    ]
+    assert config.experiment_name == experiment_name
+    assert config.data.symbols == ["BTC-USD"]
+    assert config.data.interval == "1d"
+    assert config.target.type == "allocation_utility"
+    assert config.paper.enabled is False
+    assert config.evaluation.ml_strategy_tuning.selection_policy == "best_active_fallback"
+    assert config.evaluation.ml_strategy_tuning.allocation_score_policy == score_policy
+    assert config.evaluation.ml_strategy_tuning.selection_benchmark_strategies == (
+        selection_benchmarks
+    )
+    assert config.evaluation.strict_research_gate.required_benchmark_strategies == (
+        strict_benchmarks
+    )
+    assert config.evaluation.ml_strategy_tuning.rolling_train_bars_grid == [730, 1095]
+    assert config.evaluation.ml_strategy_tuning.min_holding_period_bars_grid == [0, 18]
+    assert config.evaluation.ml_strategy_tuning.hysteresis_margin_grid == [0.0, 0.02]
+    assert [model.name for model in config.models] == [
+        "logistic_l1",
+        "random_forest",
+        "hist_gradient_boosting",
+    ]
+    if score_policy == "bull_prob100_threshold":
+        assert (
+            config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold
+            == pytest.approx(0.16)
+        )
 
 
 def test_load_config_accepts_isolated_btc_paper_daily_config() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -110,6 +110,7 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
     assert config.evaluation.ml_strategy_tuning.max_annualized_turnover is None
     assert config.evaluation.ml_strategy_tuning.selection_policy == "strict"
     assert config.evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy is None
+    assert config.evaluation.ml_strategy_tuning.no_valid_candidate_regime_fallback is None
     assert (
         config.evaluation.ml_strategy_tuning.allocation_score_policy
         == "expected_allocation"
@@ -118,6 +119,17 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
         config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold
         == pytest.approx(0.20)
     )
+    assert config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid == []
+    assert [
+        (
+            transform.name,
+            transform.bull_multiplier,
+            transform.bull_addend,
+            transform.risk_off_score_cap,
+            transform.non_bull_score_cap,
+        )
+        for transform in config.evaluation.ml_strategy_tuning.allocation_score_transforms
+    ] == [("identity", 1.0, 0.0, None, None)]
     assert [
         (
             policy.name,
@@ -125,9 +137,10 @@ def test_load_config_preserves_backward_compatible_allocation_defaults(tmp_path:
             policy.sideways_floor,
             policy.bear_floor,
             policy.risk_off_cap,
+            policy.gate_bull_floor,
         )
         for policy in config.evaluation.ml_strategy_tuning.regime_participation_policies
-    ] == [("model_only", 0.0, 0.0, 0.0, 0.25)]
+    ] == [("model_only", 0.0, 0.0, 0.0, 0.25, None)]
     assert config.baselines.pattern_exit_overlay.enabled is False
     assert config.baselines.pattern_meta_label.enabled is False
 
@@ -155,6 +168,7 @@ def test_load_config_accepts_crypto_time_series_features_and_ml_sweep(
             "crypto_bollinger_std": 2.0,
             "crypto_volume_window": 24,
             "crypto_time_features": True,
+            "crypto_regime_signal_features_enabled": True,
         },
         evaluation={
             "ml_strategy_threshold_sweep": {
@@ -183,6 +197,7 @@ def test_load_config_accepts_crypto_time_series_features_and_ml_sweep(
 
     assert config.features.indicator_stack_ml_features_enabled is True
     assert config.features.crypto_time_series_enabled is True
+    assert config.features.crypto_regime_signal_features_enabled is True
     assert config.features.crypto_return_windows == [1, 12, 24]
     assert config.features.crypto_ma_windows == [24]
     assert config.evaluation.ml_strategy_threshold_sweep.enabled is True
@@ -236,6 +251,158 @@ def test_load_config_accepts_no_candidate_fallback_regime_policy(
         config.evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy
         == "bull100_sideways25"
     )
+    assert (
+        config.evaluation.ml_strategy_tuning.no_valid_candidate_regime_fallback
+        == "bull100_sideways25"
+    )
+
+
+def test_load_config_accepts_regime_gate_bull_floor(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        evaluation={
+            "ml_strategy_tuning": {
+                "enabled": True,
+                "regime_participation_policies": [
+                    {
+                        "name": "gate_bull_override",
+                        "bull_floor": 0.75,
+                        "sideways_floor": 0.25,
+                        "bear_floor": 0.0,
+                        "risk_off_cap": 0.25,
+                        "gate_bull_floor": 1.0,
+                    }
+                ],
+            },
+        },
+    )
+
+    config = load_config(config_path)
+
+    policy = config.evaluation.ml_strategy_tuning.regime_participation_policies[0]
+    assert policy.gate_bull_floor == pytest.approx(1.0)
+
+
+def test_load_config_rejects_invalid_regime_gate_bull_floor(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        evaluation={
+            "ml_strategy_tuning": {
+                "enabled": True,
+                "regime_participation_policies": [
+                    {
+                        "name": "bad_gate_bull_floor",
+                        "gate_bull_floor": 0.33,
+                    }
+                ],
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="gate_bull_floor"):
+        load_config(config_path)
+
+
+def test_load_config_accepts_no_valid_candidate_regime_fallback_alias(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        evaluation={
+            "ml_strategy_tuning": {
+                "enabled": True,
+                "no_valid_candidate_regime_fallback": "bull100_sideways25",
+                "allocation_score_policy": "bull_prob100_threshold",
+                "allocation_score_policy_prob100_threshold_grid": [0.2, 0.36],
+                "regime_participation_policies": [
+                    {
+                        "name": "bull100_sideways25",
+                        "bull_floor": 1.0,
+                        "sideways_floor": 0.25,
+                        "bear_floor": 0.0,
+                        "risk_off_cap": 0.25,
+                    }
+                ],
+            },
+        },
+    )
+
+    config = load_config(config_path)
+
+    assert (
+        config.evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy
+        == "bull100_sideways25"
+    )
+    assert (
+        config.evaluation.ml_strategy_tuning.no_valid_candidate_regime_fallback
+        == "bull100_sideways25"
+    )
+    assert config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid == [
+        0.2,
+        0.36,
+    ]
+
+
+def test_load_config_accepts_allocation_score_transforms(tmp_path: Path) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        evaluation={
+            "ml_strategy_tuning": {
+                "enabled": True,
+                "allocation_score_transforms": [
+                    {"name": "identity"},
+                    {
+                        "name": "bull_shift_18",
+                        "bull_multiplier": 1.0,
+                        "bull_addend": 0.18,
+                        "risk_off_score_cap": 0.25,
+                        "non_bull_score_cap": 0.50,
+                    },
+                ],
+            },
+        },
+    )
+
+    config = load_config(config_path)
+
+    transforms = config.evaluation.ml_strategy_tuning.allocation_score_transforms
+    assert [(transform.name, transform.bull_addend) for transform in transforms] == [
+        ("identity", 0.0),
+        ("bull_shift_18", 0.18),
+    ]
+    assert transforms[1].bull_multiplier == pytest.approx(1.0)
+    assert transforms[1].risk_off_score_cap == pytest.approx(0.25)
+    assert transforms[1].non_bull_score_cap == pytest.approx(0.50)
+
+
+@pytest.mark.parametrize(
+    "allocation_score_transforms",
+    [
+        [{"name": ""}],
+        [{"name": "duplicate"}, {"name": "duplicate"}],
+        [{"name": "bad_multiplier", "bull_multiplier": float("nan")}],
+        [{"name": "bad_multiplier", "bull_multiplier": -0.01}],
+        [{"name": "bad_addend", "bull_addend": float("inf")}],
+        [{"name": "bad_cap", "risk_off_score_cap": 1.10}],
+        [{"name": "bad_cap", "non_bull_score_cap": -0.01}],
+    ],
+)
+def test_load_config_rejects_invalid_allocation_score_transforms(
+    tmp_path: Path,
+    allocation_score_transforms: list[dict[str, object]],
+) -> None:
+    config_path = _write_config(
+        tmp_path / "config.yaml",
+        evaluation={
+            "ml_strategy_tuning": {
+                "enabled": True,
+                "allocation_score_transforms": allocation_score_transforms,
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="allocation_score_transforms"):
+        load_config(config_path)
 
 
 def test_load_config_accepts_btc_regime_tiered_research_config() -> None:
@@ -569,10 +736,11 @@ def test_load_config_accepts_btc_long_history_challenger_configs(
             policy.sideways_floor,
             policy.bear_floor,
             policy.risk_off_cap,
+            policy.gate_bull_floor,
         ]
         if value is not None
     }
-    assert policy_tiers <= {0.0, 0.25, 0.50, 1.0}
+    assert policy_tiers <= {0.0, 0.25, 0.50, 0.75, 1.0}
     assert [
         profile.name
         for profile in config.evaluation.ml_strategy_tuning.allocation_utility_profiles
@@ -593,6 +761,359 @@ def test_load_config_accepts_btc_long_history_challenger_configs(
         0.25,
         0.50,
     ]
+
+
+@pytest.mark.parametrize(
+    ("path", "experiment_name", "target_type", "signal_features_enabled"),
+    [
+        (
+            "configs/experiment.btc_phase8_target_return_capture_utility.yaml",
+            "btc_phase8_target_return_capture_utility",
+            "allocation_utility",
+            False,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_signal_feature_utility.yaml",
+            "btc_phase8_bull_signal_feature_utility",
+            "allocation_utility",
+            True,
+        ),
+        (
+            "configs/experiment.btc_phase8_regime_state_bull_signal.yaml",
+            "btc_phase8_regime_state_bull_signal",
+            "regime_state",
+            True,
+        ),
+    ],
+)
+def test_load_config_accepts_btc_target_score_pivot_configs(
+    path: str,
+    experiment_name: str,
+    target_type: str,
+    signal_features_enabled: bool,
+) -> None:
+    config = load_config(path)
+
+    assert config.experiment_name == experiment_name
+    assert config.data.symbols == ["BTC-USD"]
+    assert config.data.interval == "1d"
+    assert config.data.cache_dir == "artifacts/data-btc-phase8-1d-long"
+    assert config.target.type == target_type
+    assert config.paper.enabled is False
+    assert [model.name for model in config.models] == [
+        "logistic_l1",
+        "random_forest",
+        "hist_gradient_boosting",
+    ]
+    assert config.features.crypto_regime_signal_features_enabled is signal_features_enabled
+    assert config.evaluation.ml_strategy_tuning.selection_policy == "best_active_fallback"
+    assert (
+        config.evaluation.ml_strategy_tuning.allocation_score_policy
+        == "expected_allocation"
+    )
+    assert [
+        policy.name
+        for policy in config.evaluation.ml_strategy_tuning.regime_participation_policies
+    ] == ["model_only"]
+    assert [
+        profile.name
+        for profile in config.evaluation.ml_strategy_tuning.allocation_utility_profiles
+    ] == ["return_capture_p15", "return_capture_p25", "baseline_p25"]
+    assert config.evaluation.strict_research_gate.required_benchmark_strategies == [
+        "buy_hold",
+        "btc_static_25",
+        "btc_static_50",
+        "btc_static_75",
+        "btc_rebalanced_25",
+        "btc_rebalanced_50",
+        "btc_rebalanced_75",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("path", "experiment_name", "target_type", "score_policy", "threshold_grid"),
+    [
+        (
+            "configs/experiment.btc_phase8_bull_floor_signal_return_capture_fallback.yaml",
+            "btc_phase8_bull_floor_signal_return_capture_fallback",
+            "allocation_utility",
+            "expected_allocation",
+            [],
+        ),
+        (
+            "configs/experiment.btc_phase8_prob100_signal_threshold_fallback.yaml",
+            "btc_phase8_prob100_signal_threshold_fallback",
+            "allocation_utility",
+            "bull_prob100_threshold",
+            [0.20, 0.28, 0.36],
+        ),
+        (
+            "configs/experiment.btc_phase8_regime_floor_state_fallback.yaml",
+            "btc_phase8_regime_floor_state_fallback",
+            "regime_state",
+            "expected_allocation",
+            [],
+        ),
+    ],
+)
+def test_load_config_accepts_btc_regime_policy_next_experiment_configs(
+    path: str,
+    experiment_name: str,
+    target_type: str,
+    score_policy: str,
+    threshold_grid: list[float],
+) -> None:
+    config = load_config(path)
+
+    strict_benchmarks = [
+        "buy_hold",
+        "btc_static_25",
+        "btc_static_50",
+        "btc_static_75",
+        "btc_rebalanced_25",
+        "btc_rebalanced_50",
+        "btc_rebalanced_75",
+    ]
+    assert config.experiment_name == experiment_name
+    assert config.data.symbols == ["BTC-USD"]
+    assert config.target.type == target_type
+    assert config.paper.enabled is False
+    assert config.features.crypto_regime_signal_features_enabled is True
+    assert config.evaluation.ml_strategy_tuning.selection_policy == "best_active_fallback"
+    assert config.evaluation.ml_strategy_tuning.allocation_score_policy == score_policy
+    assert (
+        config.evaluation.ml_strategy_tuning.allocation_score_policy_prob100_threshold_grid
+        == threshold_grid
+    )
+    assert (
+        config.evaluation.ml_strategy_tuning.no_valid_candidate_regime_fallback
+        == "bull100_sideways25"
+    )
+    assert (
+        config.evaluation.ml_strategy_tuning.no_candidate_fallback_regime_policy
+        == "bull100_sideways25"
+    )
+    assert config.evaluation.strict_research_gate.required_benchmark_strategies == (
+        strict_benchmarks
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "experiment_name", "calibration", "rolling_train_grid"),
+    [
+        (
+            "configs/experiment.btc_phase8_bull_floor_score_boost_fallback.yaml",
+            "btc_phase8_bull_floor_score_boost_fallback",
+            "sigmoid",
+            [730, 1095],
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_score_boost_uncalibrated.yaml",
+            "btc_phase8_bull_floor_score_boost_uncalibrated",
+            "none",
+            [730, 1095],
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_score_boost_long_train.yaml",
+            "btc_phase8_bull_floor_score_boost_long_train",
+            "sigmoid",
+            [1095, 1460],
+        ),
+    ],
+)
+def test_load_config_accepts_btc_score_transform_next_experiment_configs(
+    path: str,
+    experiment_name: str,
+    calibration: str,
+    rolling_train_grid: list[int],
+) -> None:
+    config = load_config(path)
+
+    assert config.experiment_name == experiment_name
+    assert config.data.symbols == ["BTC-USD"]
+    assert config.target.type == "allocation_utility"
+    assert config.paper.enabled is False
+    assert config.evaluation.ml_strategy_tuning.selection_policy == "best_active_fallback"
+    assert (
+        config.evaluation.ml_strategy_tuning.allocation_probability_calibration
+        == calibration
+    )
+    assert (
+        config.evaluation.ml_strategy_tuning.rolling_train_bars_grid
+        == rolling_train_grid
+    )
+    assert [
+        transform.name
+        for transform in config.evaluation.ml_strategy_tuning.allocation_score_transforms
+    ] == [
+        "identity",
+        "bull_shift_10",
+        "bull_shift_18",
+        "bull_mult115_shift10",
+        "bull_mult125_shift10",
+    ]
+    assert (
+        config.evaluation.ml_strategy_tuning.no_valid_candidate_regime_fallback
+        == "bull100_sideways25"
+    )
+    assert config.evaluation.strict_research_gate.enabled is True
+
+
+@pytest.mark.parametrize(
+    (
+        "path",
+        "experiment_name",
+        "objective",
+        "expected_gate_bull_floor",
+        "risk_off_caps",
+        "holding_grid",
+        "hysteresis_grid",
+        "turnover_cap",
+    ),
+    [
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_override.yaml",
+            "btc_phase8_bull_floor_gate_bull_override",
+            "net_return_and_risk_vs_required_benchmarks",
+            1.0,
+            {0.25},
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_riskoff0.yaml",
+            "btc_phase8_bull_floor_gate_bull_riskoff0",
+            "net_return_and_risk_vs_required_benchmarks",
+            1.0,
+            {0.0},
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_low_turnover.yaml",
+            "btc_phase8_bull_floor_gate_bull_low_turnover",
+            "net_return_and_risk_vs_required_benchmarks",
+            1.0,
+            {0.25},
+            [18, 36, 54],
+            [0.02, 0.04],
+            12.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_score_validity_selection.yaml",
+            "btc_phase8_bull_floor_score_validity_selection",
+            "net_return_risk_score_validity_vs_required_benchmarks",
+            None,
+            {0.25},
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_score_validity.yaml",
+            "btc_phase8_bull_floor_gate_bull_score_validity",
+            "net_return_risk_score_validity_vs_required_benchmarks",
+            1.0,
+            {0.25},
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+    ],
+)
+def test_load_config_accepts_btc_gate_bull_floor_and_score_validity_configs(
+    path: str,
+    experiment_name: str,
+    objective: str,
+    expected_gate_bull_floor: float | None,
+    risk_off_caps: set[float],
+    holding_grid: list[int],
+    hysteresis_grid: list[float],
+    turnover_cap: float,
+) -> None:
+    config = load_config(path)
+
+    assert config.experiment_name == experiment_name
+    assert config.data.symbols == ["BTC-USD"]
+    assert config.target.type == "allocation_utility"
+    assert config.paper.enabled is False
+    tuning = config.evaluation.ml_strategy_tuning
+    assert tuning.selection_policy == "best_active_fallback"
+    assert tuning.objective == objective
+    assert tuning.min_holding_period_bars_grid == holding_grid
+    assert tuning.hysteresis_margin_grid == hysteresis_grid
+    assert tuning.max_annualized_turnover == pytest.approx(turnover_cap)
+    assert {policy.risk_off_cap for policy in tuning.regime_participation_policies} == (
+        risk_off_caps
+    )
+    assert {
+        policy.gate_bull_floor
+        for policy in tuning.regime_participation_policies
+    } == {expected_gate_bull_floor}
+    if "riskoff0" in path:
+        assert {
+            policy.sideways_floor
+            for policy in tuning.regime_participation_policies
+        } == {0.0, 0.25, 0.50}
+    assert config.evaluation.strict_research_gate.enabled is True
+
+
+@pytest.mark.parametrize(
+    ("path", "experiment_name", "calibration", "holding_grid", "hysteresis_grid", "turnover_cap"),
+    [
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity.yaml",
+            "btc_phase8_bull_floor_gate_bull_prob100_score_validity",
+            "sigmoid",
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated.yaml",
+            "btc_phase8_bull_floor_gate_bull_prob100_score_validity_uncalibrated",
+            "none",
+            [0, 18],
+            [0.0, 0.02],
+            24.0,
+        ),
+        (
+            "configs/experiment.btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover.yaml",
+            "btc_phase8_bull_floor_gate_bull_prob100_score_validity_low_turnover",
+            "sigmoid",
+            [18, 36, 54],
+            [0.02, 0.04],
+            12.0,
+        ),
+    ],
+)
+def test_load_config_accepts_gate_bull_score_validity_repair_configs(
+    path: str,
+    experiment_name: str,
+    calibration: str,
+    holding_grid: list[int],
+    hysteresis_grid: list[float],
+    turnover_cap: float,
+) -> None:
+    config = load_config(path)
+    tuning = config.evaluation.ml_strategy_tuning
+
+    assert config.experiment_name == experiment_name
+    assert config.paper.enabled is False
+    assert tuning.allocation_score_policy == "gate_bull_prob100_threshold"
+    assert tuning.allocation_score_policy_prob100_threshold_grid == [0.20, 0.28, 0.36]
+    assert tuning.objective == "net_return_risk_score_validity_vs_required_benchmarks"
+    assert tuning.allocation_probability_calibration == calibration
+    assert tuning.min_holding_period_bars_grid == holding_grid
+    assert tuning.hysteresis_margin_grid == hysteresis_grid
+    assert tuning.max_annualized_turnover == pytest.approx(turnover_cap)
+    assert all(
+        policy.gate_bull_floor is None
+        for policy in tuning.regime_participation_policies
+    )
+    assert config.evaluation.strict_research_gate.enabled is True
 
 
 @pytest.mark.parametrize(
@@ -759,6 +1280,25 @@ def test_load_config_accepts_isolated_btc_paper_daily_config() -> None:
             "allocation_score_policy_prob100_threshold",
         ),
         (
+            {"allocation_score_policy_prob100_threshold_grid": [0.2, 1.2]},
+            "allocation_score_policy_prob100_threshold_grid",
+        ),
+        (
+            {"allocation_score_policy_prob100_threshold_grid": [-0.1]},
+            "allocation_score_policy_prob100_threshold_grid",
+        ),
+        (
+            {
+                "no_candidate_fallback_regime_policy": "model_only",
+                "no_valid_candidate_regime_fallback": "other_policy",
+                "regime_participation_policies": [
+                    {"name": "model_only"},
+                    {"name": "other_policy"},
+                ],
+            },
+            "no_candidate_fallback_regime_policy",
+        ),
+        (
             {"objective": "net_return_and_risk_vs_required_benchmarks"},
             "selection_benchmark_strategies",
         ),
@@ -839,7 +1379,7 @@ def test_load_config_accepts_isolated_btc_paper_daily_config() -> None:
         (
             {
                 "regime_participation_policies": [
-                    {"name": "bad_floor", "bull_floor": 0.75},
+                    {"name": "bad_floor", "bull_floor": 0.80},
                 ]
             },
             "bull_floor",
@@ -847,7 +1387,7 @@ def test_load_config_accepts_isolated_btc_paper_daily_config() -> None:
         (
             {
                 "regime_participation_policies": [
-                    {"name": "bad_cap", "risk_off_cap": 0.75},
+                    {"name": "bad_cap", "risk_off_cap": 0.80},
                 ]
             },
             "risk_off_cap",

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -107,6 +107,48 @@ def test_crypto_regime_features_are_trailing_only() -> None:
         assert baseline_features.iloc[:-1][column].equals(modified_features.iloc[:-1][column])
 
 
+def test_crypto_regime_signal_features_are_opt_in_and_trailing_only() -> None:
+    fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / "crypto_hourly_panel.csv"
+    baseline = load_panel_csv(fixture_path)
+    modified = baseline.copy()
+    modified.loc[modified.index[-1], "adj_close"] *= 3.0
+    modified.loc[modified.index[-1], "volume"] *= 5.0
+
+    kwargs = {
+        "return_windows": [1, 3],
+        "ma_windows": [3],
+        "vol_windows": [3],
+        "momentum_window": 3,
+        "crypto_regime_features_enabled": True,
+        "crypto_regime_trend_windows": [3, 6],
+        "crypto_regime_volatility_window": 3,
+        "crypto_regime_percentile_window": 6,
+        "crypto_regime_drawdown_window": 6,
+        "crypto_regime_volume_window": 3,
+    }
+    without_signals = add_feature_set(baseline, **kwargs)
+    baseline_features = add_feature_set(
+        baseline,
+        **kwargs,
+        crypto_regime_signal_features_enabled=True,
+    )
+    modified_features = add_feature_set(
+        modified,
+        **kwargs,
+        crypto_regime_signal_features_enabled=True,
+    )
+
+    signal_columns = [
+        "crypto_regime_bull_participation_signal",
+        "crypto_regime_drawdown_defense_signal",
+    ]
+    for column in signal_columns:
+        assert column not in without_signals.columns
+        assert column in baseline_features.columns
+        assert set(baseline_features[column].dropna().unique()) <= {0, 1}
+        assert baseline_features.iloc[:-1][column].equals(modified_features.iloc[:-1][column])
+
+
 def test_indicator_stack_ml_features_are_trailing_only() -> None:
     fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / "crypto_hourly_panel.csv"
     baseline = load_panel_csv(fixture_path)

--- a/tests/unit/test_phase8_btc_gate.py
+++ b/tests/unit/test_phase8_btc_gate.py
@@ -3,16 +3,111 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from marketlab.config import ExperimentConfig, RegimeParticipationPolicyConfig
+from marketlab.config import (
+    AllocationScoreTransformConfig,
+    ExperimentConfig,
+    RegimeParticipationPolicyConfig,
+)
 from marketlab.pipeline import (
+    _allocation_score_policy_prob100_threshold_candidates,
+    _allocation_score_transform_candidates,
     _apply_allocation_score_policy,
+    _apply_allocation_score_transform,
     _deterministic_regime_fallback_weights_for_rows,
     _latest_training_rows,
     _predicted_tier_support,
+    _prediction_frame_with_allocation_score_policy,
+    _score_policy_repair_authorization,
+    _score_validity_metrics,
     _select_ml_strategy_candidate,
     _select_ml_strategy_candidate_for_policy,
     _strict_research_gate,
 )
+
+
+def test_prob100_threshold_candidates_use_grid_only_for_prob100_policy() -> None:
+    config = ExperimentConfig()
+    tuning = config.evaluation.ml_strategy_tuning
+    tuning.allocation_score_policy = "bull_prob100_threshold"
+    tuning.allocation_score_policy_prob100_threshold = 0.20
+    tuning.allocation_score_policy_prob100_threshold_grid = [0.36, 0.20, 0.36]
+
+    assert _allocation_score_policy_prob100_threshold_candidates(config) == [0.20, 0.36]
+
+    tuning.allocation_score_policy = "expected_allocation"
+    assert _allocation_score_policy_prob100_threshold_candidates(config) == [0.20]
+
+    tuning.allocation_score_policy = "gate_bull_prob100_threshold"
+    assert _allocation_score_policy_prob100_threshold_candidates(config) == [0.20, 0.36]
+
+
+def test_score_transform_candidates_default_to_identity() -> None:
+    config = ExperimentConfig()
+
+    candidates = _allocation_score_transform_candidates(config)
+
+    assert [(candidate.name, candidate.bull_multiplier, candidate.bull_addend) for candidate in candidates] == [
+        ("identity", 1.0, 0.0)
+    ]
+
+
+def test_allocation_score_transform_boosts_only_runtime_bull_and_caps_non_bull() -> None:
+    rows = pd.DataFrame(
+        {
+            "crypto_regime_risk_off": [0, 1, 0, 0],
+            "crypto_regime_trend_state": [1, 1, 0, -1],
+        },
+        index=[10, 11, 12, 13],
+    )
+    scores = pd.Series([0.44, 0.44, 0.44, 0.44], index=rows.index)
+
+    transformed, applied = _apply_allocation_score_transform(
+        rows=rows,
+        score_series=scores,
+        score_transform=AllocationScoreTransformConfig(
+            name="bull_shift_18",
+            bull_multiplier=1.0,
+            bull_addend=0.18,
+            risk_off_score_cap=0.25,
+            non_bull_score_cap=0.50,
+        ),
+    )
+
+    assert transformed.tolist() == pytest.approx([0.62, 0.25, 0.44, 0.44])
+    assert applied.tolist() == [True, True, False, False]
+
+
+def test_prediction_frame_applies_selected_score_transform_before_tiering() -> None:
+    predictions = pd.DataFrame(
+        {
+            "score": [0.64, 0.44],
+            "raw_expected_allocation_score": [0.64, 0.44],
+            "crypto_regime_risk_off": [0, 0],
+            "crypto_regime_trend_state": [1, 0],
+            "prob_tier_0": [0.10, 0.10],
+            "prob_tier_100": [0.20, 0.20],
+        }
+    )
+
+    transformed = _prediction_frame_with_allocation_score_policy(
+        predictions=predictions,
+        allocation_score_policy="expected_allocation",
+        prob100_threshold=0.20,
+        score_transform=AllocationScoreTransformConfig(
+            name="bull_shift_18",
+            bull_multiplier=1.0,
+            bull_addend=0.18,
+            non_bull_score_cap=0.50,
+        ),
+    )
+
+    assert transformed["allocation_score_transform"].tolist() == [
+        "bull_shift_18",
+        "bull_shift_18",
+    ]
+    assert transformed["score"].tolist() == pytest.approx([0.82, 0.44])
+    assert transformed["predicted_tier_weight"].tolist() == pytest.approx([1.0, 0.50])
+    assert transformed["score_transform_applied"].tolist() == [True, False]
 
 
 def test_strict_research_gate_requires_cost_regime_and_exposure_checks() -> None:
@@ -147,6 +242,118 @@ def test_allocation_score_policy_keeps_expected_score_when_threshold_fails() -> 
     assert triggered.tolist() == [False, False]
 
 
+def test_gate_bull_score_policy_requires_completed_bar_gate_and_raw_authorization() -> None:
+    rows = pd.DataFrame(
+        {
+            "gate_bull": [True, False, True],
+            "crypto_regime_risk_off": [0, 0, 1],
+            "crypto_regime_trend_state": [0, 1, -1],
+        }
+    )
+    scores = pd.Series([0.42, 0.42, 0.42])
+    probabilities = pd.DataFrame(
+        {
+            "prob_tier_0": [0.10, 0.10, 0.10],
+            "prob_tier_100": [0.30, 0.30, 0.30],
+        }
+    )
+
+    denied_scores, denied_triggered = _apply_allocation_score_policy(
+        rows=rows,
+        score_series=scores,
+        probability_frame=probabilities,
+        allocation_score_policy="gate_bull_prob100_threshold",
+        prob100_threshold=0.20,
+        score_policy_repair_authorized=False,
+    )
+    final_scores, triggered = _apply_allocation_score_policy(
+        rows=rows,
+        score_series=scores,
+        probability_frame=probabilities,
+        allocation_score_policy="gate_bull_prob100_threshold",
+        prob100_threshold=0.20,
+        score_policy_repair_authorized=True,
+    )
+
+    assert denied_scores.tolist() == [0.42, 0.42, 0.42]
+    assert denied_triggered.tolist() == [False, False, False]
+    assert final_scores.tolist() == [1.0, 0.42, 1.0]
+    assert triggered.tolist() == [True, False, True]
+
+
+@pytest.mark.parametrize(
+    ("correlation", "authorized", "denied_reason"),
+    [
+        (0.20, True, ""),
+        (0.0, True, ""),
+        (-0.01, False, "negative_validation_raw_score_forward_return_correlation"),
+        (pd.NA, False, "non_finite_validation_raw_score_forward_return_correlation"),
+    ],
+)
+def test_gate_bull_score_policy_authorization_uses_finite_non_negative_raw_correlation(
+    correlation: object,
+    authorized: bool,
+    denied_reason: str,
+) -> None:
+    assert _score_policy_repair_authorization(
+        allocation_score_policy="gate_bull_prob100_threshold",
+        validation_raw_score_forward_return_correlation=correlation,
+    ) == (authorized, denied_reason)
+
+
+def test_post_repair_correlation_cannot_authorize_gate_bull_repair() -> None:
+    predictions = pd.DataFrame(
+        {
+            "score": [0.0, 1.0, 1.0],
+            "raw_expected_allocation_score": [0.9, 0.5, 0.1],
+            "forward_return": [0.0, 0.5, 1.0],
+            "target_weight": [0.0, 0.5, 1.0],
+        }
+    )
+
+    metrics = _score_validity_metrics(predictions)
+    authorized, denied_reason = _score_policy_repair_authorization(
+        allocation_score_policy="gate_bull_prob100_threshold",
+        validation_raw_score_forward_return_correlation=metrics[
+            "validation_raw_score_forward_return_correlation"
+        ],
+    )
+
+    assert metrics["validation_score_forward_return_correlation"] > 0.0
+    assert metrics["validation_raw_score_forward_return_correlation"] < 0.0
+    assert authorized is False
+    assert denied_reason == "negative_validation_raw_score_forward_return_correlation"
+
+
+def test_prediction_frame_records_denied_gate_bull_repair_without_promoting() -> None:
+    predictions = pd.DataFrame(
+        {
+            "score": [0.42],
+            "raw_expected_allocation_score": [0.42],
+            "gate_bull": [True],
+            "prob_tier_0": [0.10],
+            "prob_tier_100": [0.30],
+        }
+    )
+
+    transformed = _prediction_frame_with_allocation_score_policy(
+        predictions=predictions,
+        allocation_score_policy="gate_bull_prob100_threshold",
+        prob100_threshold=0.20,
+        score_policy_repair_authorized=False,
+        score_policy_repair_denied_reason=(
+            "negative_validation_raw_score_forward_return_correlation"
+        ),
+    )
+
+    assert transformed["score"].tolist() == [0.42]
+    assert transformed["score_policy_triggered_100"].tolist() == [False]
+    assert transformed["score_policy_repair_authorized"].tolist() == [False]
+    assert transformed["score_policy_repair_denied_reason"].tolist() == [
+        "negative_validation_raw_score_forward_return_correlation"
+    ]
+
+
 def test_deterministic_regime_fallback_weights_map_test_regime_labels() -> None:
     panel_dates = pd.date_range("2026-01-01", periods=6, freq="D")
     panel = pd.DataFrame(
@@ -182,6 +389,43 @@ def test_deterministic_regime_fallback_weights_map_test_regime_labels() -> None:
     assert weights["weight"].tolist() == [0.25, 1.0, 0.50, 0.25, 0.0]
     assert weights["symbol"].eq("BTC-USD").all()
     assert weights["strategy"].eq("ml_indicator_tuned__long_only__cash").all()
+
+
+def test_deterministic_regime_fallback_applies_gate_bull_floor_after_risk_off() -> None:
+    panel_dates = pd.date_range("2026-01-01", periods=4, freq="D")
+    panel = pd.DataFrame(
+        {
+            "symbol": ["BTC-USD"] * len(panel_dates),
+            "timestamp": panel_dates,
+        }
+    )
+    rows = pd.DataFrame(
+        {
+            "signal_date": panel_dates[:3],
+            "effective_date": panel_dates[1:],
+            "crypto_regime_risk_off": [1, 0, 0],
+            "crypto_regime_trend_state": [1, 0, -1],
+            "gate_bull": [True, True, False],
+        }
+    )
+    policy = RegimeParticipationPolicyConfig(
+        name="gate_bull_override",
+        bull_floor=0.75,
+        sideways_floor=0.25,
+        bear_floor=0.0,
+        risk_off_cap=0.25,
+        gate_bull_floor=1.0,
+    )
+
+    weights = _deterministic_regime_fallback_weights_for_rows(
+        panel=panel,
+        rows=rows,
+        frequency="bar",
+        strategy_name="ml_indicator_tuned__long_only__cash",
+        policy=policy,
+    )
+
+    assert weights["weight"].tolist() == [1.0, 1.0, 0.0]
 
 
 def test_deterministic_regime_fallback_weights_require_regime_columns() -> None:
@@ -632,7 +876,7 @@ def test_strict_research_gate_fails_when_selected_fold_fraction_is_low() -> None
     assert bool(gate.loc[gate["condition"] == "overall", "passed"].iloc[0]) is False
 
 
-def test_strict_gate_counts_deterministic_regime_fallback_rows_as_selected() -> None:
+def test_strict_gate_counts_regime_policy_fallback_rows_as_selected() -> None:
     config = ExperimentConfig()
     config.evaluation.strict_research_gate.enabled = True
     config.evaluation.strict_research_gate.min_selected_fold_fraction = 0.75
@@ -643,7 +887,7 @@ def test_strict_gate_counts_deterministic_regime_fallback_rows_as_selected() -> 
         {
             "fold_id": [1, 2, 3, 4],
             "selection_status": ["selected", "selected", "selected", "selected"],
-            "selection_source": ["deterministic_regime_fallback"] * 4,
+            "selection_source": ["regime_policy_fallback"] * 4,
             "passed_gate": [False, False, False, False],
             "selected_model_name": [pd.NA, pd.NA, pd.NA, pd.NA],
             "selected_regime_policy": ["bull100_sideways25"] * 4,
@@ -891,6 +1135,53 @@ def test_runtime_selection_policy_rejects_non_benchmark_fallback_failures() -> N
 
     assert selected is None
     assert source == "none"
+
+
+def test_score_validity_selection_rejects_negative_correlation_until_fallback() -> None:
+    selected, source = _select_ml_strategy_candidate_for_policy(
+        [
+            _runtime_selection_candidate(
+                model_name="negative_score_order",
+                passed_gate=False,
+                failure_reasons="negative_score_forward_return_correlation",
+                min_benchmark_excess=0.20,
+                excess_return=0.30,
+            ),
+            _runtime_selection_candidate(
+                model_name="benchmark_only",
+                passed_gate=False,
+                failure_reasons="non_positive_required_benchmark_excess",
+                min_benchmark_excess=-0.02,
+                excess_return=0.05,
+            ),
+        ],
+        selection_policy="best_active_fallback",
+        allow_score_validity_fallback=True,
+    )
+
+    assert selected is not None
+    assert selected["model_name"] == "benchmark_only"
+    assert source == "best_active_fallback"
+
+
+def test_score_validity_selection_falls_back_when_only_negative_score_order_exists() -> None:
+    selected, source = _select_ml_strategy_candidate_for_policy(
+        [
+            _runtime_selection_candidate(
+                model_name="negative_score_order",
+                passed_gate=False,
+                failure_reasons="negative_score_forward_return_correlation",
+                min_benchmark_excess=0.20,
+                excess_return=0.30,
+            ),
+        ],
+        selection_policy="best_active_fallback",
+        allow_score_validity_fallback=True,
+    )
+
+    assert selected is not None
+    assert selected["model_name"] == "negative_score_order"
+    assert source == "best_active_fallback"
 
 
 def test_runtime_selection_policy_strict_does_not_fallback() -> None:

--- a/tests/unit/test_phase8_btc_gate.py
+++ b/tests/unit/test_phase8_btc_gate.py
@@ -14,6 +14,7 @@ from marketlab.pipeline import (
     _apply_allocation_score_policy,
     _apply_allocation_score_transform,
     _deterministic_regime_fallback_weights_for_rows,
+    _guarded_gate_bull_risk_off_override_authorization,
     _latest_training_rows,
     _predicted_tier_support,
     _prediction_frame_with_allocation_score_policy,
@@ -21,6 +22,7 @@ from marketlab.pipeline import (
     _score_validity_metrics,
     _select_ml_strategy_candidate,
     _select_ml_strategy_candidate_for_policy,
+    _selection_validation_cost_bps,
     _strict_research_gate,
 )
 
@@ -352,6 +354,67 @@ def test_prediction_frame_records_denied_gate_bull_repair_without_promoting() ->
     assert transformed["score_policy_repair_denied_reason"].tolist() == [
         "negative_validation_raw_score_forward_return_correlation"
     ]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "correlation", "authorized", "denied_reason"),
+    [
+        (False, 0.20, False, ""),
+        (True, 0.20, True, ""),
+        (True, 0.0, True, ""),
+        (True, -0.01, False, "negative_validation_raw_score_forward_return_correlation"),
+        (True, pd.NA, False, "non_finite_validation_raw_score_forward_return_correlation"),
+    ],
+)
+def test_guarded_gate_bull_risk_off_override_requires_raw_score_validity(
+    enabled: bool,
+    correlation: object,
+    authorized: bool,
+    denied_reason: str,
+) -> None:
+    assert _guarded_gate_bull_risk_off_override_authorization(
+        enabled=enabled,
+        validation_raw_score_forward_return_correlation=correlation,
+    ) == (authorized, denied_reason)
+
+
+def test_prediction_frame_marks_only_authorized_gate_bull_risk_off_rows() -> None:
+    predictions = pd.DataFrame(
+        {
+            "score": [0.42, 0.42, 0.42],
+            "raw_expected_allocation_score": [0.42, 0.42, 0.42],
+            "gate_bull": [True, False, True],
+            "crypto_regime_risk_off": [1, 1, 0],
+            "crypto_regime_trend_state": [1, 1, 1],
+            "prob_tier_0": [0.10, 0.10, 0.10],
+            "prob_tier_100": [0.30, 0.30, 0.30],
+        }
+    )
+
+    transformed = _prediction_frame_with_allocation_score_policy(
+        predictions=predictions,
+        allocation_score_policy="gate_bull_prob100_threshold",
+        prob100_threshold=0.20,
+        score_policy_repair_authorized=True,
+        guarded_gate_bull_risk_off_override_enabled=True,
+        guarded_gate_bull_risk_off_override_authorized=True,
+    )
+
+    assert transformed["guarded_gate_bull_risk_off_override_triggered"].tolist() == [
+        True,
+        False,
+        False,
+    ]
+
+
+def test_selection_validation_costs_default_to_portfolio_cost() -> None:
+    config = ExperimentConfig()
+    config.portfolio.costs.bps_per_trade = 35.0
+
+    assert _selection_validation_cost_bps(config) == [35.0]
+
+    config.evaluation.ml_strategy_tuning.selection_validation_cost_bps = [35.0, 50.0]
+    assert _selection_validation_cost_bps(config) == [35.0, 50.0]
 
 
 def test_deterministic_regime_fallback_weights_map_test_regime_labels() -> None:
@@ -1024,6 +1087,33 @@ def test_ml_strategy_candidate_selection_prefers_required_benchmark_margin() -> 
     selected = _select_ml_strategy_candidate(candidates)
 
     assert selected["model_name"] == "better_benchmark_margin"
+
+
+def test_ml_strategy_candidate_selection_prefers_worst_cost_benchmark_margin() -> None:
+    candidates = [
+        {
+            "model_name": "better_base_cost",
+            "excess_cumulative_return": 0.20,
+            "min_benchmark_excess_cumulative_return": 0.08,
+            "min_selection_validation_cost_benchmark_excess_cumulative_return": 0.01,
+            "drawdown_delta": 1.0,
+            "sharpe_like_delta": 1.0,
+            "annualized_turnover": 1.0,
+        },
+        {
+            "model_name": "better_worst_cost",
+            "excess_cumulative_return": 0.12,
+            "min_benchmark_excess_cumulative_return": 0.05,
+            "min_selection_validation_cost_benchmark_excess_cumulative_return": 0.03,
+            "drawdown_delta": 0.0,
+            "sharpe_like_delta": 0.0,
+            "annualized_turnover": 10.0,
+        },
+    ]
+
+    selected = _select_ml_strategy_candidate(candidates)
+
+    assert selected["model_name"] == "better_worst_cost"
 
 
 def _runtime_selection_candidate(

--- a/tests/unit/test_phase8_bull_participation.py
+++ b/tests/unit/test_phase8_bull_participation.py
@@ -69,6 +69,7 @@ def _write_bull_participation_artifacts(run_dir: Path) -> None:
             ],
             "selected_regime_bull_floor": [1.0, 1.0, pd.NA],
             "selected_regime_risk_off_cap": [0.25, 0.25, pd.NA],
+            "selected_regime_gate_bull_floor": [1.0, 1.0, pd.NA],
         }
     ).to_csv(run_dir / "ml_strategy_tuning_selections.csv", index=False)
 
@@ -95,6 +96,7 @@ def test_build_phase8_bull_participation_summarizes_prediction_compression_and_b
         "value",
     ] == pytest.approx(2 / 3)
     assert by_metric.loc["selection_source_best_active_fallback_folds", "value"] == 1
+    assert by_metric.loc["selected_regime_gate_bull_floor_mode", "value"] == 1.0
 
     confusion = detail.loc[
         detail["metric"].eq("target_vs_predicted_tier_fraction")

--- a/tests/unit/test_phase8_grid_compare.py
+++ b/tests/unit/test_phase8_grid_compare.py
@@ -120,6 +120,12 @@ def _write_complete_run(run_dir: Path, *, strategy_return: float) -> None:
                 "value": 0.75,
                 "detail": "",
             },
+            {
+                "section": "guarded_gate_bull_risk_off_override",
+                "metric": "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+                "value": 0.50,
+                "detail": "",
+            },
         ]
     ).to_csv(run_dir / "phase8_run_summary.csv", index=False)
     pd.DataFrame(
@@ -266,6 +272,24 @@ def _write_complete_run(run_dir: Path, *, strategy_return: float) -> None:
                 "detail": "",
             },
             {
+                "section": "guarded_gate_bull_risk_off_override",
+                "metric": "guarded_gate_bull_risk_off_override_triggered_fraction",
+                "value": 0.05,
+                "detail": "",
+            },
+            {
+                "section": "guarded_gate_bull_risk_off_override",
+                "metric": "guarded_gate_bull_risk_off_override_authorized_fraction",
+                "value": 0.75,
+                "detail": "",
+            },
+            {
+                "section": "candidate_score_validity",
+                "metric": "min_selection_validation_cost_benchmark_excess_cumulative_return_min",
+                "value": -0.06,
+                "detail": "",
+            },
+            {
                 "section": "candidate_score_validity",
                 "metric": "negative_validation_score_forward_return_correlation_candidates",
                 "value": 2,
@@ -376,6 +400,20 @@ def test_build_phase8_grid_comparison_summarizes_complete_and_incomplete_runs(
     assert latest["score_policy_triggered_100_fraction"] == 0.15
     assert latest["score_policy_repair_authorized_fraction"] == 0.75
     assert latest["selected_validation_score_policy_repair_authorized_fraction"] == 0.75
+    assert latest["guarded_gate_bull_risk_off_override_triggered_fraction"] == 0.05
+    assert latest["guarded_gate_bull_risk_off_override_authorized_fraction"] == 0.75
+    assert (
+        latest[
+            "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction"
+        ]
+        == 0.50
+    )
+    assert (
+        latest[
+            "candidate_min_selection_validation_cost_benchmark_excess_cumulative_return"
+        ]
+        == -0.06
+    )
     assert latest["negative_validation_score_forward_return_correlation_candidates"] == 2
     assert latest["recommended_artifact_action"] == "keep_latest_complete"
     assert bool(latest["latest_complete_for_experiment"]) is True

--- a/tests/unit/test_phase8_grid_compare.py
+++ b/tests/unit/test_phase8_grid_compare.py
@@ -108,6 +108,18 @@ def _write_complete_run(run_dir: Path, *, strategy_return: float) -> None:
                 "value": 0.10,
                 "detail": "",
             },
+            {
+                "section": "fold_selection",
+                "metric": "selected_regime_gate_bull_floor_mode",
+                "value": 1.0,
+                "detail": "",
+            },
+            {
+                "section": "score_policy_repair",
+                "metric": "selected_validation_score_policy_repair_authorized_fraction",
+                "value": 0.75,
+                "detail": "",
+            },
         ]
     ).to_csv(run_dir / "phase8_run_summary.csv", index=False)
     pd.DataFrame(
@@ -223,6 +235,48 @@ def _write_complete_run(run_dir: Path, *, strategy_return: float) -> None:
                 "value": True,
                 "detail": "",
             },
+            {
+                "section": "candidate_score_validity",
+                "metric": "validation_score_forward_return_correlation_mean",
+                "value": -0.10,
+                "detail": "",
+            },
+            {
+                "section": "candidate_score_validity",
+                "metric": "validation_score_forward_return_correlation_min",
+                "value": -0.30,
+                "detail": "",
+            },
+            {
+                "section": "candidate_score_validity",
+                "metric": "validation_raw_score_forward_return_correlation_min",
+                "value": -0.40,
+                "detail": "",
+            },
+            {
+                "section": "score_policy_repair",
+                "metric": "score_policy_triggered_100_fraction",
+                "value": 0.15,
+                "detail": "",
+            },
+            {
+                "section": "score_policy_repair",
+                "metric": "score_policy_repair_authorized_fraction",
+                "value": 0.75,
+                "detail": "",
+            },
+            {
+                "section": "candidate_score_validity",
+                "metric": "negative_validation_score_forward_return_correlation_candidates",
+                "value": 2,
+                "detail": "",
+            },
+            {
+                "section": "candidate_score_validity",
+                "metric": "validation_gate_bull_underexposed_positive_benchmark_fraction_mean",
+                "value": 0.50,
+                "detail": "",
+            },
         ]
     ).to_csv(run_dir / "phase8_score_diagnostic_summary.csv", index=False)
     pd.DataFrame(
@@ -316,6 +370,13 @@ def test_build_phase8_grid_comparison_summarizes_complete_and_incomplete_runs(
     assert latest["active_return_vs_buy_hold"] == 2.0
     assert latest["bull_upside_capture_ratio"] == 0.65
     assert latest["gate_bull_underexposed_positive_benchmark_return_sum"] == 5.0
+    assert latest["selected_regime_gate_bull_floor_mode"] == 1.0
+    assert latest["candidate_validation_score_forward_return_correlation_min"] == -0.30
+    assert latest["candidate_validation_raw_score_forward_return_correlation_min"] == -0.40
+    assert latest["score_policy_triggered_100_fraction"] == 0.15
+    assert latest["score_policy_repair_authorized_fraction"] == 0.75
+    assert latest["selected_validation_score_policy_repair_authorized_fraction"] == 0.75
+    assert latest["negative_validation_score_forward_return_correlation_candidates"] == 2
     assert latest["recommended_artifact_action"] == "keep_latest_complete"
     assert bool(latest["latest_complete_for_experiment"]) is True
     assert incomplete["artifact_status"] == "incomplete"

--- a/tests/unit/test_phase8_grid_compare.py
+++ b/tests/unit/test_phase8_grid_compare.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from marketlab.cli import main
+from marketlab.reports.phase8_grid_compare import (
+    build_phase8_grid_comparison,
+    write_phase8_grid_comparison,
+)
+
+
+def _write_complete_run(run_dir: Path, *, strategy_return: float) -> None:
+    run_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "strategy": "buy_hold",
+                "cumulative_return": 10.0,
+                "sharpe_like": 0.9,
+                "max_drawdown": -0.55,
+            },
+            {
+                "strategy": "btc_static_25",
+                "cumulative_return": 3.0,
+            },
+            {
+                "strategy": "btc_static_50",
+                "cumulative_return": 6.0,
+            },
+            {
+                "strategy": "btc_static_75",
+                "cumulative_return": 8.0,
+            },
+            {
+                "strategy": "btc_rebalanced_25",
+                "cumulative_return": 1.5,
+            },
+            {
+                "strategy": "btc_rebalanced_50",
+                "cumulative_return": 4.0,
+            },
+            {
+                "strategy": "btc_rebalanced_75",
+                "cumulative_return": 7.0,
+            },
+            {
+                "strategy": "ml_indicator_tuned__long_only__cash",
+                "cumulative_return": strategy_return,
+                "sharpe_like": 1.1,
+                "max_drawdown": -0.35,
+                "avg_gross_exposure": 0.44,
+                "avg_turnover": 0.01,
+                "up_capture": 0.65,
+                "down_capture": 0.50,
+            },
+        ]
+    ).to_csv(run_dir / "strategy_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {"condition": "overall", "passed": False, "observed": "", "required": ""},
+        ]
+    ).to_csv(run_dir / "strict_research_gate.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "fold_id": 1,
+                "selection_status": "selected",
+            },
+        ]
+    ).to_csv(run_dir / "ml_strategy_tuning_selections.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "section": "fold_selection",
+                "metric": "selected_fold_fraction",
+                "value": 0.73,
+                "detail": "",
+            },
+            {
+                "section": "fold_selection",
+                "metric": "no_valid_candidate_folds",
+                "value": 4,
+                "detail": "",
+            },
+            {
+                "section": "target_support",
+                "metric": "target_tier_25_global_fraction",
+                "value": 0.04,
+                "detail": "",
+            },
+            {
+                "section": "target_support",
+                "metric": "target_tier_50_global_fraction",
+                "value": 0.05,
+                "detail": "",
+            },
+            {
+                "section": "predicted_support",
+                "metric": "predicted_tier_25_fraction",
+                "value": 0.80,
+                "detail": "",
+            },
+            {
+                "section": "predicted_support",
+                "metric": "predicted_tier_50_fraction",
+                "value": 0.10,
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_run_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "methodology_gate": "deployment_gate",
+                "section": "strict_gate",
+                "metric": "overall",
+                "passed": False,
+                "value": "",
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "strict_research_gate.csv",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "risk_allocation_gate",
+                "section": "summary",
+                "metric": "overall",
+                "passed": True,
+                "value": True,
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "selection_coverage_gate",
+                "section": "summary",
+                "metric": "overall",
+                "passed": False,
+                "value": False,
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "target_support_gate",
+                "section": "summary",
+                "metric": "overall",
+                "passed": False,
+                "value": False,
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "signal_validity_gate",
+                "section": "summary",
+                "metric": "overall",
+                "passed": False,
+                "value": False,
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "bull_participation_gate",
+                "section": "summary",
+                "metric": "overall",
+                "passed": False,
+                "value": False,
+                "required": "",
+                "diagnostic_only": False,
+                "source_artifact": "",
+                "detail": "",
+            },
+            {
+                "methodology_gate": "counterfactual_hypothesis",
+                "section": "summary",
+                "metric": "counterfactual_pass_available",
+                "passed": True,
+                "value": True,
+                "required": "",
+                "diagnostic_only": True,
+                "source_artifact": "",
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_methodology_review.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "section": "score_deciles",
+                "metric": "score_target_weight_correlation",
+                "value": 0.10,
+                "detail": "",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "score_forward_return_correlation",
+                "value": -0.02,
+                "detail": "",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "score_realized_utility_correlation",
+                "value": 0.03,
+                "detail": "",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "predicted_tier_100_fraction",
+                "value": 0.20,
+                "detail": "",
+            },
+            {
+                "section": "model_family_support",
+                "metric": "any_selected_oos_predicted_tier_100",
+                "value": True,
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_score_diagnostic_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "section": "runtime_participation",
+                "metric": "gate_bull_average_long_exposure",
+                "value": 0.55,
+                "detail": "",
+            },
+            {
+                "section": "bull_active_return",
+                "metric": "gate_bull_active_return_sum",
+                "value": -1.0,
+                "detail": "",
+            },
+            {
+                "section": "bull_active_return",
+                "metric": "gate_bull_underexposed_positive_benchmark_fraction",
+                "value": 0.80,
+                "detail": "",
+            },
+            {
+                "section": "bull_active_return",
+                "metric": "gate_bull_underexposed_positive_benchmark_return_sum",
+                "value": 5.0,
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_bull_participation_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "scenario": "force_runtime_bull_100",
+                "metric": "cumulative_return",
+                "value": 20.0,
+                "detail": "",
+            },
+            {
+                "scenario": "force_runtime_bull_100",
+                "metric": "avg_long_exposure",
+                "value": 0.60,
+                "detail": "",
+            },
+            {
+                "scenario": "buy_hold_gate_bull_model_elsewhere",
+                "metric": "cumulative_return",
+                "value": 18.0,
+                "detail": "",
+            },
+            {
+                "scenario": "buy_hold_gate_bull_model_elsewhere",
+                "metric": "avg_long_exposure",
+                "value": 0.58,
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_bull_counterfactual_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "scenario": "force_runtime_bull_100",
+                "condition": "overall",
+                "passed": True,
+            },
+        ]
+    ).to_csv(run_dir / "phase8_bull_counterfactual_gate.csv", index=False)
+
+
+def test_build_phase8_grid_comparison_summarizes_complete_and_incomplete_runs(
+    tmp_path: Path,
+) -> None:
+    runs_root = tmp_path / "runs"
+    first_run = runs_root / "btc_phase8_grid_fixture" / "20260501T000000Z"
+    latest_run = runs_root / "btc_phase8_grid_fixture" / "20260502T000000Z"
+    incomplete_run = runs_root / "btc_phase8_grid_fixture" / "20260503T000000Z"
+    _write_complete_run(first_run, strategy_return=8.0)
+    _write_complete_run(latest_run, strategy_return=12.0)
+    incomplete_run.mkdir(parents=True)
+    (incomplete_run / "partial.txt").write_text("partial", encoding="utf-8")
+
+    comparison = build_phase8_grid_comparison(runs_root=runs_root)
+
+    assert len(comparison) == 3
+    first = comparison.loc[comparison["run_id"].eq("20260501T000000Z")].iloc[0]
+    latest = comparison.loc[comparison["run_id"].eq("20260502T000000Z")].iloc[0]
+    incomplete = comparison.loc[comparison["run_id"].eq("20260503T000000Z")].iloc[0]
+    assert first["artifact_status"] == "complete"
+    assert first["recommended_artifact_action"] == "keep_for_grid_comparison"
+    assert bool(first["latest_complete_for_experiment"]) is False
+    assert latest["active_return_vs_buy_hold"] == 2.0
+    assert latest["bull_upside_capture_ratio"] == 0.65
+    assert latest["gate_bull_underexposed_positive_benchmark_return_sum"] == 5.0
+    assert latest["recommended_artifact_action"] == "keep_latest_complete"
+    assert bool(latest["latest_complete_for_experiment"]) is True
+    assert incomplete["artifact_status"] == "incomplete"
+    assert incomplete["recommended_artifact_action"] == "archive_or_prune_after_manifest"
+
+
+def test_write_phase8_grid_comparison_and_cli_write_output(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "btc_phase8_grid_fixture" / "20260501T000000Z"
+    _write_complete_run(run_dir, strategy_return=12.0)
+    output_path = tmp_path / "comparison.csv"
+
+    written_path = write_phase8_grid_comparison(
+        run_dirs=[run_dir],
+        output_path=output_path,
+    )
+
+    assert written_path == output_path
+    assert output_path.exists()
+
+    cli_output_path = tmp_path / "cli-comparison.csv"
+    assert (
+        main(
+            [
+                "phase8-grid-compare",
+                "--run-dir",
+                str(run_dir),
+                "--output",
+                str(cli_output_path),
+            ]
+        )
+        == 0
+    )
+    assert cli_output_path.exists()

--- a/tests/unit/test_phase8_issue_seed.py
+++ b/tests/unit/test_phase8_issue_seed.py
@@ -34,10 +34,15 @@ def test_phase8_docs_are_linked_from_mkdocs_nav() -> None:
     assert "BTC Phase 8 Methodology: btc-phase8-methodology.md" in nav_text
     assert "BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md" in nav_text
     assert "BTC Phase 8 Target/Score Pivot: phase8/BTC/target-score-pivot.md" in nav_text
+    assert (
+        "BTC Phase 8 Shadow Confirmation: phase8/BTC/shadow-confirmation-plan.md"
+        in nav_text
+    )
     assert Path("docs/crypto-hourly-trend.md").exists()
     assert Path("docs/btc-phase8-methodology.md").exists()
     assert Path("docs/phase8/BTC/bull-upside-methodology.md").exists()
     assert Path("docs/phase8/BTC/target-score-pivot.md").exists()
+    assert Path("docs/phase8/BTC/shadow-confirmation-plan.md").exists()
 
 
 def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:

--- a/tests/unit/test_phase8_issue_seed.py
+++ b/tests/unit/test_phase8_issue_seed.py
@@ -32,8 +32,10 @@ def test_phase8_docs_are_linked_from_mkdocs_nav() -> None:
 
     assert "Phase 8 Crypto Hourly Trend: crypto-hourly-trend.md" in nav_text
     assert "BTC Phase 8 Methodology: btc-phase8-methodology.md" in nav_text
+    assert "BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md" in nav_text
     assert Path("docs/crypto-hourly-trend.md").exists()
     assert Path("docs/btc-phase8-methodology.md").exists()
+    assert Path("docs/phase8/BTC/bull-upside-methodology.md").exists()
 
 
 def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:
@@ -44,7 +46,9 @@ def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:
         assert "Phase 8" in content
         assert "phase8-summary" in content
         assert "phase8-selection-probe" in content
+        assert "phase8-methodology-review" in content
         assert "phase8-bull-counterfactual" in content
+        assert "phase8-grid-compare" in content
         assert "configs/experiment.btc_paper_daily.yaml" in content
         assert "docker/compose.btc-paper.yml" in content
         assert "marketlab-btc-paper-mcp" in content

--- a/tests/unit/test_phase8_issue_seed.py
+++ b/tests/unit/test_phase8_issue_seed.py
@@ -33,9 +33,11 @@ def test_phase8_docs_are_linked_from_mkdocs_nav() -> None:
     assert "Phase 8 Crypto Hourly Trend: crypto-hourly-trend.md" in nav_text
     assert "BTC Phase 8 Methodology: btc-phase8-methodology.md" in nav_text
     assert "BTC Phase 8 Bull Upside: phase8/BTC/bull-upside-methodology.md" in nav_text
+    assert "BTC Phase 8 Target/Score Pivot: phase8/BTC/target-score-pivot.md" in nav_text
     assert Path("docs/crypto-hourly-trend.md").exists()
     assert Path("docs/btc-phase8-methodology.md").exists()
     assert Path("docs/phase8/BTC/bull-upside-methodology.md").exists()
+    assert Path("docs/phase8/BTC/target-score-pivot.md").exists()
 
 
 def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:
@@ -47,7 +49,9 @@ def test_top_level_docs_describe_current_phase8_and_btc_paper_surface() -> None:
         assert "phase8-summary" in content
         assert "phase8-selection-probe" in content
         assert "phase8-methodology-review" in content
+        assert "phase8-target-diagnostic" in content
         assert "phase8-bull-counterfactual" in content
+        assert "phase8-regime-policy-sweep" in content
         assert "phase8-grid-compare" in content
         assert "configs/experiment.btc_paper_daily.yaml" in content
         assert "docker/compose.btc-paper.yml" in content

--- a/tests/unit/test_phase8_methodology_review.py
+++ b/tests/unit/test_phase8_methodology_review.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from marketlab.cli import main
+from marketlab.reports.phase8_methodology import (
+    build_phase8_methodology_review,
+    write_phase8_methodology_review,
+)
+
+
+def _review_passed(
+    review: pd.DataFrame,
+    *,
+    methodology_gate: str,
+    metric: str,
+    section: str | None = None,
+) -> bool:
+    mask = review["methodology_gate"].eq(methodology_gate) & review["metric"].eq(metric)
+    if section is not None:
+        mask &= review["section"].eq(section)
+    return bool(review.loc[mask, "passed"].iloc[0])
+
+
+def _write_methodology_artifacts(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "condition": "sharpe_like_matches_or_improves",
+                "passed": True,
+                "observed": 0.4,
+                "required": ">= 0",
+            },
+            {
+                "condition": "max_drawdown_matches_or_improves",
+                "passed": True,
+                "observed": 0.3,
+                "required": ">= 0",
+            },
+            {
+                "condition": "average_exposure_in_range",
+                "passed": True,
+                "observed": 0.44,
+                "required": "0.2 to 0.85",
+            },
+            {
+                "condition": "annualized_turnover_budget",
+                "passed": True,
+                "observed": 8.0,
+                "required": "<= 24",
+            },
+            {
+                "condition": "multiple_selected_walk_forward_folds",
+                "passed": True,
+                "observed": 10,
+                "required": ">= 2",
+            },
+            {
+                "condition": "selected_walk_forward_fold_fraction",
+                "passed": False,
+                "observed": 0.67,
+                "required": ">= 0.75",
+            },
+            {
+                "condition": "partial_target_25_global_fraction",
+                "passed": False,
+                "observed": 0.04,
+                "required": ">= 0.05",
+            },
+            {
+                "condition": "predicted_target_25_global_fraction",
+                "passed": True,
+                "observed": 0.30,
+                "required": ">= 0.03",
+            },
+            {
+                "condition": "net_cumulative_return_beats_buy_hold",
+                "passed": False,
+                "observed": -5.0,
+                "required": "> 0",
+            },
+            {
+                "condition": "overall",
+                "passed": False,
+                "observed": "",
+                "required": "all conditions pass",
+            },
+        ]
+    ).to_csv(run_dir / "strict_research_gate.csv", index=False)
+    pd.DataFrame(
+        [
+            {"strategy": "buy_hold", "cumulative_return": 12.0},
+            {"strategy": "btc_static_25", "cumulative_return": 10.0},
+            {"strategy": "btc_rebalanced_25", "cumulative_return": 1.0},
+            {
+                "strategy": "ml_indicator_tuned__long_only__cash",
+                "cumulative_return": 7.0,
+            },
+        ]
+    ).to_csv(run_dir / "strategy_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "section": "score_deciles",
+                "metric": "score_target_weight_correlation",
+                "value": 0.1,
+                "detail": "selected OOS prediction rows",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "score_forward_return_correlation",
+                "value": -0.2,
+                "detail": "selected OOS prediction rows",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "score_realized_utility_correlation",
+                "value": 0.3,
+                "detail": "selected OOS prediction rows",
+            },
+            {
+                "section": "score_deciles",
+                "metric": "predicted_tier_100_fraction",
+                "value": 0.1,
+                "detail": "selected OOS prediction rows",
+            },
+            {
+                "section": "model_family_support",
+                "metric": "any_selected_oos_predicted_tier_100",
+                "value": True,
+                "detail": "selected OOS prediction rows",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_score_diagnostic_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "section": "runtime_participation",
+                "metric": "gate_bull_average_long_exposure",
+                "value": 0.61,
+                "detail": "rows=100",
+            },
+            {
+                "section": "bull_active_return",
+                "metric": "gate_bull_active_return_sum",
+                "value": -1.5,
+                "detail": "daily excess_return sum",
+            },
+            {
+                "section": "bull_active_return",
+                "metric": "gate_bull_underexposed_positive_benchmark_return_sum",
+                "value": 8.0,
+                "detail": "missed positive BTC return",
+            },
+            {
+                "section": "selection_context",
+                "metric": "selected_fold_fraction",
+                "value": 0.73,
+                "detail": "selected=11; total=15",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_bull_participation_summary.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "scenario": "actual_runtime",
+                "condition": "overall",
+                "passed": False,
+                "observed": "",
+                "required": "all diagnostic conditions pass",
+                "diagnostic_only": True,
+                "detail": "",
+            },
+            {
+                "scenario": "force_runtime_bull_100",
+                "condition": "overall",
+                "passed": True,
+                "observed": "",
+                "required": "all diagnostic conditions pass",
+                "diagnostic_only": True,
+                "detail": "",
+            },
+        ]
+    ).to_csv(run_dir / "phase8_bull_counterfactual_gate.csv", index=False)
+
+
+def test_build_phase8_methodology_review_classifies_current_research_gaps(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    _write_methodology_artifacts(run_dir)
+
+    review = build_phase8_methodology_review(run_dir)
+
+    assert _review_passed(
+        review,
+        methodology_gate="deployment_gate",
+        section="strict_gate",
+        metric="overall",
+    ) is False
+    assert _review_passed(
+        review,
+        methodology_gate="risk_allocation_gate",
+        section="summary",
+        metric="overall",
+    ) is True
+    assert _review_passed(
+        review,
+        methodology_gate="benchmark_family",
+        metric="active_return_vs_buy_hold",
+    ) is False
+    assert _review_passed(
+        review,
+        methodology_gate="benchmark_family",
+        metric="active_return_vs_btc_rebalanced_25",
+    ) is True
+    assert _review_passed(
+        review,
+        methodology_gate="signal_validity_gate",
+        metric="score_forward_return_correlation",
+    ) is False
+    assert _review_passed(
+        review,
+        methodology_gate="bull_participation_gate",
+        metric="gate_bull_active_return_sum",
+    ) is False
+
+    counterfactual = review.loc[
+        review["methodology_gate"].eq("counterfactual_hypothesis")
+        & review["section"].eq("force_runtime_bull_100")
+        & review["metric"].eq("overall")
+    ].iloc[0]
+    assert bool(counterfactual["passed"]) is True
+    assert bool(counterfactual["diagnostic_only"]) is True
+
+
+def test_build_phase8_methodology_review_handles_missing_artifacts(tmp_path: Path) -> None:
+    review = build_phase8_methodology_review(tmp_path / "missing-run")
+
+    assert _review_passed(
+        review,
+        methodology_gate="artifact_presence",
+        metric="strict_research_gate.csv",
+    ) is False
+    assert _review_passed(
+        review,
+        methodology_gate="deployment_gate",
+        section="strict_gate",
+        metric="overall",
+    ) is False
+    counterfactual = review.loc[
+        review["methodology_gate"].eq("counterfactual_hypothesis")
+        & review["metric"].eq("counterfactual_gate_present")
+    ].iloc[0]
+    assert bool(counterfactual["diagnostic_only"]) is True
+
+
+def test_phase8_methodology_review_cli_writes_output(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    output_path = tmp_path / "methodology.csv"
+    _write_methodology_artifacts(run_dir)
+
+    assert (
+        main(
+            [
+                "phase8-methodology-review",
+                "--run-dir",
+                str(run_dir),
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    assert output_path.exists()
+
+
+def test_write_phase8_methodology_review_defaults_to_run_directory(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_methodology_artifacts(run_dir)
+
+    output_path = write_phase8_methodology_review(run_dir)
+
+    assert output_path == run_dir / "phase8_methodology_review.csv"
+    assert output_path.exists()

--- a/tests/unit/test_phase8_regime_policy_sweep.py
+++ b/tests/unit/test_phase8_regime_policy_sweep.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from marketlab.cli import main
+from marketlab.reports.phase8_regime_policy_sweep import (
+    build_phase8_regime_policy_sweep,
+    write_phase8_regime_policy_sweep,
+)
+
+
+def _write_sweep_config(path: Path, cache_dir: Path) -> None:
+    path.write_text(
+        f"""
+experiment_name: phase8_regime_policy_sweep_test
+data:
+  symbols: ["BTC-USD"]
+  interval: "1d"
+  cache_dir: "{cache_dir.as_posix()}"
+  prepared_panel_filename: "missing.csv"
+portfolio:
+  costs:
+    bps_per_trade: 35
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  ml_strategy_tuning:
+    enabled: true
+    max_annualized_turnover: 365
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25"]
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _write_sweep_artifacts(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True)
+    dates = pd.date_range("2020-01-01", periods=5, freq="D")
+    pd.DataFrame(
+        {
+            "model_name": "logistic_l1",
+            "fold_id": [1] * len(dates),
+            "signal_date": dates - pd.Timedelta(days=1),
+            "effective_date": dates,
+            "symbol": "BTC-USD",
+            "runtime_regime": ["bull", "risk_off", "sideways", "bear", "bull"],
+            "crypto_regime_risk_off": [0, 1, 0, 0, 0],
+            "crypto_regime_trend_state": [1, 1, 0, -1, 1],
+            "gate_bull": [True, True, False, False, True],
+        }
+    ).to_csv(run_dir / "allocation_probability_diagnostics.csv", index=False)
+    pd.DataFrame(
+        {
+            "date": dates,
+            "strategy": "ml_indicator_tuned__long_only__cash",
+            "long_exposure": [0.25, 0.25, 0.25, 0.25, 0.25],
+        }
+    ).to_csv(run_dir / "daily_exposure.csv", index=False)
+    pd.DataFrame(
+        {
+            "date": dates,
+            "strategy": "ml_indicator_tuned__long_only__cash",
+            "benchmark_strategy": "buy_hold",
+            "strategy_net_return": [0.025, 0.025, 0.0, -0.025, 0.025],
+            "benchmark_net_return": [0.10, 0.10, 0.0, -0.10, 0.10],
+            "excess_return": [-0.075, -0.075, 0.0, 0.075, -0.075],
+        }
+    ).to_csv(run_dir / "benchmark_relative.csv", index=False)
+    pd.DataFrame(
+        {
+            "strategy": ["buy_hold", "btc_static_25"],
+            "cumulative_return": [0.1979, 0.0495],
+            "sharpe_like": [1.0, 0.8],
+            "max_drawdown": [-0.10, -0.03],
+        }
+    ).to_csv(run_dir / "strategy_summary.csv", index=False)
+
+
+def test_build_phase8_regime_policy_sweep_ranks_policy_metrics(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    config_path = tmp_path / "config.yaml"
+    _write_sweep_config(config_path, tmp_path / "cache")
+    _write_sweep_artifacts(run_dir)
+
+    detail, summary = build_phase8_regime_policy_sweep(
+        run_dir,
+        config_path=config_path,
+    )
+
+    assert not detail.empty
+    assert len(summary) == 24
+    assert summary.iloc[0]["active_return_vs_buy_hold"] >= summary.iloc[-1][
+        "active_return_vs_buy_hold"
+    ]
+    gate_override_rows = summary.loc[summary["gate_bull_override"].astype(bool)]
+    assert not gate_override_rows.empty
+    assert gate_override_rows["gate_bull_underexposed_positive_benchmark_fraction"].min() == (
+        pytest.approx(0.0)
+    )
+    assert {
+        "policy_metrics",
+        "benchmark_deltas",
+        "gate_bull",
+        "runtime_regime",
+    }.issubset(set(detail["section"]))
+
+
+def test_phase8_regime_policy_sweep_cli_writes_outputs(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    output_dir = tmp_path / "sweep"
+    config_path = tmp_path / "config.yaml"
+    _write_sweep_config(config_path, tmp_path / "cache")
+    _write_sweep_artifacts(run_dir)
+
+    assert (
+        main(
+            [
+                "phase8-regime-policy-sweep",
+                "--run-dir",
+                str(run_dir),
+                "--config",
+                str(config_path),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+
+    assert (output_dir / "phase8_regime_policy_sweep.csv").exists()
+    assert (output_dir / "phase8_regime_policy_sweep_summary.csv").exists()
+
+
+def test_write_phase8_regime_policy_sweep_defaults_to_run_directory(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    config_path = tmp_path / "config.yaml"
+    _write_sweep_config(config_path, tmp_path / "cache")
+    _write_sweep_artifacts(run_dir)
+
+    detail_path, summary_path = write_phase8_regime_policy_sweep(
+        run_dir,
+        config_path=config_path,
+    )
+
+    assert detail_path == run_dir / "phase8_regime_policy_sweep.csv"
+    assert summary_path == run_dir / "phase8_regime_policy_sweep_summary.csv"
+    assert detail_path.exists()
+    assert summary_path.exists()

--- a/tests/unit/test_phase8_run_summary.py
+++ b/tests/unit/test_phase8_run_summary.py
@@ -47,6 +47,12 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
             ],
             "selected_regime_gate_bull_floor": [1.0, 1.0, pd.NA, pd.NA],
             "validation_score_policy_repair_authorized": [True, False, False, False],
+            "validation_guarded_gate_bull_risk_off_override_authorized": [
+                True,
+                False,
+                False,
+                False,
+            ],
         }
     ).to_csv(run_dir / "ml_strategy_tuning_selections.csv", index=False)
     pd.DataFrame(
@@ -61,6 +67,21 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
             "validation_score_forward_return_correlation": [0.20, -0.10, -0.20],
             "validation_raw_score_forward_return_correlation": [0.10, -0.20, -0.30],
             "validation_score_policy_repair_authorized": [True, False, False],
+            "validation_guarded_gate_bull_risk_off_override_authorized": [
+                True,
+                False,
+                False,
+            ],
+            "guarded_gate_bull_risk_off_override_denied_reason": [
+                "",
+                "negative_validation_raw_score_forward_return_correlation",
+                "negative_validation_raw_score_forward_return_correlation",
+            ],
+            "min_selection_validation_cost_benchmark_excess_cumulative_return": [
+                0.02,
+                -0.03,
+                -0.05,
+            ],
             "score_policy_repair_denied_reason": [
                 "",
                 "negative_validation_raw_score_forward_return_correlation",
@@ -92,6 +113,20 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
             "predicted_tier_weight": [0.0, 0.25, 0.25, 0.50, 1.0],
             "score_policy_repair_authorized": [True, True, True, True, True],
             "score_policy_triggered_100": [False, False, False, False, True],
+            "guarded_gate_bull_risk_off_override_authorized": [
+                True,
+                True,
+                True,
+                True,
+                True,
+            ],
+            "guarded_gate_bull_risk_off_override_triggered": [
+                False,
+                True,
+                False,
+                False,
+                False,
+            ],
         }
     ).to_csv(run_dir / "allocation_probability_diagnostics.csv", index=False)
     pd.DataFrame(
@@ -144,6 +179,18 @@ def test_build_phase8_run_summary_reads_persisted_run_artifacts(tmp_path: Path) 
     assert by_metric.loc["score_policy_triggered_100_fraction", "value"] == pytest.approx(
         0.2
     )
+    assert by_metric.loc[
+        "selected_validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+        "value",
+    ] == pytest.approx(0.5)
+    assert by_metric.loc[
+        "guarded_gate_bull_risk_off_override_triggered_fraction",
+        "value",
+    ] == pytest.approx(0.2)
+    assert by_metric.loc[
+        "min_selection_validation_cost_benchmark_excess_cumulative_return_min",
+        "value",
+    ] == pytest.approx(-0.05)
     assert (
         by_metric.loc[
             "validation_raw_score_forward_return_correlation_min",

--- a/tests/unit/test_phase8_run_summary.py
+++ b/tests/unit/test_phase8_run_summary.py
@@ -39,6 +39,14 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
                 "no_valid_candidate",
                 "no_valid_candidate",
             ],
+            "selected_allocation_score_transform": [
+                "bull_shift_18",
+                "identity",
+                pd.NA,
+                pd.NA,
+            ],
+            "selected_regime_gate_bull_floor": [1.0, 1.0, pd.NA, pd.NA],
+            "validation_score_policy_repair_authorized": [True, False, False, False],
         }
     ).to_csv(run_dir / "ml_strategy_tuning_selections.csv", index=False)
     pd.DataFrame(
@@ -48,7 +56,27 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
             "failure_reasons": [
                 "",
                 "inactive_candidate;non_positive_required_benchmark_excess",
-                "insufficient_predicted_tier_support",
+                "insufficient_predicted_tier_support;negative_score_forward_return_correlation",
+            ],
+            "validation_score_forward_return_correlation": [0.20, -0.10, -0.20],
+            "validation_raw_score_forward_return_correlation": [0.10, -0.20, -0.30],
+            "validation_score_policy_repair_authorized": [True, False, False],
+            "score_policy_repair_denied_reason": [
+                "",
+                "negative_validation_raw_score_forward_return_correlation",
+                "negative_validation_raw_score_forward_return_correlation",
+            ],
+            "validation_score_target_correlation": [0.30, 0.10, 0.05],
+            "validation_gate_bull_average_exposure": [1.0, 0.25, 0.50],
+            "validation_gate_bull_underexposed_positive_benchmark_fraction": [
+                0.0,
+                1.0,
+                0.5,
+            ],
+            "validation_gate_bull_underexposed_positive_benchmark_return_sum": [
+                0.0,
+                0.03,
+                0.02,
             ],
         }
     ).to_csv(run_dir / "ml_strategy_tuning_candidates.csv", index=False)
@@ -62,6 +90,8 @@ def _write_phase8_artifacts(run_dir: Path) -> None:
     pd.DataFrame(
         {
             "predicted_tier_weight": [0.0, 0.25, 0.25, 0.50, 1.0],
+            "score_policy_repair_authorized": [True, True, True, True, True],
+            "score_policy_triggered_100": [False, False, False, False, True],
         }
     ).to_csv(run_dir / "allocation_probability_diagnostics.csv", index=False)
     pd.DataFrame(
@@ -101,6 +131,40 @@ def test_build_phase8_run_summary_reads_persisted_run_artifacts(tmp_path: Path) 
     )
     assert by_metric.loc["target_tier_25_global_fraction", "value"] == 0.2
     assert by_metric.loc["predicted_tier_25_fraction", "value"] == 0.4
+    assert by_metric.loc["selected_score_transform_mode", "value"] == "bull_shift_18"
+    assert by_metric.loc["selected_score_transform_identity_folds", "value"] == 1
+    assert by_metric.loc["selected_regime_gate_bull_floor_mode", "value"] == 1.0
+    assert (
+        by_metric.loc[
+            "selected_validation_score_policy_repair_authorized_fraction",
+            "value",
+        ]
+        == pytest.approx(0.5)
+    )
+    assert by_metric.loc["score_policy_triggered_100_fraction", "value"] == pytest.approx(
+        0.2
+    )
+    assert (
+        by_metric.loc[
+            "validation_raw_score_forward_return_correlation_min",
+            "value",
+        ]
+        == pytest.approx(-0.30)
+    )
+    assert (
+        by_metric.loc[
+            "candidate_rejection_reason_negative_score_forward_return_correlation",
+            "value",
+        ]
+        == 1
+    )
+    assert (
+        by_metric.loc[
+            "negative_validation_score_forward_return_correlation_candidates",
+            "value",
+        ]
+        == 2
+    )
     assert by_metric.loc["active_return_vs_buy_hold", "value"] == pytest.approx(0.02)
     assert by_metric.loc["bear_active_return", "value"] == pytest.approx(-0.02)
 

--- a/tests/unit/test_phase8_score_diagnostic.py
+++ b/tests/unit/test_phase8_score_diagnostic.py
@@ -25,6 +25,10 @@ def _write_score_artifacts(run_dir: Path) -> None:
             "runtime_regime": ["bull", "bull", "risk_off", "bear", "bull"] * 2,
             "target_weight": [1.0, 1.0, 0.0, 0.25, 0.50, 1.0, 0.0, 0.0, 0.50, 1.0],
             "predicted_tier_weight": [0.50, 0.50, 0.25, 0.25, 0.50, 1.0, 0.25, 0.50, 0.50, 1.0],
+            "allocation_score_transform": ["bull_shift_18"] * 10,
+            "score_transform_applied": [True, True, False, False, True] * 2,
+            "score_policy_repair_authorized": [True] * 10,
+            "score_policy_triggered_100": [False, True, False, False, True] * 2,
             "score": [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.00],
             "prob_tier_100": [0.05, 0.06, 0.07, 0.08, 0.09, 0.30, 0.31, 0.32, 0.33, 0.34],
             "forward_return": [-0.04, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06],
@@ -41,10 +45,24 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "min_holding_period_bars": 18,
                 "hysteresis_margin": 0.02,
                 "regime_policy": "bull100_sideways25",
+                "regime_gate_bull_floor": 1.0,
+                "allocation_score_transform": "bull_shift_18",
+                "score_transform_bull_multiplier": 1.0,
+                "score_transform_bull_addend": 0.18,
+                "score_transform_risk_off_score_cap": 0.25,
+                "score_transform_non_bull_score_cap": 0.50,
                 "threshold": 0.0,
                 "validation_predicted_25_fraction": 0.20,
                 "validation_predicted_50_fraction": 0.80,
                 "validation_predicted_100_fraction": 0.0,
+                "validation_score_forward_return_correlation": -0.25,
+                "validation_raw_score_forward_return_correlation": -0.35,
+                "validation_score_policy_repair_authorized": False,
+                "validation_score_target_correlation": 0.10,
+                "validation_gate_bull_average_exposure": 0.50,
+                "validation_gate_bull_underexposed_positive_benchmark_fraction": 1.0,
+                "validation_gate_bull_underexposed_positive_benchmark_return_sum": 0.04,
+                "validation_score_transform_applied_fraction": 0.60,
                 "min_validation_predicted_target_fraction": 0.20,
                 "min_benchmark_excess_cumulative_return": -0.01,
                 "passed_gate": False,
@@ -57,10 +75,24 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "min_holding_period_bars": 18,
                 "hysteresis_margin": 0.02,
                 "regime_policy": "bull100_sideways25",
+                "regime_gate_bull_floor": 1.0,
+                "allocation_score_transform": "identity",
+                "score_transform_bull_multiplier": 1.0,
+                "score_transform_bull_addend": 0.0,
+                "score_transform_risk_off_score_cap": pd.NA,
+                "score_transform_non_bull_score_cap": pd.NA,
                 "threshold": 0.0,
                 "validation_predicted_25_fraction": 0.10,
                 "validation_predicted_50_fraction": 0.70,
                 "validation_predicted_100_fraction": 0.20,
+                "validation_score_forward_return_correlation": 0.40,
+                "validation_raw_score_forward_return_correlation": 0.30,
+                "validation_score_policy_repair_authorized": True,
+                "validation_score_target_correlation": 0.30,
+                "validation_gate_bull_average_exposure": 1.0,
+                "validation_gate_bull_underexposed_positive_benchmark_fraction": 0.0,
+                "validation_gate_bull_underexposed_positive_benchmark_return_sum": 0.0,
+                "validation_score_transform_applied_fraction": 0.0,
                 "min_validation_predicted_target_fraction": 0.10,
                 "min_benchmark_excess_cumulative_return": 0.03,
                 "passed_gate": True,
@@ -77,6 +109,12 @@ def _write_score_artifacts(run_dir: Path) -> None:
             "selected_min_holding_period_bars": [18],
             "selected_hysteresis_margin": [0.02],
             "selected_regime_policy": ["bull100_sideways25"],
+            "selected_regime_gate_bull_floor": [1.0],
+            "selected_allocation_score_transform": ["bull_shift_18"],
+            "selected_score_transform_bull_multiplier": [1.0],
+            "selected_score_transform_bull_addend": [0.18],
+            "selected_score_transform_risk_off_score_cap": [0.25],
+            "selected_score_transform_non_bull_score_cap": [0.50],
             "selected_threshold": [0.0],
             "validation_predicted_25_fraction": [0.20],
             "validation_predicted_50_fraction": [0.80],
@@ -99,6 +137,39 @@ def test_build_phase8_score_diagnostic_reports_deciles_confusion_and_support(
     assert bool(
         by_metric.loc["candidate_validation_predicted_100_available", "value"]
     ) is True
+    assert by_metric.loc["selected_score_transform_mode", "value"] == "bull_shift_18"
+    assert by_metric.loc["score_transform_applied_fraction", "value"] == pytest.approx(0.60)
+    assert by_metric.loc["score_policy_triggered_100_fraction", "value"] == pytest.approx(
+        0.40
+    )
+    assert by_metric.loc["score_policy_repair_authorized_fraction", "value"] == pytest.approx(
+        1.0
+    )
+    assert (
+        by_metric.loc[
+            "validation_score_forward_return_correlation_min",
+            "value",
+        ]
+        == pytest.approx(-0.25)
+    )
+    assert (
+        by_metric.loc[
+            "negative_validation_score_forward_return_correlation_candidates",
+            "value",
+        ]
+        == 1
+    )
+    assert (
+        by_metric.loc[
+            "validation_raw_score_forward_return_correlation_min",
+            "value",
+        ]
+        == pytest.approx(-0.35)
+    )
+    assert by_metric.loc[
+        "validation_score_policy_repair_authorized_fraction",
+        "value",
+    ] == pytest.approx(0.5)
 
     deciles = detail.loc[
         detail["section"].eq("score_deciles") & detail["metric"].eq("score_mean")
@@ -118,6 +189,12 @@ def test_build_phase8_score_diagnostic_reports_deciles_confusion_and_support(
         & detail["metric"].eq("validation_predicted_50_fraction_mean")
     ].iloc[0]
     assert selected_support["value"] == pytest.approx(0.80)
+    selected_transform_support = detail.loc[
+        detail["section"].eq("candidate_score_support")
+        & detail["group"].astype(str).eq("selected")
+        & detail["metric"].eq("validation_score_transform_applied_fraction_mean")
+    ].iloc[0]
+    assert selected_transform_support["value"] == pytest.approx(0.60)
 
 
 def test_build_phase8_score_diagnostic_handles_missing_artifacts(tmp_path: Path) -> None:

--- a/tests/unit/test_phase8_score_diagnostic.py
+++ b/tests/unit/test_phase8_score_diagnostic.py
@@ -29,6 +29,15 @@ def _write_score_artifacts(run_dir: Path) -> None:
             "score_transform_applied": [True, True, False, False, True] * 2,
             "score_policy_repair_authorized": [True] * 10,
             "score_policy_triggered_100": [False, True, False, False, True] * 2,
+            "guarded_gate_bull_risk_off_override_authorized": [True] * 10,
+            "guarded_gate_bull_risk_off_override_triggered": [
+                False,
+                True,
+                False,
+                False,
+                False,
+            ]
+            * 2,
             "score": [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 1.00],
             "prob_tier_100": [0.05, 0.06, 0.07, 0.08, 0.09, 0.30, 0.31, 0.32, 0.33, 0.34],
             "forward_return": [-0.04, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06],
@@ -58,6 +67,7 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "validation_score_forward_return_correlation": -0.25,
                 "validation_raw_score_forward_return_correlation": -0.35,
                 "validation_score_policy_repair_authorized": False,
+                "validation_guarded_gate_bull_risk_off_override_authorized": False,
                 "validation_score_target_correlation": 0.10,
                 "validation_gate_bull_average_exposure": 0.50,
                 "validation_gate_bull_underexposed_positive_benchmark_fraction": 1.0,
@@ -65,6 +75,7 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "validation_score_transform_applied_fraction": 0.60,
                 "min_validation_predicted_target_fraction": 0.20,
                 "min_benchmark_excess_cumulative_return": -0.01,
+                "min_selection_validation_cost_benchmark_excess_cumulative_return": -0.02,
                 "passed_gate": False,
             },
             {
@@ -88,6 +99,7 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "validation_score_forward_return_correlation": 0.40,
                 "validation_raw_score_forward_return_correlation": 0.30,
                 "validation_score_policy_repair_authorized": True,
+                "validation_guarded_gate_bull_risk_off_override_authorized": True,
                 "validation_score_target_correlation": 0.30,
                 "validation_gate_bull_average_exposure": 1.0,
                 "validation_gate_bull_underexposed_positive_benchmark_fraction": 0.0,
@@ -95,6 +107,7 @@ def _write_score_artifacts(run_dir: Path) -> None:
                 "validation_score_transform_applied_fraction": 0.0,
                 "min_validation_predicted_target_fraction": 0.10,
                 "min_benchmark_excess_cumulative_return": 0.03,
+                "min_selection_validation_cost_benchmark_excess_cumulative_return": 0.01,
                 "passed_gate": True,
             },
         ]
@@ -145,6 +158,14 @@ def test_build_phase8_score_diagnostic_reports_deciles_confusion_and_support(
     assert by_metric.loc["score_policy_repair_authorized_fraction", "value"] == pytest.approx(
         1.0
     )
+    assert by_metric.loc[
+        "guarded_gate_bull_risk_off_override_triggered_fraction",
+        "value",
+    ] == pytest.approx(0.20)
+    assert by_metric.loc[
+        "guarded_gate_bull_risk_off_override_authorized_fraction",
+        "value",
+    ] == pytest.approx(1.0)
     assert (
         by_metric.loc[
             "validation_score_forward_return_correlation_min",
@@ -170,6 +191,14 @@ def test_build_phase8_score_diagnostic_reports_deciles_confusion_and_support(
         "validation_score_policy_repair_authorized_fraction",
         "value",
     ] == pytest.approx(0.5)
+    assert by_metric.loc[
+        "validation_guarded_gate_bull_risk_off_override_authorized_fraction",
+        "value",
+    ] == pytest.approx(0.5)
+    assert by_metric.loc[
+        "min_selection_validation_cost_benchmark_excess_cumulative_return_min",
+        "value",
+    ] == pytest.approx(-0.02)
 
     deciles = detail.loc[
         detail["section"].eq("score_deciles") & detail["metric"].eq("score_mean")

--- a/tests/unit/test_phase8_target_diagnostic.py
+++ b/tests/unit/test_phase8_target_diagnostic.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from marketlab.cli import main
+from marketlab.reports.phase8_target_diagnostic import (
+    build_phase8_target_diagnostic,
+    write_phase8_target_diagnostic,
+)
+
+
+def _write_target_artifacts(run_dir: Path) -> None:
+    run_dir.mkdir(parents=True)
+    dates = pd.date_range("2020-01-01", periods=8, freq="D")
+    pd.DataFrame(
+        {
+            "model_name": ["logistic_l1"] * 8,
+            "fold_id": [1] * 4 + [2] * 4,
+            "signal_date": dates - pd.Timedelta(days=1),
+            "effective_date": dates,
+            "symbol": "BTC-USD",
+            "runtime_regime": [
+                "bull",
+                "bull",
+                "risk_off",
+                "bear",
+                "sideways",
+                "bull",
+                "bull",
+                "risk_off",
+            ],
+            "target_weight": [1.0, 0.50, 0.25, 0.0, 0.25, 1.0, 0.50, 0.0],
+            "predicted_tier_weight": [1.0, 0.50, 0.25, 0.0, 0.25, 0.50, 0.50, 0.0],
+            "score": [0.90, 0.70, 0.30, 0.10, 0.40, 0.80, 0.65, 0.05],
+            "forward_return": [0.08, 0.05, -0.04, -0.08, 0.02, 0.04, 0.03, -0.03],
+            "forward_drawdown": [-0.02, -0.12, -0.18, -0.22, -0.03, -0.04, -0.01, -0.11],
+            "realized_utility": [0.08, 0.01, -0.01, 0.0, 0.01, 0.02, 0.01, 0.0],
+        }
+    ).to_csv(run_dir / "allocation_probability_diagnostics.csv", index=False)
+
+
+def _write_gate_config(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "configs"
+    data_dir = tmp_path / "data"
+    config_dir.mkdir()
+    data_dir.mkdir()
+    dates = pd.date_range("2019-12-28", periods=12, freq="D")
+    prices = [100, 101, 102, 103, 104, 105, 106, 104, 103, 107, 108, 109]
+    pd.DataFrame(
+        {
+            "symbol": ["BTC-USD"] * len(dates),
+            "timestamp": dates,
+            "open": prices,
+            "high": prices,
+            "low": prices,
+            "close": prices,
+            "volume": [1000] * len(dates),
+            "adj_close": prices,
+            "adj_factor": [1.0] * len(dates),
+            "adj_open": prices,
+            "adj_high": prices,
+            "adj_low": prices,
+        }
+    ).to_csv(data_dir / "panel.csv", index=False)
+    config_path = config_dir / "experiment.btc_phase8_test.yaml"
+    config_path.write_text(
+        """
+experiment_name: btc_phase8_test
+data:
+  symbols: ["BTC-USD"]
+  interval: "1d"
+  cache_dir: "data"
+  prepared_panel_filename: "panel.csv"
+features:
+  crypto_regime_features_enabled: true
+  crypto_regime_trend_windows: [2]
+  crypto_regime_volatility_window: 2
+  crypto_regime_percentile_window: 2
+  crypto_regime_drawdown_window: 2
+  crypto_regime_volume_window: 2
+evaluation:
+  strict_research_gate:
+    recent_window_months: 1
+paper:
+  enabled: false
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_build_phase8_target_diagnostic_reports_target_score_pivot_metrics(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    _write_target_artifacts(run_dir)
+
+    detail, summary = build_phase8_target_diagnostic(run_dir)
+    by_metric = summary.set_index("metric")
+
+    assert by_metric.loc["bull_continuation_rows", "value"] == 4
+    assert by_metric.loc["bull_continuation_full_target_fraction", "value"] == pytest.approx(
+        0.50
+    )
+    assert by_metric.loc[
+        "bull_continuation_full_prediction_fraction",
+        "value",
+    ] == pytest.approx(0.25)
+    assert by_metric.loc[
+        "positive_return_rows_assigned_below_100_fraction",
+        "value",
+    ] == pytest.approx(3 / 5)
+    assert by_metric.loc[
+        "drawdown_defense_rows_assigned_below_100_fraction",
+        "value",
+    ] == pytest.approx(1.0)
+    assert by_metric.loc["score_target_weight_correlation", "value"] > 0.9
+
+    runtime_rows = detail.loc[
+        detail["section"].eq("runtime_regime")
+        & detail["metric"].eq("full_target_fraction")
+        & detail["group"].eq("bull")
+    ]
+    assert runtime_rows.iloc[0]["value"] == pytest.approx(0.50)
+
+    matrix = detail.loc[
+        detail["section"].eq("target_prediction_matrix")
+        & detail["group"].astype(str).eq("100")
+        & detail["subgroup"].astype(str).eq("50")
+    ]
+    assert not matrix.empty
+
+
+def test_build_phase8_target_diagnostic_handles_missing_artifacts(tmp_path: Path) -> None:
+    detail, summary = build_phase8_target_diagnostic(tmp_path / "missing-run")
+    by_metric = summary.set_index("metric")
+
+    assert detail.empty
+    assert bool(by_metric.loc["allocation_probability_present", "value"]) is False
+
+
+def test_build_phase8_target_diagnostic_joins_config_gate_bull_labels(
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    _write_target_artifacts(run_dir)
+    config_path = _write_gate_config(tmp_path)
+
+    detail, summary = build_phase8_target_diagnostic(run_dir, config_path=config_path)
+    by_metric = summary.set_index("metric")
+
+    assert by_metric.loc["runtime_regime_source", "value"] == "config"
+    assert by_metric.loc["gate_bull_rows", "value"] > 0
+    assert not detail.loc[detail["section"].eq("gate_bull_label")].empty
+
+
+def test_phase8_target_diagnostic_cli_writes_outputs(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    output_dir = tmp_path / "target"
+    _write_target_artifacts(run_dir)
+
+    assert (
+        main(
+            [
+                "phase8-target-diagnostic",
+                "--run-dir",
+                str(run_dir),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+
+    assert (output_dir / "phase8_target_diagnostic.csv").exists()
+    assert (output_dir / "phase8_target_diagnostic_summary.csv").exists()
+
+
+def test_write_phase8_target_diagnostic_defaults_to_run_directory(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write_target_artifacts(run_dir)
+
+    detail_path, summary_path = write_phase8_target_diagnostic(run_dir)
+
+    assert detail_path == run_dir / "phase8_target_diagnostic.csv"
+    assert summary_path == run_dir / "phase8_target_diagnostic_summary.csv"
+    assert detail_path.exists()
+    assert summary_path.exists()

--- a/tests/unit/test_phase8_target_profile_sweep.py
+++ b/tests/unit/test_phase8_target_profile_sweep.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from marketlab.config import ExperimentConfig
+from marketlab.reports.phase8_target_profile_sweep import (
+    build_phase8_target_profile_sweep,
+    write_phase8_target_profile_sweep,
+)
+
+
+def _rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "forward_return": [-0.10, 0.10],
+            "forward_drawdown": [-0.10, 0.0],
+            "forward_realized_volatility": [0.0, 0.0],
+        }
+    )
+
+
+def test_target_profile_sweep_selects_first_passing_profile_deterministically() -> None:
+    sweep = build_phase8_target_profile_sweep(
+        _rows(),
+        drawdown_penalties=[0.50, 0.75],
+        volatility_penalties=[0.25],
+        risk_penalty_powers=[2.0],
+        min_partial_target_fraction=0.0,
+    )
+
+    assert sweep["profile_name"].tolist() == [
+        "dd0.5_vol0.25_power2",
+        "dd0.75_vol0.25_power2",
+    ]
+    assert sweep["passes_partial_target_support"].tolist() == [True, True]
+    assert sweep["selected"].tolist() == [True, False]
+
+
+def test_write_target_profile_sweep_uses_strict_gate_support_threshold(tmp_path) -> None:
+    config = ExperimentConfig()
+    config.target.type = "allocation_utility"
+    config.portfolio.costs.bps_per_trade = 0.0
+    config.evaluation.strict_research_gate.min_partial_target_fraction = 0.0
+    output_path = tmp_path / "target-profile-sweep.csv"
+
+    written_path = write_phase8_target_profile_sweep(
+        _rows(),
+        config=config,
+        output_path=output_path,
+    )
+
+    written = pd.read_csv(written_path)
+    assert written_path == output_path
+    assert written["selected"].sum() == 1
+    assert written.iloc[0]["profile_name"] == "dd0.5_vol0.25_power2"
+
+
+def test_target_profile_sweep_rejects_non_allocation_target() -> None:
+    with pytest.raises(ValueError, match="requires allocation_utility"):
+        build_phase8_target_profile_sweep(_rows(), target_type="binary")

--- a/tests/unit/test_tiered_allocation.py
+++ b/tests/unit/test_tiered_allocation.py
@@ -175,6 +175,40 @@ def test_generate_weights_applies_completed_bar_gate_bull_floor_after_runtime_po
     assert _signal_weights(weights, predictions) == [1.0, 1.0, 0.25, 0.0]
 
 
+def test_generate_weights_applies_only_pre_authorized_guarded_risk_off_override() -> None:
+    predictions = pd.DataFrame(
+        {
+            "model_name": ["m"] * 3,
+            "fold_id": [1] * 3,
+            "signal_date": pd.date_range("2026-01-01", periods=3, freq="4h"),
+            "effective_date": pd.date_range("2026-01-01 04:00", periods=3, freq="4h"),
+            "symbol": ["BTC/USD"] * 3,
+            "score": [0.10, 0.10, 0.10],
+            "crypto_regime_risk_off": [1, 1, 0],
+            "crypto_regime_trend_state": [1, 1, 1],
+            "guarded_gate_bull_risk_off_override_triggered": [True, False, False],
+        }
+    )
+
+    weights = generate_weights(
+        predictions=predictions,
+        panel=_panel(),
+        thresholds=(0.25, 0.50, 0.75),
+        frequency="4h",
+        strategy_name="btc_direct_tiered",
+        direct_scores=True,
+        regime_policy=RegimeParticipationPolicy(
+            name="bull100_sideways25",
+            bull_floor=1.0,
+            sideways_floor=0.25,
+            bear_floor=0.0,
+            risk_off_cap=0.25,
+        ),
+    )
+
+    assert _signal_weights(weights, predictions) == [1.0, 0.0, 1.0]
+
+
 def test_generate_weights_regime_policy_uses_only_current_signal_row() -> None:
     predictions = pd.DataFrame(
         {

--- a/tests/unit/test_tiered_allocation.py
+++ b/tests/unit/test_tiered_allocation.py
@@ -136,6 +136,45 @@ def test_generate_weights_applies_regime_participation_floors_and_risk_cap() -> 
     assert _signal_weights(weights, predictions) == [1.0, 0.50, 0.25, 0.25]
 
 
+def test_generate_weights_applies_completed_bar_gate_bull_floor_after_runtime_policy() -> None:
+    predictions = pd.DataFrame(
+        {
+            "model_name": ["m"] * 4,
+            "fold_id": [1] * 4,
+            "signal_date": pd.date_range("2026-01-01", periods=4, freq="4h"),
+            "effective_date": pd.date_range("2026-01-01 04:00", periods=4, freq="4h"),
+            "symbol": ["BTC/USD"] * 4,
+            "score": [0.10, 0.10, 0.90, 0.10],
+            "crypto_regime_risk_off": [1, 0, 1, 0],
+            "crypto_regime_trend_state": [1, 0, 1, -1],
+            "gate_bull": [True, True, False, False],
+        }
+    )
+
+    weights = generate_weights(
+        predictions=predictions,
+        panel=pd.DataFrame(
+            {
+                "symbol": ["BTC/USD"] * 5,
+                "timestamp": pd.date_range("2026-01-01", periods=5, freq="4h"),
+            }
+        ),
+        thresholds=(0.50, 0.55, 0.62),
+        frequency="4h",
+        strategy_name="btc_tiered",
+        regime_policy=RegimeParticipationPolicy(
+            name="gate_bull_override",
+            bull_floor=0.75,
+            sideways_floor=0.25,
+            bear_floor=0.0,
+            risk_off_cap=0.25,
+            gate_bull_floor=1.0,
+        ),
+    )
+
+    assert _signal_weights(weights, predictions) == [1.0, 1.0, 0.25, 0.0]
+
+
 def test_generate_weights_regime_policy_uses_only_current_signal_row() -> None:
     predictions = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- Add guarded multi-cost gate-bull risk-off override selection for Phase 8 BTC research.
- Add guarded cost-robustness configs, batch script, diagnostics, docs, and shadow-confirmation plan.
- Update Phase 8 reports and tests for selection validation costs and guarded override fields.

## Validation
- python -m pytest -q tests/unit --basetemp .pytest_tmp_unit: 637 passed
- python -m pytest -q tests/integration -m "not real_data and not network" --basetemp .pytest_tmp_integration: 50 passed, 2 deselected
- Phase 8 targeted pytest set: 281 passed
- python -m ruff check .: passed
- python -m mkdocs build --strict: passed
- python -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py: passed
- python -m build --no-isolation: built wheel and sdist
- Built wheel installed in a local smoke venv; verified marketlab --version, list-configs, write-config, and marketlab-mcp --help.

## Local Caveats
- py -3.14 -m tox -e preflight timed out locally after 1 hour, so the underlying gates above are the local evidence and GitHub CI is the final remote gate.
- scripts/check_package.py dependency install smoke was blocked locally by pip/network/permission behavior; wheel build and installed entry-point smoke passed.
- All-in-one pytest collection still has the existing duplicate test_mcp_server.py import-name collision; tox's split unit/integration layout is green.