### PR TITLE
feat(phase9): add BTC shadow Azure launch gate

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -44,6 +44,7 @@ jobs:
             pyproject.toml
             tox.ini
             infra/azure/bootstrap/.terraform.lock.hcl
+            infra/azure/phase9-shadow/.terraform.lock.hcl
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ __pycache__/
 **/terraform.rc
 **/credentials.tfrc.json
 infra/azure/bootstrap/backend.tf
+infra/azure/phase9-shadow/backend.tf
 .terraform.tfstate.lock.info
 crash.log
 crash.*.log

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -321,7 +321,7 @@ working alerts, and a rehearsed rollback.
 | [P9-03](phase9/P9-03-WORKER-PLAN.md) | Frozen BTC shadow config and behavior lock | P9-01 | Any drift fails closed; paper remains disabled |
 | [P9-04](phase9/P9-04-WORKER-PLAN.md) | Shadow decision service and append-only journal | P9-03 | Label-safe, idempotent, conflict-preserving decisions |
 | P9-05 | Shadow scheduler, status, monthly, and final reports | P9-04 | Missing and failed runs explicit; reports cannot promote |
-| P9-06 | Azure shadow infrastructure and launch gate | P9-02, P9-05 | Disabled job validates; archive, restore, and alert tests pass |
+| [P9-06](phase9/P9-06-WORKER-PLAN.md) | Azure shadow infrastructure and launch gate | P9-02, P9-05 | Disabled job validates; archive, restore, and alert tests pass |
 | P9-07 | Hosted execution context and deployment registry | P9-01 | All four paper phases share typed, idempotent metadata |
 | P9-08 | PostgreSQL repositories and migrations | P9-07 | Filesystem, SQLite, and PostgreSQL contract suites pass |
 | P9-09 | Blob artifact store, outbox, and Service Bus adapters | P9-08 | Artifact parity and duplicate-delivery tests pass |
@@ -360,7 +360,9 @@ Phase 9 is complete when:
   evidence decision is recorded after `June 16, 2027`
 
 P9-05 implementation details are frozen in
-[the worker plan](phase9/P9-05-WORKER-PLAN.md).
+[the worker plan](phase9/P9-05-WORKER-PLAN.md). P9-06 infrastructure and
+launch-gate details are frozen in
+[the Azure shadow worker plan](phase9/P9-06-WORKER-PLAN.md).
 - QQQ paper decision, approval, submission, reconciliation, notifications, and
   reporting run from Azure
 - PostgreSQL is canonical QQQ workflow state and Blob Storage contains the

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,5 +16,6 @@ This site is the canonical home for MarketLab's public documentation.
 - [Phase 9 P9-03 Worker Plan](phase9/P9-03-WORKER-PLAN.md)
 - [Phase 9 P9-04 Worker Plan](phase9/P9-04-WORKER-PLAN.md)
 - [Phase 9 P9-05 Worker Plan](phase9/P9-05-WORKER-PLAN.md)
