### PR TITLE
feat(phase9): freeze BTC shadow candidate contract

### DIFF
--- a/configs/experiment.btc_phase9_shadow_daily.yaml
+++ b/configs/experiment.btc_phase9_shadow_daily.yaml
@@ -1,0 +1,178 @@
+experiment_name: btc_phase9_shadow_daily
+
+shadow:
+  candidate_id: "btc-phase9-shadow-v1"
+  behavior_version: "btc-phase8-guarded-gate-v1"
+  protocol_start: "2026-06-03"
+  protocol_end: "2027-06-02"
+  earliest_final_evaluation: "2027-06-16"
+  maturity_lag_bars: 14
+  code_lock: "ce01124"
+  artifact_root: "artifacts/phase9-shadow"
+  config_hash: "d439acca79ca2108a4d907452b5d442ab67b319d430440d07f14f9adc1295f18"
+  behavior_hash: "71beba28529abba3482145094654c5eaf8f12355d92a93830fe746a241129550"
+
+data:
+  symbols: ["BTC-USD"]
+  start_date: "2015-01-01"
+  end_date: "2027-06-02"
+  interval: "1d"
+  cache_dir: "artifacts/data-btc-phase9-shadow-1d"
+  prepared_panel_filename: "btc_usd_phase9_shadow_1d_panel.csv"
+
+features:
+  return_windows: [3, 5, 7, 14, 30]
+  ma_windows: [7, 14, 30, 60, 180]
+  vol_windows: [3, 5, 7, 14, 30, 60]
+  momentum_window: 7
+  indicator_stack_ml_features_enabled: true
+  crypto_time_series_enabled: true
+  crypto_return_windows: [1, 3, 5, 7, 14, 30, 60]
+  crypto_vol_windows: [3, 5, 7, 14, 30, 60]
+  crypto_ma_windows: [7, 14, 30, 60]
+  crypto_volume_window: 14
+  crypto_time_features: true
+  crypto_regime_features_enabled: true
+  crypto_regime_signal_features_enabled: true
+  crypto_regime_trend_windows: [15, 60, 180]
+  crypto_regime_volatility_window: 15
+  crypto_regime_percentile_window: 180
+  crypto_regime_drawdown_window: 180
+  crypto_regime_volume_window: 14
+
+target:
+  horizon_days: 14
+  type: "allocation_utility"
+  allocation_utility_drawdown_penalty: 0.75
+  allocation_utility_volatility_penalty: 0.25
+  allocation_utility_risk_penalty_power: 2.0
+
+portfolio:
+  ranking:
+    long_n: 1
+    short_n: 1
+    rebalance_frequency: "bar"
+    weighting: "equal"
+    mode: "long_only"
+    min_score_threshold: 0.55
+    cash_when_underfilled: true
+  costs:
+    bps_per_trade: 35
+
+baselines:
+  buy_hold: true
+  partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  rebalanced_partial_allocation_benchmarks:
+    enabled: true
+    weights: [0.25, 0.50, 0.75]
+  sma:
+    enabled: false
+  indicator_stack:
+    enabled: true
+    ema_fast_window: 12
+    ema_slow_window: 26
+    rsi_window: 14
+    rsi_min: 45.0
+    rsi_max: 70.0
+    macd_fast_window: 12
+    macd_slow_window: 26
+    macd_signal_window: 9
+    bollinger_window: 20
+    bollinger_std: 2.0
+    bollinger_mode: "breakout"
+    volume_window: 14
+    volume_multiplier: 1.0
+    vwap_window: 14
+    use_vwap: false
+    min_confirmations: 3
+
+models:
+  - name: logistic_l1
+  - name: random_forest
+  - name: hist_gradient_boosting
+
+evaluation:
+  benchmark_strategy: "buy_hold"
+  periods_per_year: 365
+  cost_sensitivity_bps: [10, 25, 35, 50, 75]
+  ml_strategy_tuning:
+    enabled: true
+    allocation_mode: "direct_tiered"
+    selection_policy: "best_active_fallback"
+    allocation_score_policy: "gate_bull_prob100_threshold"
+    allocation_score_policy_prob100_threshold_grid: [0.20, 0.28, 0.36]
+    selection_validation_cost_bps: [35, 50]
+    guarded_gate_bull_risk_off_override: true
+    thresholds: [0.50]
+    tier_thresholds: [0.25, 0.50, 0.75]
+    validation_months: 6
+    min_validation_rows: 90
+    min_exposure_changes: 2
+    min_average_exposure_for_active: 0.20
+    max_average_exposure_for_active: 0.85
+    rolling_train_bars_grid: [730, 1095]
+    min_holding_period_bars_grid: [0, 18]
+    hysteresis_margin_grid: [0.0, 0.02]
+    regime_participation_policies:
+      - name: "bull100_sideways25"
+        bull_floor: 1.0
+        sideways_floor: 0.25
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+      - name: "bull100_sideways50"
+        bull_floor: 1.0
+        sideways_floor: 0.50
+        bear_floor: 0.0
+        risk_off_cap: 0.25
+    no_valid_candidate_regime_fallback: "bull100_sideways25"
+    max_annualized_turnover: 24.0
+    objective: "net_return_risk_score_validity_vs_required_benchmarks"
+    selection_benchmark_strategies: ["buy_hold", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    allocation_utility_profiles:
+      - name: "partial_support_dd075"
+        drawdown_penalty: 0.75
+        volatility_penalty: 0.25
+        risk_penalty_power: 2.0
+    allocation_class_weighting: "balanced"
+    allocation_partial_class_weight_multiplier: 2.0
+    allocation_probability_calibration: "sigmoid"
+    allocation_calibration_cv: 3
+  strict_research_gate:
+    enabled: true
+    strategy_name: "ml_indicator_tuned__long_only__cash"
+    benchmark_strategy: "buy_hold"
+    required_benchmark_strategies: ["buy_hold", "btc_static_25", "btc_static_50", "btc_static_75", "btc_rebalanced_25", "btc_rebalanced_50", "btc_rebalanced_75"]
+    cost_gate_bps: 35
+    acceptable_cost_bps: 50
+    min_positive_regime_slices: 3
+    min_average_exposure: 0.20
+    max_average_exposure: 0.85
+    min_selected_fold_fraction: 0.75
+    recent_window_months: 6
+    required_partial_target_weights: [0.25, 0.50]
+    min_partial_target_fraction: 0.05
+    min_partial_target_fold_fraction: 0.60
+    required_predicted_target_weights: [0.25, 0.50]
+    min_predicted_target_fraction: 0.03
+    min_predicted_target_fold_fraction: 0.50
+  walk_forward:
+    train_years: 3
+    test_months: 6
+    step_months: 6
+    min_train_rows: 730
+    min_test_rows: 120
+    min_train_positive_rate: 0.05
+    min_test_positive_rate: 0.05
+    embargo_periods: 1
+
+paper:
+  enabled: false
+
+artifacts:
+  output_dir: "artifacts/phase9-shadow"
+  save_predictions: true
+  save_metrics_csv: true
+  save_report_md: true
+  save_plots: true

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -315,7 +315,7 @@ working alerts, and a rehearsed rollback.
 | --- | --- | --- | --- |
 | P9-01 | Canonical roadmap, Azure ADR, and protected docs tests | None | Legacy cloud plan removed; BTC, Azure, and QQQ boundaries explicit |
 | [P9-02](phase9/P9-02-WORKER-PLAN.md) | Terraform bootstrap and validation workflow | P9-01 | Remote state backend reproducible; CI validates all roots without applying |
-| P9-03 | Frozen BTC shadow config and behavior lock | P9-01 | Any drift fails closed; paper remains disabled |
+| [P9-03](phase9/P9-03-WORKER-PLAN.md) | Frozen BTC shadow config and behavior lock | P9-01 | Any drift fails closed; paper remains disabled |
 | P9-04 | Shadow decision service and append-only journal | P9-03 | Label-safe, idempotent, conflict-preserving decisions |
 | P9-05 | Shadow scheduler, status, monthly, and final reports | P9-04 | Missing and failed runs explicit; reports cannot promote |
 | P9-06 | Azure shadow infrastructure and launch gate | P9-02, P9-05 | Disabled job validates; archive, restore, and alert tests pass |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,5 +13,6 @@ This site is the canonical home for MarketLab's public documentation.
 - [Plan](PLAN.md)
 - [Phase 9 P9-02 Worker Plan](phase9/P9-02-WORKER-PLAN.md)
 - [Phase 9 P9-02 Bootstrap Evidence](phase9/P9-02-BOOTSTRAP-EVIDENCE.md)
+- [Phase 9 P9-03 Worker Plan](phase9/P9-03-WORKER-PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/phase9/P9-03-WORKER-PLAN.md
+++ b/docs/phase9/P9-03-WORKER-PLAN.md
@@ -1,0 +1,131 @@
+# P9-03 Worker Plan: Frozen BTC Shadow Contract
+
+## Packet Identity
+
+- Branch: `feature/phase-9-btc-shadow-lock`
+- Pull request: `feat(phase9): freeze BTC shadow candidate contract`
+- Dependency: P9-01 and the merged P9-02 documentation baseline
+- Historical candidate code lock: `ce01124`
+
+P9-03 freezes the retained Phase 8 BTC candidate as a signals-only Phase 9
+shadow contract. It supplies the configuration and fail-closed verifier that
+P9-04 must call before producing a decision.
+
+P9-03 does not fetch market data, run models, schedule work, create decision
+records, write reports, deploy Azure resources, request approval, or call a
+broker. Those behaviors remain in later packets.
+
+## Frozen Protocol
+
+| Field | Approved value |
+| --- | --- |
+| Candidate ID | `btc-phase9-shadow-v1` |
+| Behavior version | `btc-phase8-guarded-gate-v1` |
+| Protocol start | `2026-06-03` |
+| Protocol end | `2027-06-02` |
+| Earliest final labeled evaluation | `2027-06-16` |
+| Target maturity lag | `14` daily bars |
+| Symbol and interval | `BTC-USD`, `1d` |
+| Artifact root | `artifacts/phase9-shadow` |
+| Paper execution | Disabled |
+
+The checked-in config is
+`configs/experiment.btc_phase9_shadow_daily.yaml`. Its strategy-affecting
+settings must remain semantically identical to
+`configs/experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml`.
+
+The Phase 9 config ends at the protocol boundary. P9-04 must pass a runtime
+completed-bar as-of cutoff and must never modify or generate a replacement for
+the checked-in config. Missed protocol dates must be recorded explicitly by
+P9-04 and cannot be silently reconstructed with data that was unavailable at
+the original decision time.
+
+## Hash Contract
+
+The verifier uses SHA-256 over canonical UTF-8 JSON with sorted keys and compact
+separators.
+
+The full config hash covers the complete YAML mapping except the two declared
+hash values. It therefore detects changes to behavior, protocol metadata,
+safety settings, paths, and artifact options. The approved full config hash is:
+
+```text
+d439acca79ca2108a4d907452b5d442ab67b319d430440d07f14f9adc1295f18
+```
+
+The behavior hash covers the behavior version plus normalized values from:
+
+- data symbols, research start date, and interval
+- all feature, target, portfolio, baseline, model, and evaluation settings
+
+It excludes the experiment name, data end date, cache and artifact paths, and
+shadow protocol metadata. The approved behavior hash is:
+
+```text
+71beba28529abba3482145094654c5eaf8f12355d92a93830fe746a241129550
+```
+
+The expected hashes are independently pinned in
+`marketlab.shadow.contract`. Hash declarations in the YAML cannot approve a
+changed candidate because the verifier requires the declarations, calculated
+digests, and independent registry to agree.
+
+## Public Contract
+
+P9-03 adds:
+
+```python
+from marketlab.shadow import verify_shadow_contract
+
+contract = verify_shadow_contract(
+    "configs/experiment.btc_phase9_shadow_daily.yaml"
+)
+```
+
+Successful verification returns `VerifiedShadowContract`, including the typed
+experiment config, candidate identity, protocol dates, maturity lag, code lock,
+artifact root, and both calculated hashes. Any mismatch raises
+`ShadowContractError` before downstream shadow work can begin.
+
+The verifier rejects:
+
+- unknown candidate IDs or changed registry-controlled metadata
+- loading the candidate outside `configs/experiment.btc_phase9_shadow_daily.yaml`
+- malformed or reordered protocol dates
+- any full-config or behavior drift
+- a non-BTC symbol, non-daily interval, or non-14-bar target
+- an artifact root that differs from the approved shadow root
+- `paper.enabled: true`
+
+## Implementation Order
+
+1. Add the typed optional `shadow` configuration section without changing
+   existing config defaults.
+2. Add the frozen Phase 9 YAML as an operational mirror of the retained Phase 8
+   behavior.
+3. Add canonical hashing, the independent approval registry, and the verifier.
+4. Add mutation, mirror, safety, documentation, lint, and type-check coverage.
+
+The worker owns the config schema, YAML, verifier, tests, and documentation. QA
+must verify deterministic hashing and fail-closed mutations. The critic must
+review the hash boundary and prevent P9-04 decision or journal behavior from
+entering this packet. The financial reviewer must confirm that the behavior
+payload remains an exact Phase 8 strategy mirror.
+
+## Validation And Acceptance
+
+Run:
+
+```text
+python -m pytest -q tests/unit/test_phase9_shadow_contract.py tests/unit/test_phase9_plan_docs.py tests/unit/test_config.py
+python -m ruff check src/marketlab/config.py src/marketlab/shadow tests/unit/test_phase9_shadow_contract.py tests/unit/test_phase9_plan_docs.py
+python -m mypy src/marketlab/config.py src/marketlab/shadow/contract.py
+python -m mkdocs build --strict
+py -3.14 -m tox -e preflight
+git diff --check
+```
+
+P9-03 is complete only when the checked-in Phase 9 config verifies against the
+independent registry, its behavior hash equals the retained Phase 8 behavior
+hash, mutations fail closed, paper remains disabled, and P9-04 can consume the
+typed verified contract without introducing another lock mechanism.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Plan: PLAN.md
   - Phase 9 P9-02 Worker Plan: phase9/P9-02-WORKER-PLAN.md
   - Phase 9 P9-02 Bootstrap Evidence: phase9/P9-02-BOOTSTRAP-EVIDENCE.md
+  - Phase 9 P9-03 Worker Plan: phase9/P9-03-WORKER-PLAN.md
 plugins:
   - search
 extra_javascript:

--- a/src/marketlab/config.py
+++ b/src/marketlab/config.py
@@ -459,6 +459,20 @@ class PaperConfig:
 
 
 @dataclass(slots=True)
+class ShadowConfig:
+    candidate_id: str = ""
+    behavior_version: str = ""
+    protocol_start: str = ""
+    protocol_end: str = ""
+    earliest_final_evaluation: str = ""
+    maturity_lag_bars: int = 0
+    code_lock: str = ""
+    artifact_root: str = ""
+    config_hash: str = ""
+    behavior_hash: str = ""
+
+
+@dataclass(slots=True)
 class ExperimentConfig:
     experiment_name: str = "weekly_rank_v1"
     data: DataConfig = field(default_factory=DataConfig)
@@ -476,6 +490,7 @@ class ExperimentConfig:
     evaluation: EvaluationConfig = field(default_factory=EvaluationConfig)
     artifacts: ArtifactsConfig = field(default_factory=ArtifactsConfig)
     paper: PaperConfig = field(default_factory=PaperConfig)
+    shadow: ShadowConfig | None = None
     base_dir: Path = field(default_factory=Path.cwd, repr=False)
 
     def resolve_path(self, value: str | Path) -> Path:
@@ -1846,6 +1861,11 @@ def load_config(path: str | Path) -> ExperimentConfig:
             visualize_signals=evaluation_payload.get("visualize_signals", False),
         ),
         artifacts=_section(ArtifactsConfig, payload.get("artifacts")),
+        shadow=(
+            _section(ShadowConfig, payload.get("shadow"))
+            if payload.get("shadow") is not None
+            else None
+        ),
         paper=PaperConfig(
             enabled=paper_payload.get("enabled", paper_defaults.enabled),
             data_provider=paper_payload.get("data_provider", paper_defaults.data_provider),

--- a/src/marketlab/shadow/__init__.py
+++ b/src/marketlab/shadow/__init__.py
@@ -1,0 +1,13 @@
+"""Frozen Phase 9 shadow-candidate contracts."""
+
+from marketlab.shadow.contract import (
+    ShadowContractError,
+    VerifiedShadowContract,
+    verify_shadow_contract,
+)
+
+__all__ = [
+    "ShadowContractError",
+    "VerifiedShadowContract",
+    "verify_shadow_contract",
+]

--- a/src/marketlab/shadow/contract.py
+++ b/src/marketlab/shadow/contract.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from marketlab.config import ExperimentConfig, load_config
+
+_DECLARED_HASH_FIELDS = {"behavior_hash", "config_hash"}
+
+
+class ShadowContractError(RuntimeError):
+    """Raised when a shadow candidate differs from its approved contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ApprovedShadowCandidate:
+    config_filename: str
+    behavior_version: str
+    protocol_start: date
+    protocol_end: date
+    earliest_final_evaluation: date
+    maturity_lag_bars: int
+    code_lock: str
+    artifact_root: str
+    config_hash: str
+    behavior_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedShadowContract:
+    config: ExperimentConfig
+    config_path: Path
+    candidate_id: str
+    behavior_version: str
+    protocol_start: date
+    protocol_end: date
+    earliest_final_evaluation: date
+    maturity_lag_bars: int
+    code_lock: str
+    artifact_root: Path
+    config_hash: str
+    behavior_hash: str
+
+
+_APPROVED_SHADOW_CANDIDATES = {
+    "btc-phase9-shadow-v1": _ApprovedShadowCandidate(
+        config_filename="experiment.btc_phase9_shadow_daily.yaml",
+        behavior_version="btc-phase8-guarded-gate-v1",
+        protocol_start=date(2026, 6, 3),
+        protocol_end=date(2027, 6, 2),
+        earliest_final_evaluation=date(2027, 6, 16),
+        maturity_lag_bars=14,
+        code_lock="ce01124",
+        artifact_root="artifacts/phase9-shadow",
+        config_hash="d439acca79ca2108a4d907452b5d442ab67b319d430440d07f14f9adc1295f18",
+        behavior_hash="71beba28529abba3482145094654c5eaf8f12355d92a93830fe746a241129550",
+    )
+}
+
+
+def _canonical_hash(payload: object) -> str:
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _config_hash(payload: dict[str, Any]) -> str:
+    canonical_payload = dict(payload)
+    shadow_payload = canonical_payload.get("shadow")
+    if isinstance(shadow_payload, dict):
+        canonical_shadow = dict(shadow_payload)
+        for field_name in _DECLARED_HASH_FIELDS:
+            canonical_shadow.pop(field_name, None)
+        canonical_payload["shadow"] = canonical_shadow
+    return _canonical_hash(canonical_payload)
+
+
+def _behavior_payload(
+    config: ExperimentConfig,
+    *,
+    behavior_version: str,
+) -> dict[str, object]:
+    return {
+        "behavior_version": behavior_version,
+        "data": {
+            "symbols": list(config.data.symbols),
+            "start_date": config.data.start_date,
+            "interval": config.data.interval,
+        },
+        "features": asdict(config.features),
+        "target": asdict(config.target),
+        "portfolio": asdict(config.portfolio),
+        "baselines": asdict(config.baselines),
+        "models": [asdict(model) for model in config.models],
+        "evaluation": asdict(config.evaluation),
+    }
+
+
+def _behavior_hash(config: ExperimentConfig, *, behavior_version: str) -> str:
+    return _canonical_hash(
+        _behavior_payload(config, behavior_version=behavior_version)
+    )
+
+
+def _parse_protocol_date(label: str, value: object) -> date:
+    if not isinstance(value, str):
+        raise ShadowContractError(f"shadow.{label} must use YYYY-MM-DD format.")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ShadowContractError(f"shadow.{label} must use YYYY-MM-DD format.") from exc
+    if parsed.isoformat() != value:
+        raise ShadowContractError(f"shadow.{label} must use YYYY-MM-DD format.")
+    return parsed
+
+
+def _load_raw_mapping(path: Path) -> dict[str, Any]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ShadowContractError(f"Unable to read shadow config: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ShadowContractError("Shadow config must contain a YAML mapping.")
+    return payload
+
+
+def _require_equal(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise ShadowContractError(
+            f"{label} differs from the approved shadow contract: "
+            f"expected {expected!r}, received {actual!r}."
+        )
+
+
+def verify_shadow_contract(path: str | Path) -> VerifiedShadowContract:
+    config_path = Path(path).resolve()
+    raw_payload = _load_raw_mapping(config_path)
+    try:
+        config = load_config(config_path)
+    except (AttributeError, OSError, TypeError, ValueError, yaml.YAMLError) as exc:
+        raise ShadowContractError(f"Invalid shadow config: {config_path}") from exc
+
+    shadow = config.shadow
+    if shadow is None:
+        raise ShadowContractError("Shadow config must define a top-level shadow section.")
+
+    if not isinstance(shadow.candidate_id, str):
+        raise ShadowContractError("shadow.candidate_id must be a string.")
+    approved = _APPROVED_SHADOW_CANDIDATES.get(shadow.candidate_id)
+    if approved is None:
+        raise ShadowContractError(
+            f"Unknown shadow candidate_id: {shadow.candidate_id!r}."
+        )
+    if (
+        config_path.name != approved.config_filename
+        or config_path.parent.name != "configs"
+    ):
+        raise ShadowContractError(
+            "The approved shadow candidate must be loaded from "
+            f"configs/{approved.config_filename}."
+        )
+
+    protocol_start = _parse_protocol_date("protocol_start", shadow.protocol_start)
+    protocol_end = _parse_protocol_date("protocol_end", shadow.protocol_end)
+    earliest_final = _parse_protocol_date(
+        "earliest_final_evaluation",
+        shadow.earliest_final_evaluation,
+    )
+    if not protocol_start <= protocol_end < earliest_final:
+        raise ShadowContractError(
+            "Shadow protocol dates must satisfy start <= end < earliest final evaluation."
+        )
+
+    _require_equal(
+        "shadow.behavior_version",
+        shadow.behavior_version,
+        approved.behavior_version,
+    )
+    _require_equal("shadow.protocol_start", protocol_start, approved.protocol_start)
+    _require_equal("shadow.protocol_end", protocol_end, approved.protocol_end)
+    _require_equal(
+        "shadow.earliest_final_evaluation",
+        earliest_final,
+        approved.earliest_final_evaluation,
+    )
+    _require_equal(
+        "shadow.maturity_lag_bars",
+        shadow.maturity_lag_bars,
+        approved.maturity_lag_bars,
+    )
+    _require_equal("shadow.code_lock", shadow.code_lock, approved.code_lock)
+    _require_equal("shadow.artifact_root", shadow.artifact_root, approved.artifact_root)
+    _require_equal("shadow.config_hash", shadow.config_hash, approved.config_hash)
+    _require_equal("shadow.behavior_hash", shadow.behavior_hash, approved.behavior_hash)
+
+    if config.paper.enabled:
+        raise ShadowContractError("paper.enabled must remain false for the shadow candidate.")
+    _require_equal("data.symbols", config.data.symbols, ["BTC-USD"])
+    _require_equal("data.interval", config.data.interval, "1d")
+    _require_equal("data.end_date", config.data.end_date, shadow.protocol_end)
+    _require_equal(
+        "target.horizon_days",
+        config.target.horizon_days,
+        shadow.maturity_lag_bars,
+    )
+    _require_equal(
+        "artifacts.output_dir",
+        config.artifacts.output_dir,
+        shadow.artifact_root,
+    )
+
+    try:
+        actual_config_hash = _config_hash(raw_payload)
+        actual_behavior_hash = _behavior_hash(
+            config,
+            behavior_version=shadow.behavior_version,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ShadowContractError(
+            "Shadow config values must support deterministic JSON hashing."
+        ) from exc
+    _require_equal("config hash", actual_config_hash, approved.config_hash)
+    _require_equal("behavior hash", actual_behavior_hash, approved.behavior_hash)
+
+    return VerifiedShadowContract(
+        config=config,
+        config_path=config_path,
+        candidate_id=shadow.candidate_id,
+        behavior_version=shadow.behavior_version,
+        protocol_start=protocol_start,
+        protocol_end=protocol_end,
+        earliest_final_evaluation=earliest_final,
+        maturity_lag_bars=shadow.maturity_lag_bars,
+        code_lock=shadow.code_lock,
+        artifact_root=config.resolve_path(shadow.artifact_root),
+        config_hash=actual_config_hash,
+        behavior_hash=actual_behavior_hash,
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1731,3 +1731,18 @@ def test_load_config_rejects_openai_backend_without_model(tmp_path: Path) -> Non
 
     with pytest.raises(ValueError, match="paper.agent_model must be set"):
         load_config(config_path)
+
+
+def test_load_config_parses_phase9_shadow_metadata() -> None:
+    root = Path(__file__).resolve().parents[2]
+    config = load_config(root / "configs" / "experiment.btc_phase9_shadow_daily.yaml")
+
+    assert config.shadow is not None
+    assert config.shadow.candidate_id == "btc-phase9-shadow-v1"
+    assert config.shadow.behavior_version == "btc-phase8-guarded-gate-v1"
+    assert config.shadow.protocol_start == "2026-06-03"
+    assert config.shadow.protocol_end == "2027-06-02"
+    assert config.shadow.earliest_final_evaluation == "2027-06-16"
+    assert config.shadow.maturity_lag_bars == 14
+    assert config.shadow.code_lock == "ce01124"
+    assert config.shadow.artifact_root == "artifacts/phase9-shadow"

--- a/tests/unit/test_phase9_plan_docs.py
+++ b/tests/unit/test_phase9_plan_docs.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[2]
 PLAN = ROOT / "docs" / "PLAN.md"
 P9_02_PLAN = ROOT / "docs" / "phase9" / "P9-02-WORKER-PLAN.md"
 P9_02_EVIDENCE = ROOT / "docs" / "phase9" / "P9-02-BOOTSTRAP-EVIDENCE.md"
+P9_03_PLAN = ROOT / "docs" / "phase9" / "P9-03-WORKER-PLAN.md"
 
 
 def test_phase9_plan_replaces_obsolete_cloud_plan() -> None:
@@ -121,3 +122,35 @@ def test_p9_02_evidence_does_not_publish_live_azure_identifiers() -> None:
     assert "| Subscription | Approved Phase 9 subscription; name and ID retained locally |" in content
     assert "| Resource suffix | Retained locally |" in content
     assert content.count("Name retained locally") == 2
+
+
+def test_p9_03_plan_locks_shadow_scope_and_hashes() -> None:
+    content = P9_03_PLAN.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    required = [
+        "feature/phase-9-btc-shadow-lock",
+        "ce01124",
+        "2026-06-03",
+        "2027-06-02",
+        "2027-06-16",
+        "btc-phase9-shadow-v1",
+        "paper.enabled: true",
+        "does not fetch market data, run models, schedule work",
+        "cannot be silently reconstructed",
+        "d439acca79ca2108a4d907452b5d442ab67b319d430440d07f14f9adc1295f18",
+        "71beba28529abba3482145094654c5eaf8f12355d92a93830fe746a241129550",
+        "verify_shadow_contract",
+    ]
+
+    assert all(term in normalized for term in required)
+
+
+def test_p9_03_plan_is_linked_from_docs() -> None:
+    roadmap = PLAN.read_text(encoding="utf-8")
+    nav = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "phase9/P9-03-WORKER-PLAN.md" in roadmap
+    assert "Phase 9 P9-03 Worker Plan: phase9/P9-03-WORKER-PLAN.md" in nav
+    assert "phase9/P9-03-WORKER-PLAN.md" in index

--- a/tests/unit/test_phase9_shadow_contract.py
+++ b/tests/unit/test_phase9_shadow_contract.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from marketlab.config import load_config
+from marketlab.shadow import ShadowContractError, verify_shadow_contract
+from marketlab.shadow.contract import _behavior_hash, _config_hash
+
+ROOT = Path(__file__).resolve().parents[2]
+PHASE8_CONFIG = (
+    ROOT
+    / "configs"
+    / "experiment.btc_phase8_guarded_gate_bull_risk_off_override_partial_support.yaml"
+)
+SHADOW_CONFIG = ROOT / "configs" / "experiment.btc_phase9_shadow_daily.yaml"
+BEHAVIOR_VERSION = "btc-phase8-guarded-gate-v1"
+
+
+def _payload() -> dict[str, Any]:
+    payload = yaml.safe_load(SHADOW_CONFIG.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _write_mutation(
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+) -> Path:
+    payload = _payload()
+    mutate(payload)
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    path = config_dir / SHADOW_CONFIG.name
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_verified_shadow_contract_exposes_frozen_protocol() -> None:
+    contract = verify_shadow_contract(SHADOW_CONFIG)
+
+    assert contract.candidate_id == "btc-phase9-shadow-v1"
+    assert contract.behavior_version == BEHAVIOR_VERSION
+    assert contract.protocol_start.isoformat() == "2026-06-03"
+    assert contract.protocol_end.isoformat() == "2027-06-02"
+    assert contract.earliest_final_evaluation.isoformat() == "2027-06-16"
+    assert contract.maturity_lag_bars == 14
+    assert contract.code_lock == "ce01124"
+    assert contract.config.paper.enabled is False
+    assert contract.artifact_root == ROOT / "artifacts" / "phase9-shadow"
+
+
+def test_shadow_behavior_exactly_matches_retained_phase8_candidate() -> None:
+    phase8 = load_config(PHASE8_CONFIG)
+    shadow = load_config(SHADOW_CONFIG)
+
+    assert _behavior_hash(
+        shadow,
+        behavior_version=BEHAVIOR_VERSION,
+    ) == _behavior_hash(
+        phase8,
+        behavior_version=BEHAVIOR_VERSION,
+    )
+
+
+def test_hashes_are_stable_across_yaml_key_order(tmp_path: Path) -> None:
+    payload = _payload()
+    reordered = dict(reversed(list(payload.items())))
+
+    assert _config_hash(reordered) == _config_hash(payload)
+
+
+def test_shadow_contract_rejects_noncanonical_config_location(tmp_path: Path) -> None:
+    path = tmp_path / SHADOW_CONFIG.name
+    path.write_text(SHADOW_CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(ShadowContractError, match="must be loaded from configs"):
+        verify_shadow_contract(path)
+
+
+def test_behavior_hash_ignores_operational_fields_but_config_hash_does_not(
+    tmp_path: Path,
+) -> None:
+    original_payload = _payload()
+    changed_payload = _payload()
+    changed_payload["data"]["cache_dir"] = "artifacts/other-cache"
+
+    original = load_config(SHADOW_CONFIG)
+    changed_path = tmp_path / "operational-change.yaml"
+    changed_path.write_text(
+        yaml.safe_dump(changed_payload, sort_keys=False),
+        encoding="utf-8",
+    )
+    changed = load_config(changed_path)
+
+    assert _behavior_hash(original, behavior_version=BEHAVIOR_VERSION) == _behavior_hash(
+        changed,
+        behavior_version=BEHAVIOR_VERSION,
+    )
+    assert _config_hash(original_payload) != _config_hash(changed_payload)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda payload: payload["features"].update({"momentum_window": 8}), "config hash"),
+        (lambda payload: payload["paper"].update({"enabled": True}), "paper.enabled"),
+        (
+            lambda payload: payload["shadow"].update({"candidate_id": "unknown"}),
+            "Unknown shadow candidate_id",
+        ),
+        (
+            lambda payload: payload["shadow"].update({"protocol_start": "06/03/2026"}),
+            "YYYY-MM-DD",
+        ),
+        (
+            lambda payload: payload["shadow"].update({"protocol_start": 20260603}),
+            "YYYY-MM-DD",
+        ),
+        (
+            lambda payload: payload["shadow"].update({"maturity_lag_bars": 15}),
+            "maturity_lag_bars",
+        ),
+        (
+            lambda payload: payload["shadow"].update({"code_lock": "deadbeef"}),
+            "code_lock",
+        ),
+    ],
+)
+def test_shadow_contract_fails_closed_on_drift(
+    tmp_path: Path,
+    mutation: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    path = _write_mutation(tmp_path, mutation)
+
+    with pytest.raises(ShadowContractError, match=message):
+        verify_shadow_contract(path)
+
+
+def test_changed_candidate_cannot_rebless_itself(tmp_path: Path) -> None:
+    payload = _payload()
+    payload["features"]["momentum_window"] = 8
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    changed_path = config_dir / SHADOW_CONFIG.name
+    changed_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    changed_config = load_config(changed_path)
+    payload["shadow"]["config_hash"] = _config_hash(payload)
+    payload["shadow"]["behavior_hash"] = _behavior_hash(
+        changed_config,
+        behavior_version=BEHAVIOR_VERSION,
+    )
+    changed_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ShadowContractError, match="shadow.config_hash"):
+        verify_shadow_contract(changed_path)

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -110,7 +110,8 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
         assert parser[f"testenv:{env_name}"]["basepython"] == "py312"
     assert parser["testenv:typecheck"]["commands"].strip() == (
         "{envpython} -m mypy src/marketlab/config.py src/marketlab/log.py "
-        "src/marketlab/data/market.py src/marketlab/paper/alpaca.py "
+        "src/marketlab/data/market.py src/marketlab/shadow/contract.py "
+        "src/marketlab/paper/alpaca.py "
         "src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py "
         "src/marketlab/paper/observability.py src/marketlab/paper/contracts.py "
         "src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py "

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/shadow/contract.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
## Summary

- add the frozen Phase 9 BTC shadow configuration
- add an independently pinned, fail-closed contract verifier
- lock candidate metadata, strategy behavior, hashes, protocol dates, and paper-disabled safety
- document the P9-03 boundary consumed by the decision service

## Scope

This PR only establishes the frozen BTC shadow candidate contract. It does not fetch data, run models, schedule work, write decisions, generate reports, or enable paper execution.

## Validation

- Phase 9 contract, config, mutation, and documentation tests
- Ruff and mypy coverage for the typed contract surface
- strict MkDocs build
- included in the passing repository preflight on the stacked P9-04 head
