### PR TITLE
feat(phase9): add BTC shadow decision journal

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -115,7 +115,7 @@ clock.
 ### Planned Command Contract
 
 ```text
-phase9-shadow-decision --config configs/experiment.btc_phase9_shadow_daily.yaml
+phase9-shadow-decision --config configs/experiment.btc_phase9_shadow_daily.yaml --evaluation runtime-shadow-evaluation.json
 phase9-shadow-scheduler --config configs/experiment.btc_phase9_shadow_daily.yaml --once
 phase9-shadow-status --config configs/experiment.btc_phase9_shadow_daily.yaml
 phase9-shadow-report --config configs/experiment.btc_phase9_shadow_daily.yaml [--as-of YYYY-MM-DD]
@@ -316,7 +316,7 @@ working alerts, and a rehearsed rollback.
 | P9-01 | Canonical roadmap, Azure ADR, and protected docs tests | None | Legacy cloud plan removed; BTC, Azure, and QQQ boundaries explicit |
 | [P9-02](phase9/P9-02-WORKER-PLAN.md) | Terraform bootstrap and validation workflow | P9-01 | Remote state backend reproducible; CI validates all roots without applying |
 | [P9-03](phase9/P9-03-WORKER-PLAN.md) | Frozen BTC shadow config and behavior lock | P9-01 | Any drift fails closed; paper remains disabled |
-| P9-04 | Shadow decision service and append-only journal | P9-03 | Label-safe, idempotent, conflict-preserving decisions |
+| [P9-04](phase9/P9-04-WORKER-PLAN.md) | Shadow decision service and append-only journal | P9-03 | Label-safe, idempotent, conflict-preserving decisions |
 | P9-05 | Shadow scheduler, status, monthly, and final reports | P9-04 | Missing and failed runs explicit; reports cannot promote |
 | P9-06 | Azure shadow infrastructure and launch gate | P9-02, P9-05 | Disabled job validates; archive, restore, and alert tests pass |
 | P9-07 | Hosted execution context and deployment registry | P9-01 | All four paper phases share typed, idempotent metadata |

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,6 @@ This site is the canonical home for MarketLab's public documentation.
 - [Phase 9 P9-02 Worker Plan](phase9/P9-02-WORKER-PLAN.md)
 - [Phase 9 P9-02 Bootstrap Evidence](phase9/P9-02-BOOTSTRAP-EVIDENCE.md)
 - [Phase 9 P9-03 Worker Plan](phase9/P9-03-WORKER-PLAN.md)
+- [Phase 9 P9-04 Worker Plan](phase9/P9-04-WORKER-PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/phase9/P9-04-WORKER-PLAN.md
+++ b/docs/phase9/P9-04-WORKER-PLAN.md
@@ -1,0 +1,107 @@
+# P9-04 Worker Plan: BTC Shadow Decision Journal
+
+## Packet Identity
+
+- Branch: `feature/phase-9-btc-shadow-decision`
+- Pull request: `feat(phase9): add BTC shadow decision journal`
+- Dependency: P9-03 frozen BTC shadow contract
+
+P9-04 turns the verified P9-03 contract into a deterministic decision-record
+service. It validates completed-bar timing, derives the effective date and
+matured-label cutoff, fingerprints the inputs and output, and writes exactly
+one append-only JSON record per effective date.
+
+The packet does not schedule runs, generate monthly or final reports, enable
+paper execution, call a broker, change strategy settings, or define a second
+behavior hash. P9-05 owns scheduling, status aggregation, and reports.
+
+## Decision Boundary
+
+The service accepts a `VerifiedShadowContract`, a timezone-aware runtime as-of
+cutoff, BTC daily bars, and a typed evaluator. It derives a label-safe
+`ShadowDecisionContext` before invoking the evaluator. The returned
+`ShadowDecisionEvaluation` is the output of the frozen Phase 8 strategy path.
+P9-04 validates and journals that output; it does not duplicate the Phase 8
+model-selection implementation.
+
+Every invocation re-runs `verify_shadow_contract` before inspecting market
+data or writing a journal entry. The supplied contract metadata must match the
+fresh verification result.
+
+For a run at `2026-06-11T01:15:00Z`:
+
+- the `2026-06-11` in-progress daily bar is ignored
+- the latest completed signal bar must be `2026-06-10`
+- the effective date is `2026-06-11`
+- the 14-bar matured-label cutoff is `2026-05-27`
+
+BTC bars must be midnight UTC, unique, and continuous. The service rejects
+future bars, stale latest bars, missing daily bars, insufficient maturity
+history, non-BTC symbols, timezone-free cutoffs, and effective dates outside
+the frozen protocol. A stale run cannot reconstruct an earlier decision.
+
+## Record Contract
+
+Records are written under:
+
+```text
+artifacts/phase9-shadow/decisions/<effective-date>.json
+```
+
+Each record contains:
+
+- schema version and explicit `success`, `skipped`, or `failed` status
+- candidate ID, behavior version, config hash, behavior hash, and code lock
+- decision timestamp, signal date, effective date, and matured-label cutoff
+- selection source, fallback mode, and target allocation
+- deterministic input and output SHA-256 fingerprints
+- an explicit reason for skipped or failed evaluations
+
+Successful allocations are restricted to the frozen BTC tier set: `0.0`,
+`0.25`, `0.50`, or `1.0`. Selection and fallback metadata must agree. Skipped
+or failed evaluations use `selection_source: none`, have no target allocation,
+and require a reason.
+
+## Append-Only Rules
+
+The journal creates records with exclusive file creation. An identical repeat
+returns the existing record without rewriting it. Any changed metadata,
+fingerprint, status, or allocation for the same effective date raises
+`ShadowJournalConflictError` and preserves the original bytes.
+
+Read and list helpers verify the stored output fingerprint before returning a
+record. Malformed or modified evidence fails closed.
+
+## CLI
+
+The standalone wrapper directly delegates to the service:
+
+```text
+phase9-shadow-decision \
+  --config configs/experiment.btc_phase9_shadow_daily.yaml \
+  --evaluation runtime-shadow-evaluation.json \
+  [--panel artifacts/data-btc-phase9-shadow-1d/btc_usd_phase9_shadow_1d_panel.csv] \
+  [--as-of 2026-06-11T01:15:00Z]
+```
+
+The evaluation JSON contains `status`, `selection_source`, `fallback_mode`,
+`target_allocation`, optional `reason`, and an `input_payload` object used in
+the input fingerprint. The CLI defaults the panel to the verified config's
+prepared panel path and the cutoff to the current UTC time.
+
+## Validation And Acceptance
+
+Run:
+
+```text
+python -m pytest -q tests/unit/test_phase9_shadow_decision.py tests/unit/test_phase9_shadow_cli.py tests/unit/test_phase9_shadow_contract.py tests/unit/test_phase9_plan_docs.py
+python -m ruff check src/marketlab/shadow tests/unit/test_phase9_shadow_decision.py tests/unit/test_phase9_shadow_cli.py tests/unit/test_phase9_plan_docs.py
+python -m mypy src/marketlab/shadow/contract.py src/marketlab/shadow/decision.py src/marketlab/shadow/journal.py src/marketlab/shadow/cli.py
+python -m mkdocs build --strict
+py -3.14 -m tox -e preflight
+git diff --check
+```
+
+P9-04 is complete when valid decisions produce stable records, identical
+replays are idempotent, conflicting replays preserve the original evidence,
+and contract or timing drift fails before any journal write.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
   - Phase 9 P9-02 Worker Plan: phase9/P9-02-WORKER-PLAN.md
   - Phase 9 P9-02 Bootstrap Evidence: phase9/P9-02-BOOTSTRAP-EVIDENCE.md
   - Phase 9 P9-03 Worker Plan: phase9/P9-03-WORKER-PLAN.md
+  - Phase 9 P9-04 Worker Plan: phase9/P9-04-WORKER-PLAN.md
 plugins:
   - search
 extra_javascript:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 [project.scripts]
 marketlab = "marketlab.cli:main"
 marketlab-mcp = "marketlab.mcp.cli:main"
+phase9-shadow-decision = "marketlab.shadow.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/marketlab/shadow/__init__.py
+++ b/src/marketlab/shadow/__init__.py
@@ -5,9 +5,43 @@ from marketlab.shadow.contract import (
     VerifiedShadowContract,
     verify_shadow_contract,
 )
+from marketlab.shadow.decision import (
+    ShadowBar,
+    ShadowDecisionContext,
+    ShadowDecisionError,
+    ShadowDecisionEvaluation,
+    ShadowDecisionEvaluator,
+    ShadowDecisionRequest,
+    ShadowDecisionResult,
+    ShadowDecisionStatus,
+    run_shadow_decision,
+    shadow_bars_from_panel,
+)
+from marketlab.shadow.journal import (
+    ShadowDecisionJournal,
+    ShadowJournalConflictError,
+    ShadowJournalError,
+    canonical_fingerprint,
+    normalize_record_fingerprint,
+)
 
 __all__ = [
     "ShadowContractError",
+    "ShadowBar",
+    "ShadowDecisionError",
+    "ShadowDecisionContext",
+    "ShadowDecisionEvaluation",
+    "ShadowDecisionEvaluator",
+    "ShadowDecisionJournal",
+    "ShadowDecisionRequest",
+    "ShadowDecisionResult",
+    "ShadowDecisionStatus",
+    "ShadowJournalConflictError",
+    "ShadowJournalError",
     "VerifiedShadowContract",
+    "canonical_fingerprint",
+    "normalize_record_fingerprint",
+    "run_shadow_decision",
+    "shadow_bars_from_panel",
     "verify_shadow_contract",
 ]

--- a/src/marketlab/shadow/cli.py
+++ b/src/marketlab/shadow/cli.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from marketlab.data.panel import load_panel_csv
+from marketlab.shadow import (
+    ShadowDecisionEvaluation,
+    ShadowDecisionRequest,
+    run_shadow_decision,
+    shadow_bars_from_panel,
+    verify_shadow_contract,
+)
+from marketlab.shadow.decision import ShadowDecisionStatus
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="phase9-shadow-decision")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--evaluation", required=True)
+    parser.add_argument("--panel")
+    parser.add_argument("--as-of")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    contract = verify_shadow_contract(args.config)
+    evaluation = _load_evaluation(Path(args.evaluation))
+    panel_path = Path(args.panel).resolve() if args.panel else contract.config.prepared_panel_path
+    panel = load_panel_csv(panel_path)
+    as_of = _parse_as_of(args.as_of)
+    result = run_shadow_decision(
+        ShadowDecisionRequest(
+            contract=contract,
+            as_of=as_of,
+            bars=shadow_bars_from_panel(panel),
+        ),
+        evaluator=lambda context: evaluation,
+    )
+    print(result.path)
+    return 0
+
+
+def _load_evaluation(path: Path) -> ShadowDecisionEvaluation:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Unable to read shadow evaluation: {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Shadow evaluation must contain a JSON object.")
+    input_payload = payload.get("input_payload", {})
+    if not isinstance(input_payload, dict):
+        raise RuntimeError("Shadow evaluation input_payload must contain a JSON object.")
+    return ShadowDecisionEvaluation(
+        status=_status_value(payload),
+        selection_source=_string_value(payload, "selection_source"),
+        fallback_mode=_string_value(payload, "fallback_mode"),
+        target_allocation=_optional_float(payload.get("target_allocation")),
+        reason=_optional_string(payload.get("reason")),
+        input_payload=input_payload,
+    )
+
+
+def _parse_as_of(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(UTC)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError("--as-of must be an ISO-8601 datetime.") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeError("--as-of must include an explicit timezone.")
+    return parsed.astimezone(UTC)
+
+
+def _string_value(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or value.strip() == "":
+        raise RuntimeError(f"Shadow evaluation {key} must be a non-empty string.")
+    return value
+
+
+def _status_value(payload: dict[str, Any]) -> ShadowDecisionStatus:
+    value = _string_value(payload, "status")
+    if value == "success":
+        return "success"
+    if value == "skipped":
+        return "skipped"
+    if value == "failed":
+        return "failed"
+    raise RuntimeError(f"Unsupported shadow evaluation status: {value!r}.")
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RuntimeError("Shadow evaluation reason must be a string or null.")
+    return value
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(str(value))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "Shadow evaluation target_allocation must be numeric or null."
+        ) from exc

--- a/src/marketlab/shadow/decision.py
+++ b/src/marketlab/shadow/decision.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field, replace
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+import pandas as pd
+
+from marketlab.data.panel import PANEL_COLUMNS
+from marketlab.shadow.contract import VerifiedShadowContract, verify_shadow_contract
+from marketlab.shadow.journal import (
+    ShadowDecisionJournal,
+    ShadowJournalError,
+    ShadowJournalWrite,
+    canonical_fingerprint,
+)
+
+ShadowDecisionStatus = Literal["success", "skipped", "failed"]
+_ALLOWED_SELECTION_SOURCES = {
+    "strict",
+    "best_active_fallback",
+    "regime_policy_fallback",
+    "none",
+}
+_ALLOWED_FALLBACK_MODES = {
+    "none",
+    "best_active_fallback",
+    "regime_policy_fallback",
+}
+_ALLOWED_ALLOCATIONS = (0.0, 0.25, 0.50, 1.0)
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+class ShadowDecisionError(RuntimeError):
+    """Raised when a shadow decision would violate the frozen protocol."""
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowBar:
+    symbol: str
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    adj_close: float
+    adj_open: float
+    adj_high: float
+    adj_low: float
+
+    def as_fingerprint_payload(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "timestamp": _iso_utc(self.timestamp),
+            "open": self.open,
+            "high": self.high,
+            "low": self.low,
+            "close": self.close,
+            "volume": self.volume,
+            "adj_close": self.adj_close,
+            "adj_open": self.adj_open,
+            "adj_high": self.adj_high,
+            "adj_low": self.adj_low,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDecisionEvaluation:
+    status: ShadowDecisionStatus
+    selection_source: str
+    fallback_mode: str
+    target_allocation: float | None
+    reason: str | None = None
+    input_payload: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDecisionRequest:
+    contract: VerifiedShadowContract
+    as_of: datetime
+    bars: tuple[ShadowBar, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDecisionContext:
+    contract: VerifiedShadowContract
+    as_of: datetime
+    completed_bars: tuple[ShadowBar, ...]
+    signal_date: date
+    effective_date: date
+    matured_label_cutoff: date
+
+
+ShadowDecisionEvaluator = Callable[[ShadowDecisionContext], ShadowDecisionEvaluation]
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowDecisionResult:
+    path: Path
+    record: dict[str, Any]
+    created: bool
+
+
+def shadow_bars_from_panel(panel: pd.DataFrame) -> tuple[ShadowBar, ...]:
+    missing = [column for column in PANEL_COLUMNS if column not in panel.columns]
+    if missing:
+        joined = ", ".join(missing)
+        raise ShadowDecisionError(f"Shadow panel is missing required columns: {joined}")
+
+    bars: list[ShadowBar] = []
+    for row in panel.sort_values(["timestamp", "symbol"]).itertuples(index=False):
+        bars.append(
+            ShadowBar(
+                symbol=str(row.symbol),
+                timestamp=_as_utc_datetime(row.timestamp, label="bar timestamp"),
+                open=_finite_float(row.open, label="open"),
+                high=_finite_float(row.high, label="high"),
+                low=_finite_float(row.low, label="low"),
+                close=_finite_float(row.close, label="close"),
+                volume=_finite_float(row.volume, label="volume"),
+                adj_close=_finite_float(row.adj_close, label="adj_close"),
+                adj_open=_finite_float(row.adj_open, label="adj_open"),
+                adj_high=_finite_float(row.adj_high, label="adj_high"),
+                adj_low=_finite_float(row.adj_low, label="adj_low"),
+            )
+        )
+    return tuple(bars)
+
+
+def run_shadow_decision(
+    request: ShadowDecisionRequest,
+    *,
+    evaluator: ShadowDecisionEvaluator,
+    journal: ShadowDecisionJournal | None = None,
+) -> ShadowDecisionResult:
+    contract = verify_shadow_contract(request.contract.config_path)
+    _require_same_contract(request.contract, contract)
+    as_of = _as_utc_datetime(request.as_of, label="as_of")
+    completed_bars = _completed_bars(request.bars, as_of=as_of)
+    signal_date, effective_date, matured_label_cutoff = _decision_dates(
+        completed_bars,
+        as_of=as_of,
+        contract=contract,
+    )
+    context = ShadowDecisionContext(
+        contract=contract,
+        as_of=as_of,
+        completed_bars=completed_bars,
+        signal_date=signal_date,
+        effective_date=effective_date,
+        matured_label_cutoff=matured_label_cutoff,
+    )
+    evaluation = _validated_evaluation(evaluator(context))
+    input_fingerprint = _input_fingerprint(
+        contract=contract,
+        as_of=as_of,
+        completed_bars=completed_bars,
+        evaluation=evaluation,
+    )
+    record: dict[str, Any] = {
+        "schema_version": 1,
+        "candidate_id": contract.candidate_id,
+        "behavior_version": contract.behavior_version,
+        "config_hash": contract.config_hash,
+        "behavior_hash": contract.behavior_hash,
+        "code_lock": contract.code_lock,
+        "decision_timestamp": _iso_utc(as_of),
+        "signal_date": signal_date.isoformat(),
+        "effective_date": effective_date.isoformat(),
+        "matured_label_cutoff": matured_label_cutoff.isoformat(),
+        "selection_source": evaluation.selection_source,
+        "fallback_mode": evaluation.fallback_mode,
+        "target_allocation": evaluation.target_allocation,
+        "input_fingerprint": input_fingerprint,
+        "status": evaluation.status,
+        "reason": evaluation.reason,
+    }
+    selected_journal = journal or ShadowDecisionJournal(
+        contract.artifact_root / "decisions"
+    )
+    write = selected_journal.write(record)
+    return _result_from_write(write)
+
+
+def _result_from_write(write: ShadowJournalWrite) -> ShadowDecisionResult:
+    return ShadowDecisionResult(
+        path=write.path,
+        record=write.record,
+        created=write.created,
+    )
+
+
+def _require_same_contract(
+    supplied: VerifiedShadowContract,
+    verified: VerifiedShadowContract,
+) -> None:
+    fields = (
+        "config_path",
+        "candidate_id",
+        "behavior_version",
+        "protocol_start",
+        "protocol_end",
+        "earliest_final_evaluation",
+        "maturity_lag_bars",
+        "code_lock",
+        "artifact_root",
+        "config_hash",
+        "behavior_hash",
+    )
+    for field_name in fields:
+        if getattr(supplied, field_name) != getattr(verified, field_name):
+            raise ShadowDecisionError(
+                f"Supplied shadow contract field {field_name} differs from re-verification."
+            )
+
+
+def _completed_bars(
+    bars: tuple[ShadowBar, ...],
+    *,
+    as_of: datetime,
+) -> tuple[ShadowBar, ...]:
+    if not bars:
+        raise ShadowDecisionError("Shadow decision requires market bars.")
+
+    normalized: list[ShadowBar] = []
+    seen: set[tuple[str, datetime]] = set()
+    for bar in bars:
+        timestamp = _as_utc_datetime(bar.timestamp, label="bar timestamp")
+        if timestamp.hour != 0 or timestamp.minute != 0 or timestamp.second != 0:
+            raise ShadowDecisionError("Daily shadow bars must use midnight UTC timestamps.")
+        if timestamp > as_of:
+            raise ShadowDecisionError("Shadow bars must not be timestamped after the as-of cutoff.")
+        if bar.symbol != "BTC-USD":
+            raise ShadowDecisionError("Shadow decisions only accept BTC-USD bars.")
+        key = (bar.symbol, timestamp)
+        if key in seen:
+            raise ShadowDecisionError("Shadow bars must not contain duplicate timestamps.")
+        seen.add(key)
+        validated_bar = replace(
+            bar,
+            timestamp=timestamp,
+            open=_finite_float(bar.open, label="open"),
+            high=_finite_float(bar.high, label="high"),
+            low=_finite_float(bar.low, label="low"),
+            close=_finite_float(bar.close, label="close"),
+            volume=_finite_float(bar.volume, label="volume"),
+            adj_close=_finite_float(bar.adj_close, label="adj_close"),
+            adj_open=_finite_float(bar.adj_open, label="adj_open"),
+            adj_high=_finite_float(bar.adj_high, label="adj_high"),
+            adj_low=_finite_float(bar.adj_low, label="adj_low"),
+        )
+        if timestamp + timedelta(days=1) <= as_of:
+            normalized.append(validated_bar)
+
+    completed = tuple(sorted(normalized, key=lambda bar: bar.timestamp))
+    if not completed:
+        raise ShadowDecisionError("No completed daily bar is available at the as-of cutoff.")
+    for previous, current in zip(completed, completed[1:], strict=False):
+        if current.timestamp - previous.timestamp != timedelta(days=1):
+            raise ShadowDecisionError(
+                "Shadow BTC daily bars must be continuous through the as-of cutoff."
+            )
+    return completed
+
+
+def _decision_dates(
+    completed_bars: tuple[ShadowBar, ...],
+    *,
+    as_of: datetime,
+    contract: VerifiedShadowContract,
+) -> tuple[date, date, date]:
+    signal_date = completed_bars[-1].timestamp.date()
+    effective_date = signal_date + timedelta(days=1)
+    if as_of.date() != effective_date:
+        raise ShadowDecisionError(
+            "The latest completed bar must be the immediately preceding UTC day; "
+            "missed dates cannot be backfilled."
+        )
+    if not contract.protocol_start <= effective_date <= contract.protocol_end:
+        raise ShadowDecisionError(
+            "Shadow decision effective date is outside the frozen protocol window."
+        )
+    cutoff_index = len(completed_bars) - 1 - contract.maturity_lag_bars
+    if cutoff_index < 0:
+        raise ShadowDecisionError(
+            "Shadow decision does not have enough completed bars for the maturity cutoff."
+        )
+    matured_label_cutoff = completed_bars[cutoff_index].timestamp.date()
+    return signal_date, effective_date, matured_label_cutoff
+
+
+def _validated_evaluation(
+    evaluation: ShadowDecisionEvaluation,
+) -> ShadowDecisionEvaluation:
+    if evaluation.status not in {"success", "skipped", "failed"}:
+        raise ShadowDecisionError(f"Unsupported shadow decision status: {evaluation.status!r}.")
+    if evaluation.selection_source not in _ALLOWED_SELECTION_SOURCES:
+        raise ShadowDecisionError(
+            f"Unsupported shadow selection source: {evaluation.selection_source!r}."
+        )
+    if evaluation.fallback_mode not in _ALLOWED_FALLBACK_MODES:
+        raise ShadowDecisionError(
+            f"Unsupported shadow fallback mode: {evaluation.fallback_mode!r}."
+        )
+
+    expected_fallback = {
+        "strict": "none",
+        "best_active_fallback": "best_active_fallback",
+        "regime_policy_fallback": "regime_policy_fallback",
+        "none": "none",
+    }[evaluation.selection_source]
+    if evaluation.fallback_mode != expected_fallback:
+        raise ShadowDecisionError(
+            "Shadow fallback_mode must match the recorded selection_source."
+        )
+
+    if evaluation.status == "success":
+        if evaluation.selection_source == "none":
+            raise ShadowDecisionError("Successful shadow decisions require a selection source.")
+        if evaluation.target_allocation is None:
+            raise ShadowDecisionError("Successful shadow decisions require target_allocation.")
+        target_allocation = _finite_float(
+            evaluation.target_allocation,
+            label="target_allocation",
+        )
+        if target_allocation not in _ALLOWED_ALLOCATIONS:
+            raise ShadowDecisionError(
+                "Shadow target_allocation must be one of 0.0, 0.25, 0.5, or 1.0."
+            )
+    else:
+        if evaluation.selection_source != "none":
+            raise ShadowDecisionError(
+                "Skipped or failed shadow decisions must use selection_source='none'."
+            )
+        if evaluation.target_allocation is not None:
+            raise ShadowDecisionError(
+                "Skipped or failed shadow decisions must not set target_allocation."
+            )
+        if evaluation.reason is None or evaluation.reason.strip() == "":
+            raise ShadowDecisionError(
+                "Skipped or failed shadow decisions require an explicit reason."
+            )
+
+    try:
+        canonical_fingerprint(dict(evaluation.input_payload))
+    except (TypeError, ValueError, ShadowJournalError) as exc:
+        raise ShadowDecisionError(
+            "Shadow decision input_payload must be a deterministic JSON mapping."
+        ) from exc
+    return evaluation
+
+
+def _input_fingerprint(
+    *,
+    contract: VerifiedShadowContract,
+    as_of: datetime,
+    completed_bars: tuple[ShadowBar, ...],
+    evaluation: ShadowDecisionEvaluation,
+) -> str:
+    fingerprint = canonical_fingerprint(
+        {
+            "candidate_id": contract.candidate_id,
+            "behavior_version": contract.behavior_version,
+            "config_hash": contract.config_hash,
+            "behavior_hash": contract.behavior_hash,
+            "code_lock": contract.code_lock,
+            "as_of": _iso_utc(as_of),
+            "completed_bars": [
+                bar.as_fingerprint_payload() for bar in completed_bars
+            ],
+            "evaluation_input": dict(evaluation.input_payload),
+        }
+    )
+    if _SHA256_PATTERN.fullmatch(fingerprint) is None:
+        raise ShadowDecisionError("Shadow input fingerprint must be SHA-256.")
+    return fingerprint
+
+
+def _as_utc_datetime(value: object, *, label: str) -> datetime:
+    try:
+        timestamp = pd.Timestamp(value)
+    except (TypeError, ValueError) as exc:
+        raise ShadowDecisionError(f"Shadow {label} must be a datetime.") from exc
+    if timestamp.tzinfo is None:
+        if label == "as_of":
+            raise ShadowDecisionError("Shadow as_of must include an explicit timezone.")
+        timestamp = timestamp.tz_localize(UTC)
+    else:
+        timestamp = timestamp.tz_convert(UTC)
+    return timestamp.to_pydatetime()
+
+
+def _finite_float(value: object, *, label: str) -> float:
+    try:
+        resolved = float(str(value))
+    except (TypeError, ValueError) as exc:
+        raise ShadowDecisionError(f"Shadow {label} must be numeric.") from exc
+    if not math.isfinite(resolved):
+        raise ShadowDecisionError(f"Shadow {label} must be finite.")
+    return resolved
+
+
+def _iso_utc(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/src/marketlab/shadow/journal.py
+++ b/src/marketlab/shadow/journal.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+class ShadowJournalError(RuntimeError):
+    """Raised when the shadow decision journal cannot preserve its contract."""
+
+
+class ShadowJournalConflictError(ShadowJournalError):
+    """Raised when an effective date already contains a different decision."""
+
+
+def canonical_fingerprint(payload: object) -> str:
+    try:
+        encoded = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ShadowJournalError(
+            "Shadow decision values must support deterministic JSON hashing."
+        ) from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def normalize_record_fingerprint(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized.pop("output_fingerprint", None)
+    normalized["output_fingerprint"] = canonical_fingerprint(normalized)
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowJournalWrite:
+    path: Path
+    record: dict[str, Any]
+    created: bool
+
+
+class ShadowDecisionJournal:
+    def __init__(self, decisions_root: str | Path) -> None:
+        self._decisions_root = Path(decisions_root)
+
+    @property
+    def decisions_root(self) -> Path:
+        return self._decisions_root
+
+    def path_for(self, effective_date: date) -> Path:
+        return self._decisions_root / f"{effective_date.isoformat()}.json"
+
+    def read(self, effective_date: date) -> dict[str, Any] | None:
+        path = self.path_for(effective_date)
+        if not path.exists():
+            return None
+        return self._load(path)
+
+    def list(self) -> list[dict[str, Any]]:
+        if not self._decisions_root.exists():
+            return []
+        return [self._load(path) for path in sorted(self._decisions_root.glob("*.json"))]
+
+    def write(self, record: dict[str, Any]) -> ShadowJournalWrite:
+        normalized = normalize_record_fingerprint(record)
+        try:
+            effective_date = date.fromisoformat(str(normalized["effective_date"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ShadowJournalError(
+                "Shadow decision records require an ISO effective_date."
+            ) from exc
+
+        path = self.path_for(effective_date)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(
+            normalized,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+        try:
+            with path.open("x", encoding="utf-8", newline="\n") as handle:
+                handle.write(serialized)
+        except FileExistsError:
+            existing = self._load(path)
+            if existing == normalized:
+                return ShadowJournalWrite(path=path, record=existing, created=False)
+            raise ShadowJournalConflictError(
+                f"Shadow decision conflict for effective date {effective_date.isoformat()}; "
+                "the original journal record was preserved."
+            ) from None
+        except OSError as exc:
+            raise ShadowJournalError(f"Unable to write shadow decision: {path}") from exc
+        return ShadowJournalWrite(path=path, record=normalized, created=True)
+
+    @staticmethod
+    def _load(path: Path) -> dict[str, Any]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ShadowJournalError(f"Unable to read shadow decision: {path}") from exc
+        if not isinstance(payload, dict):
+            raise ShadowJournalError(f"Shadow decision must contain a JSON object: {path}")
+        try:
+            filename_date = date.fromisoformat(path.stem)
+            payload_date = date.fromisoformat(str(payload["effective_date"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ShadowJournalError(
+                f"Shadow decision path and effective_date must use ISO dates: {path}"
+            ) from exc
+        if payload_date != filename_date:
+            raise ShadowJournalError(
+                f"Shadow decision effective_date does not match its path: {path}"
+            )
+        normalized = normalize_record_fingerprint(payload)
+        if payload != normalized:
+            raise ShadowJournalError(
+                f"Shadow decision output fingerprint does not match its payload: {path}"
+            )
+        return payload

--- a/tests/unit/test_phase9_plan_docs.py
+++ b/tests/unit/test_phase9_plan_docs.py
@@ -7,6 +7,7 @@ PLAN = ROOT / "docs" / "PLAN.md"
 P9_02_PLAN = ROOT / "docs" / "phase9" / "P9-02-WORKER-PLAN.md"
 P9_02_EVIDENCE = ROOT / "docs" / "phase9" / "P9-02-BOOTSTRAP-EVIDENCE.md"
 P9_03_PLAN = ROOT / "docs" / "phase9" / "P9-03-WORKER-PLAN.md"
+P9_04_PLAN = ROOT / "docs" / "phase9" / "P9-04-WORKER-PLAN.md"
 
 
 def test_phase9_plan_replaces_obsolete_cloud_plan() -> None:
@@ -154,3 +155,35 @@ def test_p9_03_plan_is_linked_from_docs() -> None:
     assert "phase9/P9-03-WORKER-PLAN.md" in roadmap
     assert "Phase 9 P9-03 Worker Plan: phase9/P9-03-WORKER-PLAN.md" in nav
     assert "phase9/P9-03-WORKER-PLAN.md" in index
+
+
+def test_p9_04_plan_locks_decision_and_journal_scope() -> None:
+    content = P9_04_PLAN.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    required = [
+        "feature/phase-9-btc-shadow-decision",
+        "verify_shadow_contract",
+        "ShadowDecisionEvaluation",
+        "2026-05-27",
+        "artifacts/phase9-shadow/decisions/<effective-date>.json",
+        "ShadowJournalConflictError",
+        "identical repeat",
+        "does not schedule runs",
+        "cannot reconstruct an earlier decision",
+        "phase9-shadow-decision",
+    ]
+
+    assert all(term in normalized for term in required)
+
+
+def test_p9_04_plan_is_linked_from_docs_and_cli_metadata() -> None:
+    roadmap = PLAN.read_text(encoding="utf-8")
+    nav = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "phase9/P9-04-WORKER-PLAN.md" in roadmap
+    assert "Phase 9 P9-04 Worker Plan: phase9/P9-04-WORKER-PLAN.md" in nav
+    assert "phase9/P9-04-WORKER-PLAN.md" in index
+    assert 'phase9-shadow-decision = "marketlab.shadow.cli:main"' in pyproject

--- a/tests/unit/test_phase9_shadow_cli.py
+++ b/tests/unit/test_phase9_shadow_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+from marketlab.shadow import cli
+
+
+def test_shadow_cli_delegates_to_service(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    evaluation_path = tmp_path / "evaluation.json"
+    evaluation_path.write_text(
+        """{
+  "status": "success",
+  "selection_source": "strict",
+  "fallback_mode": "none",
+  "target_allocation": 0.5,
+  "input_payload": {"score": 0.61}
+}
+""",
+        encoding="utf-8",
+    )
+    panel_path = tmp_path / "panel.csv"
+    panel_path.write_text("unused", encoding="utf-8")
+    contract = SimpleNamespace(
+        config_path=Path("config.yaml"),
+        config=SimpleNamespace(prepared_panel_path=panel_path),
+    )
+    panel = pd.DataFrame()
+    captured = {}
+
+    monkeypatch.setattr(cli, "verify_shadow_contract", lambda path: contract)
+    monkeypatch.setattr(cli, "load_panel_csv", lambda path: panel)
+    monkeypatch.setattr(cli, "shadow_bars_from_panel", lambda frame: ("bar",))
+
+    def _run(request, *, evaluator):
+        captured["request"] = request
+        captured["evaluation"] = evaluator(None)
+        return SimpleNamespace(path=tmp_path / "decisions" / "2026-06-11.json")
+
+    monkeypatch.setattr(cli, "run_shadow_decision", _run)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            "config.yaml",
+            "--evaluation",
+            str(evaluation_path),
+            "--panel",
+            str(panel_path),
+            "--as-of",
+            "2026-06-11T01:15:00Z",
+        ]
+    )
+
+    request = captured["request"]
+    assert exit_code == 0
+    assert request.contract is contract
+    assert request.bars == ("bar",)
+    assert request.as_of == datetime(2026, 6, 11, 1, 15, tzinfo=UTC)
+    assert captured["evaluation"].target_allocation == 0.5
+    assert capsys.readouterr().out.strip().endswith("2026-06-11.json")

--- a/tests/unit/test_phase9_shadow_decision.py
+++ b/tests/unit/test_phase9_shadow_decision.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from marketlab.shadow import (
+    ShadowBar,
+    ShadowContractError,
+    ShadowDecisionError,
+    ShadowDecisionEvaluation,
+    ShadowDecisionJournal,
+    ShadowDecisionRequest,
+    ShadowDecisionStatus,
+    ShadowJournalConflictError,
+    ShadowJournalError,
+    canonical_fingerprint,
+    normalize_record_fingerprint,
+    run_shadow_decision,
+    verify_shadow_contract,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SHADOW_CONFIG = ROOT / "configs" / "experiment.btc_phase9_shadow_daily.yaml"
+AS_OF = datetime(2026, 6, 11, 1, 15, tzinfo=UTC)
+
+
+def _bars(
+    *,
+    symbol: str = "BTC-USD",
+    end: datetime = datetime(2026, 6, 11, tzinfo=UTC),
+    count: int = 72,
+) -> tuple[ShadowBar, ...]:
+    start = end - timedelta(days=count - 1)
+    return tuple(
+        ShadowBar(
+            symbol=symbol,
+            timestamp=start + timedelta(days=index),
+            open=100.0 + index,
+            high=101.0 + index,
+            low=99.0 + index,
+            close=100.5 + index,
+            volume=1_000.0 + index,
+            adj_close=100.5 + index,
+            adj_open=100.0 + index,
+            adj_high=101.0 + index,
+            adj_low=99.0 + index,
+        )
+        for index in range(count)
+    )
+
+
+def _evaluation(
+    *,
+    status: str = "success",
+    selection_source: str = "strict",
+    fallback_mode: str = "none",
+    target_allocation: float | None = 0.50,
+    reason: str | None = None,
+) -> ShadowDecisionEvaluation:
+    return ShadowDecisionEvaluation(
+        status=cast(ShadowDecisionStatus, status),
+        selection_source=selection_source,
+        fallback_mode=fallback_mode,
+        target_allocation=target_allocation,
+        reason=reason,
+        input_payload={
+            "selected_model": "hist_gradient_boosting",
+            "score": 0.61,
+            "validation": {"passed": True, "rows": 180},
+        },
+    )
+
+
+def _request(
+    *,
+    bars: tuple[ShadowBar, ...] | None = None,
+    as_of: datetime = AS_OF,
+) -> ShadowDecisionRequest:
+    return ShadowDecisionRequest(
+        contract=verify_shadow_contract(SHADOW_CONFIG),
+        as_of=as_of,
+        bars=bars or _bars(),
+    )
+
+
+def _run(
+    request: ShadowDecisionRequest,
+    *,
+    journal: ShadowDecisionJournal,
+    evaluation: ShadowDecisionEvaluation | None = None,
+):
+    return run_shadow_decision(
+        request,
+        evaluator=lambda context: evaluation or _evaluation(),
+        journal=journal,
+    )
+
+
+def test_shadow_decision_writes_stable_success_record(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    result = _run(_request(), journal=journal)
+
+    assert result.created is True
+    assert result.path == tmp_path / "decisions" / "2026-06-11.json"
+    assert result.record == journal.read(datetime(2026, 6, 11).date())
+    assert result.record["candidate_id"] == "btc-phase9-shadow-v1"
+    assert result.record["behavior_version"] == "btc-phase8-guarded-gate-v1"
+    assert result.record["signal_date"] == "2026-06-10"
+    assert result.record["effective_date"] == "2026-06-11"
+    assert result.record["matured_label_cutoff"] == "2026-05-27"
+    assert result.record["selection_source"] == "strict"
+    assert result.record["fallback_mode"] == "none"
+    assert result.record["target_allocation"] == 0.50
+    assert result.record["status"] == "success"
+    assert len(result.record["input_fingerprint"]) == 64
+    assert result.record == normalize_record_fingerprint(result.record)
+
+
+def test_identical_shadow_decision_rerun_is_idempotent(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    request = _request()
+    first = _run(request, journal=journal)
+    original_bytes = first.path.read_bytes()
+
+    second = _run(request, journal=journal)
+
+    assert second.created is False
+    assert second.path == first.path
+    assert second.record == first.record
+    assert second.path.read_bytes() == original_bytes
+
+
+def test_conflicting_shadow_decision_preserves_original(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    original = _run(_request(), journal=journal)
+    original_bytes = original.path.read_bytes()
+
+    with pytest.raises(ShadowJournalConflictError, match="original journal record"):
+        _run(
+            _request(),
+            journal=journal,
+            evaluation=_evaluation(target_allocation=1.0),
+        )
+
+    assert original.path.read_bytes() == original_bytes
+    assert journal.read(datetime(2026, 6, 11).date()) == original.record
+
+
+def test_shadow_decision_records_explicit_skip(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    result = _run(
+        _request(),
+        journal=journal,
+        evaluation=_evaluation(
+            status="skipped",
+            selection_source="none",
+            fallback_mode="none",
+            target_allocation=None,
+            reason="no_valid_candidate",
+        ),
+    )
+
+    assert result.record["status"] == "skipped"
+    assert result.record["reason"] == "no_valid_candidate"
+    assert result.record["target_allocation"] is None
+
+
+def test_evaluator_receives_label_safe_decision_context(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    captured = {}
+
+    def _evaluate(context):
+        captured["context"] = context
+        return _evaluation()
+
+    run_shadow_decision(_request(), evaluator=_evaluate, journal=journal)
+
+    context = captured["context"]
+    assert context.signal_date.isoformat() == "2026-06-10"
+    assert context.effective_date.isoformat() == "2026-06-11"
+    assert context.matured_label_cutoff.isoformat() == "2026-05-27"
+    assert context.completed_bars[-1].timestamp.date() == context.signal_date
+    assert all(
+        bar.timestamp.date() <= context.signal_date for bar in context.completed_bars
+    )
+
+
+def test_shadow_journal_lists_records_by_effective_date(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    first = normalize_record_fingerprint(
+        {"effective_date": "2026-06-11", "status": "skipped"}
+    )
+    second = normalize_record_fingerprint(
+        {"effective_date": "2026-06-12", "status": "failed"}
+    )
+
+    journal.write(second)
+    journal.write(first)
+
+    assert journal.list() == [first, second]
+
+
+def test_record_fingerprint_is_independent_of_mapping_order() -> None:
+    left = {"effective_date": "2026-06-11", "status": "success", "nested": {"b": 2, "a": 1}}
+    right = {"nested": {"a": 1, "b": 2}, "status": "success", "effective_date": "2026-06-11"}
+
+    assert canonical_fingerprint(left) == canonical_fingerprint(right)
+    assert normalize_record_fingerprint(left)["output_fingerprint"] == (
+        normalize_record_fingerprint(right)["output_fingerprint"]
+    )
+
+
+def test_shadow_journal_rejects_modified_record(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    write = journal.write({"effective_date": "2026-06-11", "status": "success"})
+    write.path.write_text(
+        write.path.read_text(encoding="utf-8").replace('"status": "success"', '"status": "failed"'),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ShadowJournalError, match="fingerprint"):
+        journal.read(datetime(2026, 6, 11).date())
+
+
+def test_shadow_journal_rejects_effective_date_path_mismatch(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    write = journal.write({"effective_date": "2026-06-11", "status": "success"})
+    mismatched_path = write.path.with_name("2026-06-12.json")
+    write.path.rename(mismatched_path)
+
+    with pytest.raises(ShadowJournalError, match="does not match its path"):
+        journal.list()
+
+
+@pytest.mark.parametrize(
+    ("bars", "as_of", "message"),
+    [
+        (_bars(symbol="ETH-USD"), AS_OF, "only accept BTC-USD"),
+        (_bars(end=datetime(2026, 6, 9, tzinfo=UTC)), AS_OF, "cannot be backfilled"),
+        (
+            _bars(end=datetime(2026, 6, 12, tzinfo=UTC)),
+            AS_OF,
+            "after the as-of cutoff",
+        ),
+        (_bars(count=10), AS_OF, "enough completed bars"),
+        (_bars(), datetime(2026, 6, 11, 1, 15), "explicit timezone"),
+    ],
+)
+def test_shadow_decision_rejects_timing_and_market_drift_before_write(
+    tmp_path: Path,
+    bars: tuple[ShadowBar, ...],
+    as_of: datetime,
+    message: str,
+) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    with pytest.raises(ShadowDecisionError, match=message):
+        _run(
+            _request(bars=bars, as_of=as_of),
+            journal=journal,
+        )
+
+    assert journal.list() == []
+
+
+def test_shadow_decision_rejects_missing_daily_bar_before_write(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    bars = _bars()
+    bars_with_gap = bars[:20] + bars[21:]
+
+    with pytest.raises(ShadowDecisionError, match="must be continuous"):
+        _run(_request(bars=bars_with_gap), journal=journal)
+
+    assert journal.list() == []
+
+
+def test_shadow_decision_reverifies_contract_before_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    def _reject(path: str | Path) -> None:
+        raise ShadowContractError(f"drift: {path}")
+
+    monkeypatch.setattr("marketlab.shadow.decision.verify_shadow_contract", _reject)
+
+    with pytest.raises(ShadowContractError, match="drift"):
+        _run(_request(), journal=journal)
+
+    assert journal.list() == []
+
+
+def test_shadow_decision_rejects_supplied_contract_mismatch(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+    request = _request()
+    changed_contract = replace(request.contract, behavior_hash="0" * 64)
+
+    with pytest.raises(ShadowDecisionError, match="behavior_hash"):
+        _run(
+            replace(request, contract=changed_contract),
+            journal=journal,
+        )
+
+    assert journal.list() == []
+
+
+@pytest.mark.parametrize(
+    "evaluation",
+    [
+        _evaluation(selection_source="strict", fallback_mode="regime_policy_fallback"),
+        _evaluation(target_allocation=0.75),
+        _evaluation(
+            status="failed",
+            selection_source="none",
+            fallback_mode="none",
+            target_allocation=None,
+            reason=None,
+        ),
+    ],
+)
+def test_shadow_decision_rejects_invalid_evaluation_before_write(
+    tmp_path: Path,
+    evaluation: ShadowDecisionEvaluation,
+) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    with pytest.raises(ShadowDecisionError):
+        _run(_request(), journal=journal, evaluation=evaluation)
+
+    assert journal.list() == []

--- a/tests/unit/test_phase9_shadow_decision.py
+++ b/tests/unit/test_phase9_shadow_decision.py
@@ -171,6 +171,26 @@ def test_shadow_decision_records_explicit_skip(tmp_path: Path) -> None:
     assert result.record["target_allocation"] is None
 
 
+def test_shadow_decision_records_explicit_failure(tmp_path: Path) -> None:
+    journal = ShadowDecisionJournal(tmp_path / "decisions")
+
+    result = _run(
+        _request(),
+        journal=journal,
+        evaluation=_evaluation(
+            status="failed",
+            selection_source="none",
+            fallback_mode="none",
+            target_allocation=None,
+            reason="evaluation_error",
+        ),
+    )
+
+    assert result.record["status"] == "failed"
+    assert result.record["reason"] == "evaluation_error"
+    assert result.record["target_allocation"] is None
+
+
 def test_evaluator_receives_label_safe_decision_context(tmp_path: Path) -> None:
     journal = ShadowDecisionJournal(tmp_path / "decisions")
     captured = {}

--- a/tests/unit/test_profile_validation.py
+++ b/tests/unit/test_profile_validation.py
@@ -111,6 +111,8 @@ def test_tox_preflight_tiers_match_expected_commands() -> None:
     assert parser["testenv:typecheck"]["commands"].strip() == (
         "{envpython} -m mypy src/marketlab/config.py src/marketlab/log.py "
         "src/marketlab/data/market.py src/marketlab/shadow/contract.py "
+        "src/marketlab/shadow/decision.py src/marketlab/shadow/journal.py "
+        "src/marketlab/shadow/cli.py "
         "src/marketlab/paper/alpaca.py "
         "src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py "
         "src/marketlab/paper/observability.py src/marketlab/paper/contracts.py "

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ package = editable
 deps =
     mypy>=1.20
 commands =
-    {envpython} -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/shadow/contract.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
+    {envpython} -m mypy src/marketlab/config.py src/marketlab/log.py src/marketlab/data/market.py src/marketlab/shadow/contract.py src/marketlab/shadow/decision.py src/marketlab/shadow/journal.py src/marketlab/shadow/cli.py src/marketlab/paper/alpaca.py src/marketlab/paper/approval_clients.py src/marketlab/paper/notifications.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/application/decision.py src/marketlab/paper/application/approval.py src/marketlab/paper/application/submission.py src/marketlab/paper/application/reconciliation.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py
 
 [testenv:package]
 description = Build source and wheel distributions


### PR DESCRIPTION
## Summary

- add a typed, label-safe BTC shadow decision service
- derive completed-bar signal/effective dates and the 14-bar matured-label cutoff
- add an append-only decision journal with idempotent replay and conflict preservation
- add deterministic input/output fingerprints and explicit success, skipped, and failed records
- add the thin `phase9-shadow-decision` CLI and P9-04 documentation

## Scope

This PR is stacked on P9-03 and contains only the P9-04 decision/journal packet. It does not add scheduling, status aggregation, reports, Azure infrastructure, strategy tuning, or paper execution.

After P9-03 merges, this PR should be retargeted from `feature/phase-9-btc-shadow-lock` to `master` before merging.

## Validation

- `py -3.14 -m tox -e preflight`
- 625 unit tests passed
- 50 offline integration tests passed, with 2 opt-in tests deselected
- Ruff, mypy, strict MkDocs, package verification, and `git diff --check` passed