+- [Phase 9 P9-06 Worker Plan](phase9/P9-06-WORKER-PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/phase9/P9-06-WORKER-PLAN.md
+++ b/docs/phase9/P9-06-WORKER-PLAN.md
@@ -52,13 +52,18 @@ The scheduled job runs the existing container image entrypoint through the
 marketlab phase9-shadow-scheduler --config /app/configs/experiment.btc_phase9_shadow_daily.yaml --once
 ```
 
-The job remains launch-blocked until `enable_shadow_schedule = true` is set in
-an explicitly reviewed Terraform change. The default is `false`.
+The first supervised apply keeps `create_shadow_job = false` so Azure can
+create the ACR before an image exists. After the immutable image digest is
+published to that ACR and reviewed, a second supervised apply may set
+`create_shadow_job = true` while still creating only a manual-trigger job. The
+job remains launch-blocked until `enable_shadow_schedule = true` is set in an
+explicitly reviewed Terraform change. Both defaults are `false`.
 
 ## Launch Gate
 
-The launch gate is intentionally manual and evidence-driven. The schedule may
-not be enabled until all evidence below is attached to the supervised change:
+The launch gate is intentionally manual and evidence-driven. Job creation and
+schedule enablement are separate reviewed changes. The schedule may not be
+enabled until all evidence below is attached to the supervised change:
 
 - P9-05 scheduler command succeeds from the immutable image digest
 - frozen config and behavior hashes still pass `verify_shadow_contract`

--- a/docs/phase9/P9-06-WORKER-PLAN.md
+++ b/docs/phase9/P9-06-WORKER-PLAN.md
@@ -1,0 +1,153 @@
+# P9-06 Worker Plan: BTC Shadow Azure Infrastructure And Launch Gate
+
+## Packet Identity
+
+- Branch: `feature/phase-9-btc-shadow-azure`
+- Pull request: `feat(phase9): add BTC shadow Azure launch gate`
+- Dependencies: P9-02 Azure Terraform bootstrap and P9-05 BTC shadow scheduler
+
+P9-06 adds the disabled-by-default Azure infrastructure for the frozen BTC
+shadow lane. It proves that the P9-05 one-shot scheduler can be hosted as a
+Container Apps scheduled job without enabling it, changing strategy behavior,
+or introducing any broker, approval, or generic artifact-store path.
+
+No Azure apply, plan against live resources, provider registration, or job
+enablement is authorized by this repository packet. Those actions require a
+separate supervised session with reviewed cost, names, image digest, alert
+recipient, provider status, and exact Terraform plan output.
+
+## Scope
+
+The Terraform root is:
+
+```text
+infra/azure/phase9-shadow/
+```
+
+The root uses the existing bootstrap state convention and reserves the remote
+state key:
+
+```text
+phase9-shadow.tfstate
+```
+
+It may create only the BTC shadow evidence lane resources:
+
+1. resource group
+2. managed identity
+3. Azure Container Registry
+4. Log Analytics workspace
+5. Application Insights component
+6. Container Apps environment
+7. disabled scheduled Container Apps Job
+8. StorageV2 account with Azure Files for live path-oriented artifacts
+9. versioned private Blob archive container
+10. Azure Monitor action group and query alerts for job failures and missing
+    evidence
+
+The scheduled job runs the existing container image entrypoint through the
+`marketlab` CLI alias:
+
+```text
+marketlab phase9-shadow-scheduler --config /app/configs/experiment.btc_phase9_shadow_daily.yaml --once
+```
+
+The job remains launch-blocked until `enable_shadow_schedule = true` is set in
+an explicitly reviewed Terraform change. The default is `false`.
+
+## Launch Gate
+
+The launch gate is intentionally manual and evidence-driven. The schedule may
+not be enabled until all evidence below is attached to the supervised change:
+
+- P9-05 scheduler command succeeds from the immutable image digest
+- frozen config and behavior hashes still pass `verify_shadow_contract`
+- append-only journal conflict handling is proven
+- missed-run accounting is proven
+- archive copy from Azure Files to Blob succeeds
+- restore from a dated Blob snapshot into a scratch path succeeds
+- Container Apps job failure alert fires in a test
+- missing shadow evidence alert fires in a test
+- no broker, approval, Alpaca, Telegram, Service Bus, or Key Vault secret is
+  present in the BTC shadow root
+
+The variable validation requires `launch_gate_evidence_uri` when the schedule
+is enabled. That URI points to the reviewed evidence package; it is not a
+secret.
+
+## Archive And Restore Runbook
+
+P9-06 keeps the live artifact contract filesystem-oriented by mounting Azure
+Files at `/app/artifacts`, preserving the checked-in
+`artifacts/phase9-shadow` relative path inside the container. The durable
+graduation copy is the Blob archive. This is a BTC-shadow-specific bridge and
+must not become the P9-09 generic artifact store.
+
+Archive a live tree into a dated prefix:
+
+```powershell
+$snapshotDate = "2026-06-17"
+$storage = "<approved-storage-account>"
+$share = "phase9-shadow-live"
+$container = "phase9-shadow-archive"
+
+az storage copy `
+  --source-share $share `
+  --source-path "phase9-shadow" `
+  --destination-container $container `
+  --destination-path "snapshots/$snapshotDate" `
+  --account-name $storage `
+  --auth-mode login `
+  --recursive
+```
+
+Restore a dated archive snapshot into a scratch path only:
+
+```powershell
+$snapshotDate = "2026-06-17"
+$storage = "<approved-storage-account>"
+$container = "phase9-shadow-archive"
+$scratch = "restore-check/$snapshotDate"
+
+az storage copy `
+  --source-container $container `
+  --source-path "snapshots/$snapshotDate" `
+  --destination-share "phase9-shadow-live" `
+  --destination-path $scratch `
+  --account-name $storage `
+  --auth-mode login `
+  --recursive
+```
+
+The restore check must compare decision, attempt, evidence, report, and
+`state/status.json` paths before any schedule enablement. Restores never write
+over the live artifact root.
+
+## Validation
+
+Repository validation for this packet:
+
+```text
+python -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_phase9_azure_bootstrap.py tests/unit/test_phase9_shadow_cli.py
+python -m pytest -q tests/unit
+python -m ruff check .
+python -m mypy src/marketlab/shadow src/marketlab/cli.py
+python -m mkdocs build --strict
+python -m tox -e terraform
+py -3.14 -m tox -e preflight
+git diff --check
+```
+
+Terraform validation is format, backend-disabled init, and validate only. It
+must not run plan, apply, destroy, import, refresh-only planning, Azure login,
+or provider registration.
+
+## Non-Goals
+
+- BTC broker path
+- BTC approval flow
+- QQQ Azure migration
+- generic Blob or Service Bus adapter layer
+- automatic promotion decision
+- immutable Blob policy lock
+- Azure apply without separate explicit approval

--- a/infra/azure/phase9-shadow/.terraform.lock.hcl
+++ b/infra/azure/phase9-shadow/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.74.0"
+  constraints = "~> 4.74.0"
+  hashes = [
+    "h1:PBiXTNz3vQjxlmEEO4ZwaEPms8ztbtf+NIIUuyDgtwI=",
+    "h1:Zqy2w+Hfn5RrMkjbONtzPGVtzsOxETE4gK8M03u0cig=",
+    "h1:yvqCYq9U8R+ujUFUFM1lHLvJqd+s5iqFO5MqCiqoHFA=",
+    "zh:004decccb53c332710894b890f3a5fd724aeeb440c32a8d337d6a2fe9f4427cc",
+    "zh:10ee232dfa76c987cbd226f81f825bbbe36786a8097fcb811ff655f2b471959c",
+    "zh:43ffac27efbbcc741ec6e0e96e0def151ddb04d7ce7fd0b67032dc4cdaa20e90",
+    "zh:459438a78b6cb43ba09e2c11832c6234848a08ab264dc2efe809db8b073057d6",
+    "zh:4f156cb69b8ed3d43b52fd90106d06609736019bc79faf6c1695aa942bbdade4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:921285f6e9beb02a7482bb8036e6b032255bc0c4aa61a11def63870c1ee10672",
+    "zh:994cf51bdc8aefa7e8a93474a322c9231df3512e85bc603c9295343ebc31228c",
+    "zh:9c6136ed2ae6cbbbfc57e74cdd7b83af9faea5ca3c7e3fa82877aca0b215fd27",
+    "zh:a0349f105af1882bf9d795a6fdac2fbe71f2e588ca6f4587b87de7b5423a0be8",
+    "zh:c7a91501928e23d5d8f088909aaa633a13d5f032fbc2043c6618305beb090058",
+    "zh:f11cb049e16a459f799c4f394ac20f8e9b3d0ef210cf56cb0850e0beffeaf4e1",
+  ]
+}

--- a/infra/azure/phase9-shadow/README.md
+++ b/infra/azure/phase9-shadow/README.md
@@ -1,0 +1,130 @@
+# Phase 9 BTC Shadow Azure Root
+
+This Terraform root is the repository-only implementation of P9-06. It creates
+the BTC shadow evidence lane infrastructure, but the scheduled Container Apps
+Job is launch-blocked by default.
+
+## Approval Boundary
+
+Formatting, backend-disabled initialization, validation, and tests are allowed
+without Azure approval. Stop and obtain explicit user approval before:
+
+- `az login`, subscription or tenant discovery, Azure Portal access, or
+  resource-provider registration
+- any Terraform command that refreshes, plans against, imports, changes, or
+  destroys real Azure resources
+- setting `enable_shadow_schedule = true`
+- applying, committing, pushing, or opening the pull request if the user has
+  not approved that publication step
+
+This root must not run a broker phase, request approval, submit an order,
+create QQQ resources, or introduce the P9-09 generic Blob or Service Bus
+adapter layer. The archive bridge must not become the P9-09 generic Blob or
+Service Bus adapter layer.
+
+## Local Validation Only
+
+Terraform `1.15.5` is required. These commands must not authenticate to Azure:
+
+```powershell
+terraform fmt -check -recursive infra/azure
+terraform -chdir=infra/azure/phase9-shadow init -backend=false -lockfile=readonly -input=false
+terraform -chdir=infra/azure/phase9-shadow validate -no-color
+python -m tox -e terraform
+```
+
+The committed root does not include `backend.tf`. After a supervised bootstrap,
+copy `backend.tf.example` to ignored `backend.tf` and use `backend.hcl` with
+the reserved `phase9-shadow.tfstate` key.
+
+## Resource Scope
+
+P9-06 provisions only:
+
+- resource group
+- user-assigned managed identity
+- Azure Container Registry with admin access disabled
+- Log Analytics and Application Insights
+- Container Apps environment
+- Container Apps Job using the existing Docker entrypoint:
+  `marketlab phase9-shadow-scheduler --config /app/configs/experiment.btc_phase9_shadow_daily.yaml --once`
+- StorageV2 account with Azure Files live artifacts and a private, versioned
+  Blob archive container
+- Azure Monitor action group and scheduled-query alerts for job failures and
+  missing shadow evidence
+
+The Container Apps Job has no ingress block. Its registry pull and storage
+permissions use the managed identity. The Azure Files mount uses the storage
+account key because Container Apps environment storage requires it; the key
+must remain protected in Terraform state and is not a broker, provider, or
+approval secret.
+
+## Launch Gate
+
+The default variable state is:
+
+```hcl
+enable_shadow_schedule = false
+enable_shadow_alerts   = false
+```
+
+With that default, Terraform creates a manual-trigger job only. A scheduled
+trigger is emitted only when `enable_shadow_schedule = true`. That change is
+invalid unless `launch_gate_evidence_uri` points to a reviewed evidence
+package proving:
+
+- immutable image digest was reviewed
+- `verify_shadow_contract` still passes
+- append-only decision and evidence conflict handling is proven
+- missed-run accounting is proven
+- archive copy succeeds
+- restore into a scratch path succeeds
+- job failure and missing-evidence alerts fire in tests
+
+Azure enablement is not automatic. P9-15 owns any final BTC evidence decision.
+
+## Archive Snapshot
+
+Copy the live Azure Files tree into a dated Blob archive prefix:
+
+```powershell
+$snapshotDate = "2026-06-17"
+$storage = "<approved-storage-account>"
+$share = "phase9-shadow-live"
+$container = "phase9-shadow-archive"
+
+az storage copy `
+  --source-share $share `
+  --source-path "phase9-shadow" `
+  --destination-container $container `
+  --destination-path "snapshots/$snapshotDate" `
+  --account-name $storage `
+  --auth-mode login `
+  --recursive
+```
+
+The archive container has Blob versioning enabled at the storage account and a
+`450` day lifecycle retention policy for `snapshots/`.
+
+## Restore Check
+
+Restore only into a scratch path. Never overwrite the live artifact tree:
+
+```powershell
+$snapshotDate = "2026-06-17"
+$storage = "<approved-storage-account>"
+$container = "phase9-shadow-archive"
+$scratch = "restore-check/$snapshotDate"
+
+az storage copy `
+  --source-container $container `
+  --source-path "snapshots/$snapshotDate" `
+  --destination-share "phase9-shadow-live" `
+  --destination-path $scratch `
+  --account-name $storage `
+  --auth-mode login `
+  --recursive
+```
+
+Compare the restored `decisions/`, `attempts/`, `evidence/`, `reports/`, and
+`state/status.json` paths with the source snapshot before schedule enablement.

--- a/infra/azure/phase9-shadow/README.md
+++ b/infra/azure/phase9-shadow/README.md
@@ -46,7 +46,8 @@ P9-06 provisions only:
 - Azure Container Registry with admin access disabled
 - Log Analytics and Application Insights
 - Container Apps environment
-- Container Apps Job using the existing Docker entrypoint:
+- Container Apps Job using the existing Docker entrypoint, created only after
+  the reviewed immutable image digest exists in ACR:
   `marketlab phase9-shadow-scheduler --config /app/configs/experiment.btc_phase9_shadow_daily.yaml --once`
 - StorageV2 account with Azure Files live artifacts and a private, versioned
   Blob archive container
@@ -59,6 +60,11 @@ account key because Container Apps environment storage requires it; the key
 must remain protected in Terraform state and is not a broker, provider, or
 approval secret.
 
+The first supervised apply keeps `create_shadow_job = false` so Azure can
+create the ACR before an image exists. After the immutable image digest is
+published to that ACR and reviewed, a second supervised apply may set
+`create_shadow_job = true` while keeping `enable_shadow_schedule = false`.
+
 ## Launch Gate
 
 The default variable state is:
@@ -66,9 +72,12 @@ The default variable state is:
 ```hcl
 enable_shadow_schedule = false
 enable_shadow_alerts   = false
+create_shadow_job      = false
 ```
 
-With that default, Terraform creates a manual-trigger job only. A scheduled
+With that default, Terraform creates no job resource, avoiding an apply-time
+image pull failure against an empty new ACR. After image publication,
+`create_shadow_job = true` creates a manual-trigger job only. A scheduled
 trigger is emitted only when `enable_shadow_schedule = true`. That change is
 invalid unless `launch_gate_evidence_uri` points to a reviewed evidence
 package proving:

--- a/infra/azure/phase9-shadow/backend.hcl.example
+++ b/infra/azure/phase9-shadow/backend.hcl.example
@@ -1,0 +1,4 @@
+resource_group_name  = "rg-marketlab-terraform-abc123"
+storage_account_name = "mltfabc123"
+container_name       = "tfstate"
+key                  = "phase9-shadow.tfstate"

--- a/infra/azure/phase9-shadow/backend.tf.example
+++ b/infra/azure/phase9-shadow/backend.tf.example
@@ -1,0 +1,6 @@
+terraform {
+  backend "azurerm" {
+    use_azuread_auth = true
+    use_cli          = true
+  }
+}

--- a/infra/azure/phase9-shadow/main.tf
+++ b/infra/azure/phase9-shadow/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_container_registry" "shadow" {
   admin_enabled                 = false
   anonymous_pull_enabled        = false
   public_network_access_enabled = true
-  export_policy_enabled         = false
+  export_policy_enabled         = true
   quarantine_policy_enabled     = false
   trust_policy_enabled          = false
   tags                          = local.tags
@@ -193,6 +193,8 @@ resource "azurerm_role_assignment" "shadow_file_live_artifacts" {
 }
 
 resource "azurerm_container_app_job" "shadow_scheduler" {
+  count = var.create_shadow_job ? 1 : 0
+
   name                         = "caj-ml-p9-shadow-${var.resource_suffix}"
   resource_group_name          = azurerm_resource_group.shadow.name
   location                     = azurerm_resource_group.shadow.location
@@ -310,8 +312,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failures" {
     query                   = <<-KQL
       ContainerAppSystemLogs_CL
       | where TimeGenerated > ago(15m)
-      | where JobName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
-          or ContainerAppName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
+      | where JobName_s == "caj-ml-p9-shadow-${var.resource_suffix}"
+          or ContainerAppName_s == "caj-ml-p9-shadow-${var.resource_suffix}"
       | where Reason_s has_any ("Failed", "Error")
           or Log_s has_any ("failed", "error", "exception")
     KQL
@@ -349,7 +351,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "missing_evidence" {
     query                   = <<-KQL
       ContainerAppConsoleLogs_CL
       | where TimeGenerated > ago(26h)
-      | where ContainerAppName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
+      | where ContainerAppName_s == "caj-ml-p9-shadow-${var.resource_suffix}"
       | where Log_s has_any ("decision_evidence", "label_evidence", "state/status.json")
     KQL
     time_aggregation_method = "Count"

--- a/infra/azure/phase9-shadow/main.tf
+++ b/infra/azure/phase9-shadow/main.tf
@@ -1,0 +1,369 @@
+locals {
+  required_tags = {
+    "cost-center" = var.cost_center
+    "managed-by"  = "terraform"
+    "owner"       = var.owner
+    "phase"       = "9"
+    "project"     = "marketlab"
+    "purpose"     = "btc-shadow"
+    "workload"    = "phase9-shadow"
+  }
+
+  tags = merge(var.additional_tags, local.required_tags)
+
+  container_image = "${azurerm_container_registry.shadow.login_server}/${var.container_repository}@${var.marketlab_image_digest}"
+}
+
+resource "azurerm_resource_group" "shadow" {
+  name     = "rg-marketlab-phase9-shadow-${var.resource_suffix}"
+  location = var.location
+  tags     = local.tags
+}
+
+resource "azurerm_user_assigned_identity" "shadow" {
+  name                = "id-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name = azurerm_resource_group.shadow.name
+  location            = azurerm_resource_group.shadow.location
+  tags                = local.tags
+}
+
+resource "azurerm_container_registry" "shadow" {
+  name                          = "mlp9sh${var.resource_suffix}acr"
+  resource_group_name           = azurerm_resource_group.shadow.name
+  location                      = azurerm_resource_group.shadow.location
+  sku                           = "Basic"
+  admin_enabled                 = false
+  anonymous_pull_enabled        = false
+  public_network_access_enabled = true
+  export_policy_enabled         = false
+  quarantine_policy_enabled     = false
+  trust_policy_enabled          = false
+  tags                          = local.tags
+}
+
+resource "azurerm_log_analytics_workspace" "shadow" {
+  name                       = "log-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name        = azurerm_resource_group.shadow.name
+  location                   = azurerm_resource_group.shadow.location
+  sku                        = "PerGB2018"
+  retention_in_days          = 90
+  daily_quota_gb             = 1
+  internet_ingestion_enabled = true
+  internet_query_enabled     = true
+  tags                       = local.tags
+}
+
+resource "azurerm_application_insights" "shadow" {
+  name                          = "appi-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name           = azurerm_resource_group.shadow.name
+  location                      = azurerm_resource_group.shadow.location
+  application_type              = "other"
+  workspace_id                  = azurerm_log_analytics_workspace.shadow.id
+  local_authentication_disabled = true
+  internet_ingestion_enabled    = true
+  internet_query_enabled        = true
+  tags                          = local.tags
+}
+
+resource "azurerm_container_app_environment" "shadow" {
+  name                       = "cae-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name        = azurerm_resource_group.shadow.name
+  location                   = azurerm_resource_group.shadow.location
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.shadow.id
+  public_network_access      = "Enabled"
+  tags                       = local.tags
+}
+
+resource "azurerm_storage_account" "shadow" {
+  name                            = "mlp9sh${var.resource_suffix}"
+  resource_group_name             = azurerm_resource_group.shadow.name
+  location                        = azurerm_resource_group.shadow.location
+  account_tier                    = "Standard"
+  account_replication_type        = "ZRS"
+  account_kind                    = "StorageV2"
+  access_tier                     = "Hot"
+  min_tls_version                 = "TLS1_2"
+  https_traffic_only_enabled      = true
+  allow_nested_items_to_be_public = false
+  shared_access_key_enabled       = true
+  default_to_oauth_authentication = true
+  public_network_access_enabled   = true
+  local_user_enabled              = false
+
+  blob_properties {
+    versioning_enabled       = true
+    last_access_time_enabled = true
+
+    delete_retention_policy {
+      days = 30
+    }
+
+    container_delete_retention_policy {
+      days = 30
+    }
+  }
+
+  share_properties {
+    retention_policy {
+      days = 30
+    }
+
+    smb {
+      versions                        = ["SMB3.1.1"]
+      authentication_types            = ["NTLMv2"]
+      kerberos_ticket_encryption_type = ["AES-256"]
+      channel_encryption_type         = ["AES-256-GCM"]
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_share" "live_artifacts" {
+  name               = "phase9-shadow-live"
+  storage_account_id = azurerm_storage_account.shadow.id
+  quota              = var.live_share_quota_gb
+  access_tier        = "Hot"
+}
+
+resource "azurerm_storage_container" "archive" {
+  name                  = "phase9-shadow-archive"
+  storage_account_id    = azurerm_storage_account.shadow.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_management_policy" "archive_retention" {
+  storage_account_id = azurerm_storage_account.shadow.id
+
+  rule {
+    name    = "retain-shadow-archive"
+    enabled = true
+
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = ["${azurerm_storage_container.archive.name}/snapshots/"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_creation_greater_than = var.archive_retention_days
+      }
+
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.archive_retention_days
+      }
+
+      version {
+        delete_after_days_since_creation = var.archive_retention_days
+      }
+    }
+  }
+
+  depends_on = [azurerm_storage_container.archive]
+}
+
+resource "azurerm_container_app_environment_storage" "live_artifacts" {
+  name                         = "phase9-shadow-live"
+  container_app_environment_id = azurerm_container_app_environment.shadow.id
+  account_name                 = azurerm_storage_account.shadow.name
+  share_name                   = azurerm_storage_share.live_artifacts.name
+  access_key                   = azurerm_storage_account.shadow.primary_access_key
+  access_mode                  = "ReadWrite"
+}
+
+resource "azurerm_role_assignment" "shadow_acr_pull" {
+  scope                = azurerm_container_registry.shadow.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.shadow.principal_id
+  principal_type       = "ServicePrincipal"
+}
+
+resource "azurerm_role_assignment" "shadow_blob_archive" {
+  scope                = azurerm_storage_account.shadow.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.shadow.principal_id
+  principal_type       = "ServicePrincipal"
+}
+
+resource "azurerm_role_assignment" "shadow_file_live_artifacts" {
+  scope                = azurerm_storage_account.shadow.id
+  role_definition_name = "Storage File Data SMB Share Contributor"
+  principal_id         = azurerm_user_assigned_identity.shadow.principal_id
+  principal_type       = "ServicePrincipal"
+}
+
+resource "azurerm_container_app_job" "shadow_scheduler" {
+  name                         = "caj-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name          = azurerm_resource_group.shadow.name
+  location                     = azurerm_resource_group.shadow.location
+  container_app_environment_id = azurerm_container_app_environment.shadow.id
+  replica_timeout_in_seconds   = 3600
+  replica_retry_limit          = 0
+  tags                         = local.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.shadow.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.shadow.login_server
+    identity = azurerm_user_assigned_identity.shadow.id
+  }
+
+  dynamic "manual_trigger_config" {
+    for_each = var.enable_shadow_schedule ? [] : [1]
+
+    content {
+      parallelism              = 1
+      replica_completion_count = 1
+    }
+  }
+
+  dynamic "schedule_trigger_config" {
+    for_each = var.enable_shadow_schedule ? [1] : []
+
+    content {
+      cron_expression          = var.shadow_cron_expression
+      parallelism              = 1
+      replica_completion_count = 1
+    }
+  }
+
+  template {
+    container {
+      name   = "phase9-shadow-scheduler"
+      image  = local.container_image
+      cpu    = 0.5
+      memory = "1Gi"
+      args = [
+        "phase9-shadow-scheduler",
+        "--config",
+        var.shadow_config_path,
+        "--once",
+      ]
+
+      env {
+        name  = "MARKETLAB_DEPLOYMENT_ID"
+        value = "phase9-shadow"
+      }
+
+      env {
+        name  = "MARKETLAB_SHADOW_LAUNCH_GATE"
+        value = var.enable_shadow_schedule ? "enabled" : "disabled"
+      }
+
+      env {
+        name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
+        value = azurerm_application_insights.shadow.connection_string
+      }
+
+      volume_mounts {
+        name = "live-artifacts"
+        path = "/app/artifacts"
+      }
+    }
+
+    volume {
+      name         = "live-artifacts"
+      storage_name = azurerm_container_app_environment_storage.live_artifacts.name
+      storage_type = "AzureFile"
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.shadow_acr_pull,
+    azurerm_role_assignment.shadow_blob_archive,
+    azurerm_role_assignment.shadow_file_live_artifacts,
+  ]
+}
+
+resource "azurerm_monitor_action_group" "shadow" {
+  name                = "ag-ml-p9-shadow-${var.resource_suffix}"
+  resource_group_name = azurerm_resource_group.shadow.name
+  short_name          = "p9shadow"
+  enabled             = var.enable_shadow_alerts
+  tags                = local.tags
+
+  email_receiver {
+    name                    = "phase9-shadow-operator"
+    email_address           = var.alert_email
+    use_common_alert_schema = true
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failures" {
+  name                  = "alert-ml-p9-shadow-job-failures-${var.resource_suffix}"
+  resource_group_name   = azurerm_resource_group.shadow.name
+  location              = azurerm_resource_group.shadow.location
+  display_name          = "MarketLab Phase 9 shadow job failures"
+  description           = "Alerts only on BTC shadow Container Apps job failure evidence."
+  enabled               = var.enable_shadow_alerts
+  scopes                = [azurerm_log_analytics_workspace.shadow.id]
+  severity              = 2
+  evaluation_frequency  = "PT15M"
+  window_duration       = "PT15M"
+  skip_query_validation = true
+  tags                  = local.tags
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppSystemLogs_CL
+      | where TimeGenerated > ago(15m)
+      | where JobName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
+          or ContainerAppName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
+      | where Reason_s has_any ("Failed", "Error")
+          or Log_s has_any ("failed", "error", "exception")
+    KQL
+    time_aggregation_method = "Count"
+    operator                = "GreaterThan"
+    threshold               = 0
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.shadow.id]
+    email_subject = "MarketLab Phase 9 BTC shadow job failure"
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "missing_evidence" {
+  name                  = "alert-ml-p9-shadow-missing-evidence-${var.resource_suffix}"
+  resource_group_name   = azurerm_resource_group.shadow.name
+  location              = azurerm_resource_group.shadow.location
+  display_name          = "MarketLab Phase 9 shadow missing evidence"
+  description           = "Alerts only when the scheduled BTC shadow lane misses expected decision evidence."
+  enabled               = var.enable_shadow_schedule && var.enable_shadow_alerts
+  scopes                = [azurerm_log_analytics_workspace.shadow.id]
+  severity              = 2
+  evaluation_frequency  = "PT1H"
+  window_duration       = "P1D"
+  skip_query_validation = true
+  tags                  = local.tags
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | where TimeGenerated > ago(26h)
+      | where ContainerAppName_s == "${azurerm_container_app_job.shadow_scheduler.name}"
+      | where Log_s has_any ("decision_evidence", "label_evidence", "state/status.json")
+    KQL
+    time_aggregation_method = "Count"
+    operator                = "LessThan"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.shadow.id]
+    email_subject = "MarketLab Phase 9 BTC shadow evidence missing"
+  }
+}

--- a/infra/azure/phase9-shadow/outputs.tf
+++ b/infra/azure/phase9-shadow/outputs.tf
@@ -1,0 +1,39 @@
+output "resource_group_name" {
+  description = "Resource group containing the disabled BTC shadow workload."
+  value       = azurerm_resource_group.shadow.name
+}
+
+output "managed_identity_id" {
+  description = "Managed identity assigned to the Container Apps shadow job."
+  value       = azurerm_user_assigned_identity.shadow.id
+}
+
+output "container_registry_login_server" {
+  description = "ACR login server used with managed identity pull."
+  value       = azurerm_container_registry.shadow.login_server
+}
+
+output "container_app_job_name" {
+  description = "Container Apps Job name for the BTC shadow scheduler."
+  value       = azurerm_container_app_job.shadow_scheduler.name
+}
+
+output "schedule_enabled" {
+  description = "Launch-gate state for the scheduled trigger."
+  value       = var.enable_shadow_schedule
+}
+
+output "launch_gate_evidence_uri" {
+  description = "Reviewed evidence URI required before enabling the schedule."
+  value       = var.launch_gate_evidence_uri
+}
+
+output "live_artifact_share_name" {
+  description = "Azure Files share mounted at /app/artifacts."
+  value       = azurerm_storage_share.live_artifacts.name
+}
+
+output "archive_container_name" {
+  description = "Versioned Blob container for dated BTC shadow archive snapshots."
+  value       = azurerm_storage_container.archive.name
+}

--- a/infra/azure/phase9-shadow/outputs.tf
+++ b/infra/azure/phase9-shadow/outputs.tf
@@ -15,7 +15,12 @@ output "container_registry_login_server" {
 
 output "container_app_job_name" {
   description = "Container Apps Job name for the BTC shadow scheduler."
-  value       = azurerm_container_app_job.shadow_scheduler.name
+  value       = "caj-ml-p9-shadow-${var.resource_suffix}"
+}
+
+output "container_app_job_created" {
+  description = "Whether the Container Apps Job resource is included in this apply."
+  value       = var.create_shadow_job
 }
 
 output "schedule_enabled" {

--- a/infra/azure/phase9-shadow/terraform.tfvars.example
+++ b/infra/azure/phase9-shadow/terraform.tfvars.example
@@ -1,0 +1,18 @@
+resource_suffix = "abc123"
+location        = "eastus2"
+owner           = "replace-with-approved-owner"
+cost_center     = "replace-with-approved-cost-center"
+alert_email     = "operator@example.com"
+
+marketlab_image_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+enable_shadow_schedule    = false
+enable_shadow_alerts      = false
+launch_gate_evidence_uri  = ""
+archive_retention_days    = 450
+live_share_quota_gb       = 16
+shadow_cron_expression    = "15 1 * * *"
+container_repository      = "marketlab"
+shadow_config_path        = "/app/configs/experiment.btc_phase9_shadow_daily.yaml"
+
+additional_tags = {}

--- a/infra/azure/phase9-shadow/terraform.tfvars.example
+++ b/infra/azure/phase9-shadow/terraform.tfvars.example
@@ -8,6 +8,7 @@ marketlab_image_digest = "sha256:00000000000000000000000000000000000000000000000
 
 enable_shadow_schedule    = false
 enable_shadow_alerts      = false
+create_shadow_job         = false
 launch_gate_evidence_uri  = ""
 archive_retention_days    = 450
 live_share_quota_gb       = 16

--- a/infra/azure/phase9-shadow/variables.tf
+++ b/infra/azure/phase9-shadow/variables.tf
@@ -1,0 +1,165 @@
+variable "resource_suffix" {
+  description = "Globally unique lowercase alphanumeric suffix used by Azure resources."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{4,8}$", var.resource_suffix))
+    error_message = "resource_suffix must contain 4-8 lowercase alphanumeric characters."
+  }
+}
+
+variable "location" {
+  description = "Azure region for the BTC shadow resources."
+  type        = string
+  default     = "eastus2"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]+$", var.location))
+    error_message = "location must be an Azure region name containing lowercase letters and numbers."
+  }
+}
+
+variable "owner" {
+  description = "User-approved owner tag for the BTC shadow resources."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.owner)) > 0
+    error_message = "owner must not be empty."
+  }
+}
+
+variable "cost_center" {
+  description = "User-approved cost-center tag for the BTC shadow resources."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.cost_center)) > 0
+    error_message = "cost_center must not be empty."
+  }
+}
+
+variable "alert_email" {
+  description = "User-approved operator email for Azure Monitor action-group receivers."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", var.alert_email))
+    error_message = "alert_email must be an email address approved for Phase 9 alerting."
+  }
+}
+
+variable "marketlab_image_digest" {
+  description = "Immutable MarketLab image digest already published to the shadow ACR."
+  type        = string
+
+  validation {
+    condition     = can(regex("^sha256:[0-9a-f]{64}$", var.marketlab_image_digest))
+    error_message = "marketlab_image_digest must be an immutable sha256 digest."
+  }
+}
+
+variable "container_repository" {
+  description = "ACR repository containing the MarketLab image."
+  type        = string
+  default     = "marketlab"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9._/-]{0,127}$", var.container_repository))
+    error_message = "container_repository must be a valid lowercase ACR repository name."
+  }
+}
+
+variable "shadow_config_path" {
+  description = "Container-local path to the frozen BTC shadow config."
+  type        = string
+  default     = "/app/configs/experiment.btc_phase9_shadow_daily.yaml"
+
+  validation {
+    condition     = var.shadow_config_path == "/app/configs/experiment.btc_phase9_shadow_daily.yaml"
+    error_message = "shadow_config_path must remain on the frozen BTC Phase 9 shadow config."
+  }
+}
+
+variable "shadow_cron_expression" {
+  description = "UTC cron expression for the BTC shadow scheduled job."
+  type        = string
+  default     = "15 1 * * *"
+
+  validation {
+    condition     = var.shadow_cron_expression == "15 1 * * *"
+    error_message = "shadow_cron_expression must remain the approved 01:15 UTC schedule."
+  }
+}
+
+variable "enable_shadow_schedule" {
+  description = "Explicit launch-gate switch. False creates only a manual-trigger job."
+  type        = bool
+  default     = false
+}
+
+variable "enable_shadow_alerts" {
+  description = "Explicit alert switch used during supervised alert testing and launch."
+  type        = bool
+  default     = false
+}
+
+variable "launch_gate_evidence_uri" {
+  description = "Reviewed evidence URI required before the scheduled job can be enabled."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      !var.enable_shadow_schedule
+      || can(regex("^https://", var.launch_gate_evidence_uri))
+    )
+    error_message = "launch_gate_evidence_uri must be an https URI before enable_shadow_schedule can be true."
+  }
+}
+
+variable "archive_retention_days" {
+  description = "Minimum lifecycle retention for Blob archive snapshots and versions."
+  type        = number
+  default     = 450
+
+  validation {
+    condition     = var.archive_retention_days >= 450
+    error_message = "archive_retention_days must preserve at least 450 days of BTC shadow evidence."
+  }
+}
+
+variable "live_share_quota_gb" {
+  description = "Quota for the Azure Files live artifact share."
+  type        = number
+  default     = 16
+
+  validation {
+    condition     = var.live_share_quota_gb >= 16 && var.live_share_quota_gb <= 5120
+    error_message = "live_share_quota_gb must be between 16 and 5120."
+  }
+}
+
+variable "additional_tags" {
+  description = "Optional tags. Required MarketLab tags cannot be overridden."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for key in keys(var.additional_tags) : !contains(
+        [
+          "cost-center",
+          "managed-by",
+          "owner",
+          "phase",
+          "project",
+          "purpose",
+          "workload",
+        ],
+        lower(key),
+      )
+    ])
+    error_message = "additional_tags cannot redefine a required MarketLab tag."
+  }
+}

--- a/infra/azure/phase9-shadow/variables.tf
+++ b/infra/azure/phase9-shadow/variables.tf
@@ -96,6 +96,17 @@ variable "enable_shadow_schedule" {
   description = "Explicit launch-gate switch. False creates only a manual-trigger job."
   type        = bool
   default     = false
+
+  validation {
+    condition     = !var.enable_shadow_schedule || var.create_shadow_job
+    error_message = "enable_shadow_schedule requires create_shadow_job because the scheduled trigger belongs to the Container Apps Job."
+  }
+}
+
+variable "create_shadow_job" {
+  description = "Explicit job-creation switch. Keep false until the reviewed immutable image digest exists in the shadow ACR."
+  type        = bool
+  default     = false
 }
 
 variable "enable_shadow_alerts" {

--- a/infra/azure/phase9-shadow/versions.tf
+++ b/infra/azure/phase9-shadow/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = "= 1.15.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.74.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  resource_provider_registrations = "none"
+  storage_use_azuread             = true
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Phase 9 P9-03 Worker Plan: phase9/P9-03-WORKER-PLAN.md
   - Phase 9 P9-04 Worker Plan: phase9/P9-04-WORKER-PLAN.md
   - Phase 9 P9-05 Worker Plan: phase9/P9-05-WORKER-PLAN.md
+  - Phase 9 P9-06 Worker Plan: phase9/P9-06-WORKER-PLAN.md
 plugins:
   - search
 extra_javascript:

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import sys
 from collections.abc import Callable
 from time import perf_counter
 
@@ -47,9 +48,17 @@ from marketlab.reports.phase8_target_profile_sweep import (
     write_phase8_target_profile_sweep,
 )
 from marketlab.resources.templates import CONFIG_TEMPLATE_NAMES, write_config_template
+from marketlab.shadow import cli as shadow_cli
 from marketlab.targets import build_modeling_dataset
 
 LOGGER = logging.getLogger(__name__)
+
+SHADOW_COMMANDS = {
+    "phase9-shadow-decision": "main",
+    "phase9-shadow-scheduler": "scheduler_main",
+    "phase9-shadow-status": "status_main",
+    "phase9-shadow-report": "report_main",
+}
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -88,6 +97,25 @@ def build_parser() -> argparse.ArgumentParser:
     paper_report.add_argument("--config", required=True)
     paper_report.add_argument("--start", required=True)
     paper_report.add_argument("--end", required=True)
+
+    phase9_shadow_decision = subparsers.add_parser("phase9-shadow-decision")
+    phase9_shadow_decision.add_argument("--config", required=True)
+    phase9_shadow_decision.add_argument("--evaluation", required=True)
+    phase9_shadow_decision.add_argument("--panel")
+    phase9_shadow_decision.add_argument("--as-of")
+
+    phase9_shadow_scheduler = subparsers.add_parser("phase9-shadow-scheduler")
+    phase9_shadow_scheduler.add_argument("--config", required=True)
+    phase9_shadow_scheduler.add_argument("--once", action="store_true")
+    phase9_shadow_scheduler.add_argument("--as-of")
+
+    phase9_shadow_status = subparsers.add_parser("phase9-shadow-status")
+    phase9_shadow_status.add_argument("--config", required=True)
+    phase9_shadow_status.add_argument("--as-of")
+
+    phase9_shadow_report = subparsers.add_parser("phase9-shadow-report")
+    phase9_shadow_report.add_argument("--config", required=True)
+    phase9_shadow_report.add_argument("--as-of")
 
     subparsers.add_parser("list-configs")
 
@@ -286,8 +314,13 @@ def _run_paper_report_command(
 
 def main(argv: list[str] | None = None) -> int:
     configure_logging()
+    raw_args = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_args)
+
+    if args.command in SHADOW_COMMANDS:
+        shadow_main = getattr(shadow_cli, SHADOW_COMMANDS[args.command])
+        return shadow_main(raw_args[1:])
 
     if args.command == "list-configs":
         for template_name in CONFIG_TEMPLATE_NAMES:
@@ -349,7 +382,7 @@ def main(argv: list[str] | None = None) -> int:
         config = load_config(args.config)
         panel, _ = prepare_data(config)
         modeling_dataset = build_modeling_dataset(panel, config)
-        output_path = (
+        sweep_output_path = (
             args.output
             if args.output is not None
             else "artifacts/runs/phase8_btc_target_profile_sweep.csv"
@@ -358,7 +391,7 @@ def main(argv: list[str] | None = None) -> int:
             write_phase8_target_profile_sweep(
                 modeling_dataset,
                 config=config,
-                output_path=output_path,
+                output_path=sweep_output_path,
             )
         )
         return 0
@@ -479,18 +512,18 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "backtest":
-        artifacts = backtest(config)
-        print(artifacts.run_dir)
+        backtest_artifacts = backtest(config)
+        print(backtest_artifacts.run_dir)
         return 0
 
     if args.command == "run-experiment":
-        artifacts = run_experiment(config)
-        print(artifacts.run_dir)
+        experiment_artifacts = run_experiment(config)
+        print(experiment_artifacts.run_dir)
         return 0
 
     if args.command == "train-models":
-        artifacts = train_models(config)
-        print(artifacts.run_dir)
+        training_artifacts = train_models(config)
+        print(training_artifacts.run_dir)
         return 0
 
     parser.error(f"Unsupported command: {args.command}")

--- a/tests/unit/test_phase9_azure_bootstrap.py
+++ b/tests/unit/test_phase9_azure_bootstrap.py
@@ -206,6 +206,8 @@ def test_phase9_shadow_launch_gate_defaults_to_disabled_schedule() -> None:
 
     required = [
         "default = false",
+        "create_shadow_job",
+        "enable_shadow_schedule requires create_shadow_job",
         "for_each = var.enable_shadow_schedule ? [] : [1]",
         "for_each = var.enable_shadow_schedule ? [1] : []",
         "launch_gate_evidence_uri must be an https URI before enable_shadow_schedule can be true",
@@ -217,6 +219,7 @@ def test_phase9_shadow_launch_gate_defaults_to_disabled_schedule() -> None:
     ]
 
     assert all(clause in variables or clause in main or clause in tfvars for clause in required)
+    assert "create_shadow_job = false" in tfvars
     assert "enable_shadow_schedule = false" in tfvars
     assert "enable_shadow_alerts = false" in tfvars
 
@@ -273,6 +276,7 @@ def test_phase9_shadow_identity_alerts_and_no_public_ingress_are_locked() -> Non
         "missing_evidence",
         "ContainerAppSystemLogs_CL",
         "ContainerAppConsoleLogs_CL",
+        "count = var.create_shadow_job ? 1 : 0",
     ]
     forbidden = [
         'resource "azurerm_container_app"',

--- a/tests/unit/test_phase9_azure_bootstrap.py
+++ b/tests/unit/test_phase9_azure_bootstrap.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BOOTSTRAP = ROOT / "infra" / "azure" / "bootstrap"
+PHASE9_SHADOW = ROOT / "infra" / "azure" / "phase9-shadow"
 MAIN = BOOTSTRAP / "main.tf"
 VERSIONS = BOOTSTRAP / "versions.tf"
 LOCK = BOOTSTRAP / ".terraform.lock.hcl"
@@ -146,9 +147,13 @@ def test_operator_values_and_terraform_state_are_ignored() -> None:
     assert "**/terraform.rc" in ignored
     assert "**/credentials.tfrc.json" in ignored
     assert "infra/azure/bootstrap/backend.tf" in ignored
+    assert "infra/azure/phase9-shadow/backend.tf" in ignored
     assert (BOOTSTRAP / "backend.tf.example").exists()
     assert (BOOTSTRAP / "backend.hcl.example").exists()
     assert (BOOTSTRAP / "terraform.tfvars.example").exists()
+    assert (PHASE9_SHADOW / "backend.tf.example").exists()
+    assert (PHASE9_SHADOW / "backend.hcl.example").exists()
+    assert (PHASE9_SHADOW / "terraform.tfvars.example").exists()
 
 
 def test_bootstrap_runbook_preserves_supervision_gates() -> None:
@@ -166,3 +171,138 @@ def test_bootstrap_runbook_preserves_supervision_gates() -> None:
         "separately reviewed destroy plan",
     ]
     assert all(clause in runbook for clause in required)
+
+
+def test_phase9_shadow_resource_scope_is_locked() -> None:
+    content = (PHASE9_SHADOW / "main.tf").read_text(encoding="utf-8")
+    resource_types = re.findall(r'^resource\s+"([^"]+)"\s+"[^"]+"\s+\{', content, re.MULTILINE)
+
+    assert resource_types == [
+        "azurerm_resource_group",
+        "azurerm_user_assigned_identity",
+        "azurerm_container_registry",
+        "azurerm_log_analytics_workspace",
+        "azurerm_application_insights",
+        "azurerm_container_app_environment",
+        "azurerm_storage_account",
+        "azurerm_storage_share",
+        "azurerm_storage_container",
+        "azurerm_storage_management_policy",
+        "azurerm_container_app_environment_storage",
+        "azurerm_role_assignment",
+        "azurerm_role_assignment",
+        "azurerm_role_assignment",
+        "azurerm_container_app_job",
+        "azurerm_monitor_action_group",
+        "azurerm_monitor_scheduled_query_rules_alert_v2",
+        "azurerm_monitor_scheduled_query_rules_alert_v2",
+    ]
+
+
+def test_phase9_shadow_launch_gate_defaults_to_disabled_schedule() -> None:
+    main = _normalized(PHASE9_SHADOW / "main.tf")
+    variables = _normalized(PHASE9_SHADOW / "variables.tf")
+    tfvars = _normalized(PHASE9_SHADOW / "terraform.tfvars.example")
+
+    required = [
+        "default = false",
+        "for_each = var.enable_shadow_schedule ? [] : [1]",
+        "for_each = var.enable_shadow_schedule ? [1] : []",
+        "launch_gate_evidence_uri must be an https URI before enable_shadow_schedule can be true",
+        '"15 1 * * *"',
+        '"phase9-shadow-scheduler"',
+        '"/app/configs/experiment.btc_phase9_shadow_daily.yaml"',
+        '"--once"',
+        "marketlab_image_digest must be an immutable sha256 digest",
+    ]
+
+    assert all(clause in variables or clause in main or clause in tfvars for clause in required)
+    assert "enable_shadow_schedule = false" in tfvars
+    assert "enable_shadow_alerts = false" in tfvars
+
+
+def test_phase9_shadow_storage_archive_and_restore_controls_are_documented() -> None:
+    main = _normalized(PHASE9_SHADOW / "main.tf")
+    runbook = _normalized(PHASE9_SHADOW / "README.md")
+
+    required_main = [
+        'account_replication_type = "ZRS"',
+        'account_kind = "StorageV2"',
+        'min_tls_version = "TLS1_2"',
+        "https_traffic_only_enabled = true",
+        "allow_nested_items_to_be_public = false",
+        "versioning_enabled = true",
+        'name = "phase9-shadow-live"',
+        'name = "phase9-shadow-archive"',
+        'container_access_type = "private"',
+        "azurerm_storage_management_policy",
+        "delete_after_days_since_creation_greater_than = var.archive_retention_days",
+        "delete_after_days_since_creation = var.archive_retention_days",
+        'path = "/app/artifacts"',
+        'storage_type = "AzureFile"',
+    ]
+    required_runbook = [
+        "Archive Snapshot",
+        "Restore Check",
+        "az storage copy",
+        "snapshots/$snapshotDate",
+        "restore-check/$snapshotDate",
+        "Never overwrite the live artifact tree",
+        "`450` day lifecycle retention policy",
+        "must not become the P9-09 generic Blob or Service Bus adapter layer",
+    ]
+
+    assert all(clause in main for clause in required_main)
+    assert all(clause in runbook for clause in required_runbook)
+
+
+def test_phase9_shadow_identity_alerts_and_no_public_ingress_are_locked() -> None:
+    main_content = (PHASE9_SHADOW / "main.tf").read_text(encoding="utf-8")
+    main = " ".join(main_content.split())
+
+    required = [
+        'type = "UserAssigned"',
+        "identity_ids = [azurerm_user_assigned_identity.shadow.id]",
+        "identity = azurerm_user_assigned_identity.shadow.id",
+        'role_definition_name = "AcrPull"',
+        'role_definition_name = "Storage Blob Data Contributor"',
+        'role_definition_name = "Storage File Data SMB Share Contributor"',
+        "azurerm_monitor_action_group",
+        "azurerm_monitor_scheduled_query_rules_alert_v2",
+        "job_failures",
+        "missing_evidence",
+        "ContainerAppSystemLogs_CL",
+        "ContainerAppConsoleLogs_CL",
+    ]
+    forbidden = [
+        'resource "azurerm_container_app"',
+        'resource "azurerm_key_vault"',
+        'resource "azurerm_servicebus',
+        'ingress {',
+        "alpaca",
+        "broker",
+        "approval",
+        "telegram",
+    ]
+
+    assert all(clause in main for clause in required)
+    assert all(clause.lower() not in main_content.lower() for clause in forbidden)
+
+
+def test_phase9_shadow_backend_provider_and_tox_validation_are_locked() -> None:
+    backend = _normalized(PHASE9_SHADOW / "backend.tf.example")
+    backend_hcl = _normalized(PHASE9_SHADOW / "backend.hcl.example")
+    versions = _normalized(PHASE9_SHADOW / "versions.tf")
+    lock = _normalized(PHASE9_SHADOW / ".terraform.lock.hcl")
+    tox = _normalized(ROOT / "tox.ini")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'backend "azurerm" { use_azuread_auth = true use_cli = true }' in backend
+    assert "key = \"phase9-shadow.tfstate\"" in backend_hcl
+    assert 'required_version = "= 1.15.5"' in versions
+    assert 'version = "~> 4.74.0"' in versions
+    assert 'resource_provider_registrations = "none"' in versions
+    assert 'version = "4.74.0"' in lock
+    assert "phase9-shadow init -backend=false -lockfile=readonly -input=false" in tox
+    assert "phase9-shadow validate -no-color" in tox
+    assert "infra/azure/phase9-shadow/.terraform.lock.hcl" in workflow

--- a/tests/unit/test_phase9_plan_docs.py
+++ b/tests/unit/test_phase9_plan_docs.py
@@ -9,6 +9,7 @@ P9_02_EVIDENCE = ROOT / "docs" / "phase9" / "P9-02-BOOTSTRAP-EVIDENCE.md"
 P9_03_PLAN = ROOT / "docs" / "phase9" / "P9-03-WORKER-PLAN.md"
 P9_04_PLAN = ROOT / "docs" / "phase9" / "P9-04-WORKER-PLAN.md"
 P9_05_PLAN = ROOT / "docs" / "phase9" / "P9-05-WORKER-PLAN.md"
+P9_06_PLAN = ROOT / "docs" / "phase9" / "P9-06-WORKER-PLAN.md"
 
 
 def test_phase9_plan_replaces_obsolete_cloud_plan() -> None:
@@ -226,3 +227,38 @@ def test_p9_05_plan_is_linked_from_docs_and_cli_metadata() -> None:
     assert 'phase9-shadow-scheduler = "marketlab.shadow.cli:scheduler_main"' in pyproject
     assert 'phase9-shadow-status = "marketlab.shadow.cli:status_main"' in pyproject
     assert 'phase9-shadow-report = "marketlab.shadow.cli:report_main"' in pyproject
+
+
+def test_p9_06_plan_locks_shadow_azure_launch_gate_scope() -> None:
+    content = P9_06_PLAN.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    required = [
+        "feature/phase-9-btc-shadow-azure",
+        "feat(phase9): add BTC shadow Azure launch gate",
+        "infra/azure/phase9-shadow/",
+        "phase9-shadow.tfstate",
+        "disabled scheduled Container Apps Job",
+        "marketlab phase9-shadow-scheduler --config /app/configs/experiment.btc_phase9_shadow_daily.yaml --once",
+        "enable_shadow_schedule = true",
+        "launch_gate_evidence_uri",
+        "append-only journal conflict handling is proven",
+        "archive copy from Azure Files to Blob succeeds",
+        "restore from a dated Blob snapshot into a scratch path succeeds",
+        "no broker, approval, Alpaca, Telegram, Service Bus, or Key Vault secret",
+        "must not become the P9-09 generic artifact store",
+        "Terraform validation is format, backend-disabled init, and validate only",
+        "Azure apply without separate explicit approval",
+    ]
+
+    assert all(term in normalized for term in required)
+
+
+def test_p9_06_plan_is_linked_from_docs() -> None:
+    roadmap = PLAN.read_text(encoding="utf-8")
+    nav = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "phase9/P9-06-WORKER-PLAN.md" in roadmap
+    assert "Phase 9 P9-06 Worker Plan: phase9/P9-06-WORKER-PLAN.md" in nav
+    assert "phase9/P9-06-WORKER-PLAN.md" in index

--- a/tests/unit/test_phase9_shadow_cli.py
+++ b/tests/unit/test_phase9_shadow_cli.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 
+from marketlab import cli as marketlab_cli
 from marketlab.shadow import cli
 
 
@@ -66,3 +68,70 @@ def test_shadow_cli_delegates_to_service(
     assert request.as_of == datetime(2026, 6, 11, 1, 15, tzinfo=UTC)
     assert captured["evaluation"].target_allocation == 0.5
     assert capsys.readouterr().out.strip().endswith("2026-06-11.json")
+
+
+@pytest.mark.parametrize(
+    ("command", "target", "argv"),
+    [
+        (
+            "phase9-shadow-decision",
+            "main",
+            [
+                "--config",
+                "config.yaml",
+                "--evaluation",
+                "evaluation.json",
+                "--panel",
+                "panel.csv",
+                "--as-of",
+                "2026-06-11T01:15:00Z",
+            ],
+        ),
+        (
+            "phase9-shadow-scheduler",
+            "scheduler_main",
+            [
+                "--config",
+                "config.yaml",
+                "--once",
+                "--as-of",
+                "2026-06-11T01:15:00Z",
+            ],
+        ),
+        (
+            "phase9-shadow-status",
+            "status_main",
+            ["--config", "config.yaml", "--as-of", "2026-06-30"],
+        ),
+        (
+            "phase9-shadow-report",
+            "report_main",
+            ["--config", "config.yaml", "--as-of", "2026-06-30"],
+        ),
+    ],
+)
+def test_marketlab_phase9_shadow_aliases_delegate_to_existing_console_parsers(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    target: str,
+    argv: list[str],
+) -> None:
+    captured = {}
+
+    def _delegate(args):
+        captured["argv"] = args
+        return 0
+
+    monkeypatch.setattr(marketlab_cli.shadow_cli, target, _delegate)
+
+    exit_code = marketlab_cli.main([command, *argv])
+
+    assert exit_code == 0
+    assert captured["argv"] == argv
+
+
+def test_marketlab_phase9_shadow_scheduler_alias_preserves_once_gate() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        marketlab_cli.main(["phase9-shadow-scheduler", "--config", "config.yaml"])
+
+    assert excinfo.value.code == 2

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,8 @@ commands =
     terraform fmt -check -recursive {tox_root}{/}infra{/}azure
     terraform -chdir={tox_root}{/}infra{/}azure{/}bootstrap init -backend=false -lockfile=readonly -input=false
     terraform -chdir={tox_root}{/}infra{/}azure{/}bootstrap validate -no-color
+    terraform -chdir={tox_root}{/}infra{/}azure{/}phase9-shadow init -backend=false -lockfile=readonly -input=false
+    terraform -chdir={tox_root}{/}infra{/}azure{/}phase9-shadow validate -no-color
 
 [testenv:typecheck]
 description = Run mypy across the current typed MarketLab module subset


### PR DESCRIPTION
## Summary

- Add the P9-06 BTC shadow Azure worker plan and docs links.
- Expose existing Phase 9 shadow scripts through `marketlab phase9-shadow-*` aliases for the Docker entrypoint.
- Add `infra/azure/phase9-shadow` as a disabled-by-default Terraform root with launch-gate variables, archive/restore runbook coverage, and alert/storage guardrail tests.

## Safety

- No Azure login, plan, apply, destroy, import, refresh-only plan, or provider registration was run.
- The Container Apps scheduled job defaults to manual trigger only; `enable_shadow_schedule = false`.
- BTC broker, approval, QQQ migration, Service Bus, and generic artifact-store work remain out of scope.

## Validation

- `python -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_phase9_azure_bootstrap.py tests/unit/test_phase9_shadow_cli.py`
- `python -m pytest -q tests/unit`
- `python -m ruff check .`
- `python -m mypy src/marketlab/shadow src/marketlab/cli.py`
- `python -m mkdocs build --strict`
- `python -m tox -e terraform`
- `py -3.14 -m tox -e preflight`
- `git diff --check`