### PR TITLE
feat(phase9): add hosted paper execution registry

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -322,7 +322,7 @@ working alerts, and a rehearsed rollback.
 | [P9-04](phase9/P9-04-WORKER-PLAN.md) | Shadow decision service and append-only journal | P9-03 | Label-safe, idempotent, conflict-preserving decisions |
 | P9-05 | Shadow scheduler, status, monthly, and final reports | P9-04 | Missing and failed runs explicit; reports cannot promote |
 | [P9-06](phase9/P9-06-WORKER-PLAN.md) | Azure shadow infrastructure and launch gate | P9-02, P9-05 | Disabled job validates; archive, restore, and alert tests pass |
-| P9-07 | Hosted execution context and deployment registry | P9-01 | All four paper phases share typed, idempotent metadata |
+| [P9-07](phase9/P9-07-WORKER-PLAN.md) | Hosted execution context and deployment registry | P9-01 | All four paper phases share typed, idempotent metadata |
 | P9-08 | PostgreSQL repositories and migrations | P9-07 | Filesystem, SQLite, and PostgreSQL contract suites pass |
 | P9-09 | Blob artifact store, outbox, and Service Bus adapters | P9-08 | Artifact parity and duplicate-delivery tests pass |
 | P9-10 | QQQ Azure Terraform and deployment pipeline | P9-02, P9-09 | Dev environment deploys disabled-by-default jobs using managed identity |
@@ -362,7 +362,9 @@ Phase 9 is complete when:
 P9-05 implementation details are frozen in
 [the worker plan](phase9/P9-05-WORKER-PLAN.md). P9-06 infrastructure and
 launch-gate details are frozen in
-[the Azure shadow worker plan](phase9/P9-06-WORKER-PLAN.md).
+[the Azure shadow worker plan](phase9/P9-06-WORKER-PLAN.md). P9-07 hosted
+execution and registry details are frozen in
+[the hosted execution worker plan](phase9/P9-07-WORKER-PLAN.md).
 - QQQ paper decision, approval, submission, reconciliation, notifications, and
   reporting run from Azure
 - PostgreSQL is canonical QQQ workflow state and Blob Storage contains the

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,5 +17,6 @@ This site is the canonical home for MarketLab's public documentation.
 - [Phase 9 P9-04 Worker Plan](phase9/P9-04-WORKER-PLAN.md)
 - [Phase 9 P9-05 Worker Plan](phase9/P9-05-WORKER-PLAN.md)
 - [Phase 9 P9-06 Worker Plan](phase9/P9-06-WORKER-PLAN.md)
+- [Phase 9 P9-07 Worker Plan](phase9/P9-07-WORKER-PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/phase9/P9-07-WORKER-PLAN.md
+++ b/docs/phase9/P9-07-WORKER-PLAN.md
@@ -1,0 +1,230 @@
+# P9-07 Worker Plan: Hosted Execution Context And Deployment Registry
+
+- Branch: `feature/phase-9-hosted-execution-registry`
+- Pull request: `feat(phase9): add hosted paper execution registry`
+- Dependency: P9-01 canonical Phase 9 roadmap
+
+P9-07 adds typed hosted execution metadata and local deployment registry
+adapters for the existing QQQ paper control plane. It prepares the paper
+phases for later hosted jobs while preserving the current local CLI, Docker,
+MCP, scheduler, approval worker, broker, proposal, approval, submission,
+reconciliation, notification, and report semantics.
+
+P9-07 is a local contract packet only. It does not add PostgreSQL, Blob
+Storage, Service Bus, QQQ Terraform, Azure SDK calls, managed identity wiring,
+broker behavior changes, strategy changes, config changes, or deployment
+automation. P9-08 owns PostgreSQL migrations. P9-09 owns Blob, outbox, and
+Service Bus adapters. P9-10 owns QQQ Azure Terraform and rollout wiring.
+
+## Checkpoint: 2026-06-20
+
+Current branch: `feature/phase-9-hosted-execution-registry`.
+
+Implemented so far:
+
+- added this P9-07 worker plan and linked it from `docs/PLAN.md`,
+  `docs/index.md`, `mkdocs.yml`, and `tests/unit/test_phase9_plan_docs.py`
+- added hosted execution contracts in `marketlab.paper.contracts`:
+  `PaperHostedExecutionContext`, `PaperDeploymentRecord`,
+  `PaperPhaseRunRecord`, `PaperDeploymentRegistry`, hosted environment and
+  phase literals, exact metadata field validation, and conflict error type
+- added filesystem and SQLite local registry adapters beside the existing paper
+  persistence adapters
+- filesystem registry writes under `paper_state_dir/deployments/` and
+  `paper_state_dir/phase-runs/`
+- SQLite registry adds local P9-07 registry tables only:
+  `paper_deployment_records` and `paper_phase_run_records`
+- duplicate hosted `idempotency_key` values with identical metadata are
+  accepted; conflicting metadata raises before paper phase side effects
+- threaded optional hosted metadata through `run_paper_decision`,
+  `decide_paper_proposal`, `run_paper_submit`, and
+  `reconcile_latest_submission_status`
+- threaded hosted metadata through scheduler and agent paths, deriving child
+  phase contexts from the supplied hosted job context
+- added CLI flags and `MARKETLAB_*` environment defaults for hosted metadata,
+  with explicit flags taking precedence
+- expanded unit coverage for contracts, adapter behavior, service guard
+  ordering, scheduler derivation, agent derivation, CLI precedence, partial
+  metadata rejection, and duplicate idempotency conflicts
+
+Validation completed before stopping:
+
+```text
+python -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_paper_contracts.py tests/unit/test_paper_persistence.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_agent.py tests/unit/test_cli.py
+# 111 passed
+
+python -m pytest -q tests/unit
+# 685 passed
+
+python -m ruff check .
+# All checks passed
+
+python -m mypy src/marketlab/log.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py src/marketlab/cli.py
+# Success: no issues found in 9 source files
+
+python -m mkdocs build --strict
+# passed
+
+git diff --check
+# passed, with only Git line-ending warnings
+```
+
+Preflight status:
+
+- `py -3.14 -m tox -e preflight` passed `lint`, `docs`, `typecheck`,
+  `package`, and `py312`
+- the first `integration` lane failed because `.tox/integration` was missing
+  `pyvenv.cfg` after a Windows virtualenv/cache issue
+- the tox integration environment was repaired with repo-local temp and
+  `VIRTUALENV_OVERRIDE_APP_DATA`
+- a follow-up integration run then failed during pytest basetemp cleanup with
+  `WinError 5` against `artifacts/tmp/pytest-integration`
+- the stale pytest temp directory was removed after path verification
+- the final integration rerun was intentionally interrupted by the user before
+  completion
+
+Resume checklist:
+
+- verify no stray Python/tox validation process is running
+- decide whether to remove the generated `.virtualenv-app-data/` directory
+  before publication
+- rerun the integration lane with repo-local temp settings:
+
+```text
+$env:TMP='C:\git\market-lab\artifacts\tmp'
+$env:TEMP='C:\git\market-lab\artifacts\tmp'
+$env:TMPDIR='C:\git\market-lab\artifacts\tmp'
+$env:VIRTUALENV_OVERRIDE_APP_DATA='C:\git\market-lab\.virtualenv-app-data'
+py -3.14 -m tox -e integration
+```
+
+- if integration passes, rerun full `py -3.14 -m tox -e preflight`
+- inspect `git status --short` and remove generated validation artifacts from
+  the working tree before committing
+- then review the diff for scope boundaries and, if still clean, continue with
+  the planned small-commit publication path
+
+## Hosted Metadata Contract
+
+Every hosted phase uses exactly these metadata fields:
+
+```text
+deployment_id
+environment
+phase
+execution_id
+correlation_id
+idempotency_key
+trigger_source
+requested_at
+config_version
+image_digest
+```
+
+Supported environments are `dev`, `uat`, and `paper-prod`. Supported phases
+are `decision`, `agent_approve`, `submit`, and `reconcile`.
+
+The public typed contracts are:
+
+- `PaperHostedExecutionContext`
+- `PaperDeploymentRecord`
+- `PaperPhaseRunRecord`
+- `PaperDeploymentRegistry`
+
+The existing structured log phases remain `paper-decision`, `paper-approve`,
+`paper-submit`, and `paper-submit-reconcile`; the hosted `phase` field is the
+registry contract and not a replacement for existing log names.
+
+## Local Registry Adapters
+
+The filesystem adapter writes under the existing paper state root:
+
+```text
+artifacts/paper/state/deployments/
+artifacts/paper/state/phase-runs/
+```
+
+The SQLite adapter adds local P9-07 registry tables beside the existing paper
+state tables. It does not mirror registry state to JSON and does not introduce
+PostgreSQL compatibility code.
+
+Duplicate `idempotency_key` values with identical metadata are accepted as
+idempotent repeats. Duplicate `idempotency_key` values with conflicting
+metadata raise before a paper phase creates providers, calls brokers, sends
+notifications, or mutates proposal, approval, submission, or reconciliation
+state.
+
+## Service Wiring
+
+The four phase entrypoints accept optional hosted metadata:
+
+```text
+run_paper_decision
+decide_paper_proposal
+run_paper_submit
+reconcile_latest_submission_status
+```
+
+When hosted metadata is missing, local behavior and existing log context
+remain unchanged. When hosted metadata is present, the service records the
+phase run before phase side effects and uses the hosted `execution_id` and
+`correlation_id` in structured logs.
+
+The scheduler derives child phase contexts for `decision`, `submit`, and
+`reconcile` from the scheduler job metadata. The agent approval worker derives
+one `agent_approve` context per proposal from the worker job metadata. Callers
+derive from the supplied hosted metadata rather than inventing unrelated phase
+identifiers.
+
+## CLI Contract
+
+Paper phase-capable CLI commands accept explicit hosted metadata flags and
+`MARKETLAB_*` environment defaults. Explicit flags win over environment
+values.
+
+```text
+--deployment-id        MARKETLAB_DEPLOYMENT_ID
+--environment          MARKETLAB_ENVIRONMENT
+--execution-id         MARKETLAB_EXECUTION_ID
+--correlation-id       MARKETLAB_CORRELATION_ID
+--idempotency-key      MARKETLAB_IDEMPOTENCY_KEY
+--trigger-source       MARKETLAB_TRIGGER_SOURCE
+--requested-at         MARKETLAB_REQUESTED_AT
+--config-version       MARKETLAB_CONFIG_VERSION
+--image-digest         MARKETLAB_IMAGE_DIGEST
+                       MARKETLAB_PHASE
+```
+
+`MARKETLAB_PHASE` is validated for direct phase commands. The scheduler may
+accept it as seed metadata because scheduler iterations can derive multiple
+phase contexts from one hosted job.
+
+Partial hosted metadata is rejected. If no hosted metadata is supplied, the CLI
+uses the existing local execution path.
+
+## Acceptance
+
+P9-07 is complete when:
+
+- docs and navigation link this worker plan
+- hosted contracts reject unsupported phases, environments, missing fields,
+  extra fields, and malformed `requested_at` values
+- filesystem and SQLite registry adapters share duplicate and conflict tests
+- service wrappers reject conflicting hosted metadata before phase side effects
+- scheduler and agent worker derive phase contexts from hosted job metadata
+- CLI flags override `MARKETLAB_*` values, partial metadata fails, and duplicate
+  idempotency conflicts surface through CLI execution
+- no trading semantics, strategy parameters, broker behavior, or approval
+  decisions change
+
+## Validation
+
+```text
+python -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_paper_contracts.py tests/unit/test_paper_persistence.py tests/unit/test_paper_service.py tests/unit/test_paper_scheduler.py tests/unit/test_paper_agent.py tests/unit/test_cli.py
+python -m pytest -q tests/unit
+python -m ruff check .
+python -m mypy src/marketlab/log.py src/marketlab/paper/observability.py src/marketlab/paper/contracts.py src/marketlab/paper/persistence/filesystem.py src/marketlab/paper/persistence/sqlite.py src/marketlab/paper/service.py src/marketlab/paper/agent.py src/marketlab/paper/scheduler.py src/marketlab/cli.py
+python -m mkdocs build --strict
+py -3.14 -m tox -e preflight
+git diff --check
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Phase 9 P9-04 Worker Plan: phase9/P9-04-WORKER-PLAN.md
   - Phase 9 P9-05 Worker Plan: phase9/P9-05-WORKER-PLAN.md
   - Phase 9 P9-06 Worker Plan: phase9/P9-06-WORKER-PLAN.md
+  - Phase 9 P9-07 Worker Plan: phase9/P9-07-WORKER-PLAN.md
 plugins:
   - search
 extra_javascript:

--- a/src/marketlab/cli.py
+++ b/src/marketlab/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from collections.abc import Callable
 from time import perf_counter
@@ -26,7 +27,9 @@ from marketlab.paper import (
     run_paper_submit,
     run_scheduler_loop,
 )
+from marketlab.paper.contracts import PaperHostedExecutionContext, PaperHostedPhase
 from marketlab.paper.observability import (
+    hosted_execution_details,
     paper_execution_context,
     root_execution_context,
 )
@@ -53,12 +56,84 @@ from marketlab.targets import build_modeling_dataset
 
 LOGGER = logging.getLogger(__name__)
 
+HOSTED_METADATA_ENV = {
+    "deployment_id": "MARKETLAB_DEPLOYMENT_ID",
+    "environment": "MARKETLAB_ENVIRONMENT",
+    "execution_id": "MARKETLAB_EXECUTION_ID",
+    "correlation_id": "MARKETLAB_CORRELATION_ID",
+    "idempotency_key": "MARKETLAB_IDEMPOTENCY_KEY",
+    "trigger_source": "MARKETLAB_TRIGGER_SOURCE",
+    "requested_at": "MARKETLAB_REQUESTED_AT",
+    "config_version": "MARKETLAB_CONFIG_VERSION",
+    "image_digest": "MARKETLAB_IMAGE_DIGEST",
+}
+HOSTED_COMMAND_PHASES: dict[str, PaperHostedPhase] = {
+    "paper-decision": "decision",
+    "paper-submit": "submit",
+    "paper-approve": "agent_approve",
+    "paper-agent-approve": "agent_approve",
+    "paper-scheduler": "decision",
+}
 SHADOW_COMMANDS = {
     "phase9-shadow-decision": "main",
     "phase9-shadow-scheduler": "scheduler_main",
     "phase9-shadow-status": "status_main",
     "phase9-shadow-report": "report_main",
 }
+
+
+def _add_hosted_execution_arguments(command: argparse.ArgumentParser) -> None:
+    command.add_argument("--deployment-id", dest="hosted_deployment_id")
+    command.add_argument("--environment", dest="hosted_environment")
+    command.add_argument("--execution-id", dest="hosted_execution_id")
+    command.add_argument("--correlation-id", dest="hosted_correlation_id")
+    command.add_argument("--idempotency-key", dest="hosted_idempotency_key")
+    command.add_argument("--trigger-source", dest="hosted_trigger_source")
+    command.add_argument("--requested-at", dest="hosted_requested_at")
+    command.add_argument("--config-version", dest="hosted_config_version")
+    command.add_argument("--image-digest", dest="hosted_image_digest")
+
+
+def _hosted_value(args: argparse.Namespace, field_name: str) -> str:
+    explicit = str(getattr(args, f"hosted_{field_name}", "") or "").strip()
+    if explicit != "":
+        return explicit
+    return os.environ.get(HOSTED_METADATA_ENV[field_name], "").strip()
+
+
+def _resolve_hosted_execution_context(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    *,
+    phase: PaperHostedPhase,
+    allow_env_phase: bool = False,
+) -> PaperHostedExecutionContext | None:
+    values = {
+        field_name: _hosted_value(args, field_name)
+        for field_name in HOSTED_METADATA_ENV
+    }
+    env_phase = os.environ.get("MARKETLAB_PHASE", "").strip()
+    if env_phase != "" and not allow_env_phase and env_phase != phase:
+        parser.error(f"MARKETLAB_PHASE={env_phase!r} does not match command phase {phase!r}.")
+    resolved_phase = env_phase if allow_env_phase and env_phase != "" else phase
+    if not any(values.values()) and env_phase == "":
+        return None
+    missing = [field_name for field_name, value in values.items() if value == ""]
+    if missing:
+        parser.error(
+            "Hosted paper execution metadata is incomplete; missing: "
+            + ", ".join(missing)
+        )
+    try:
+        return PaperHostedExecutionContext.from_metadata(
+            {
+                **values,
+                "phase": resolved_phase,
+            }
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    raise AssertionError("parser.error should exit")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -72,15 +147,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     paper_decision = subparsers.add_parser("paper-decision")
     paper_decision.add_argument("--config", required=True)
+    _add_hosted_execution_arguments(paper_decision)
 
     paper_submit = subparsers.add_parser("paper-submit")
     paper_submit.add_argument("--config", required=True)
+    _add_hosted_execution_arguments(paper_submit)
 
     paper_approve = subparsers.add_parser("paper-approve")
     paper_approve.add_argument("--config", required=True)
     paper_approve.add_argument("--proposal-id", required=True)
     paper_approve.add_argument("--decision", required=True, choices=("approve", "reject"))
     paper_approve.add_argument("--actor", required=True, choices=("agent", "manual"))
+    _add_hosted_execution_arguments(paper_approve)
 
     paper_status = subparsers.add_parser("paper-status")
     paper_status.add_argument("--config", required=True)
@@ -88,10 +166,12 @@ def build_parser() -> argparse.ArgumentParser:
     paper_agent_approve = subparsers.add_parser("paper-agent-approve")
     paper_agent_approve.add_argument("--config", required=True)
     paper_agent_approve.add_argument("--once", action="store_true")
+    _add_hosted_execution_arguments(paper_agent_approve)
 
     paper_scheduler = subparsers.add_parser("paper-scheduler")
     paper_scheduler.add_argument("--config", required=True)
     paper_scheduler.add_argument("--once", action="store_true")
+    _add_hosted_execution_arguments(paper_scheduler)
 
     paper_report = subparsers.add_parser("paper-report")
     paper_report.add_argument("--config", required=True)
@@ -178,12 +258,15 @@ def _run_logged_paper_command(
     *,
     action: Callable[[ExecutionContext], tuple[int, str | None]],
     proposal_id: str | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> int:
     root_context = root_execution_context(
-        deployment="local_cli",
+        deployment=hosted_context.deployment_id if hosted_context is not None else "local_cli",
         phase=command_name,
         proposal_id=proposal_id,
-        details={"command": command_name},
+        details=hosted_execution_details(hosted_context, {"command": command_name}),
+        execution_id=hosted_context.execution_id if hosted_context is not None else None,
+        correlation_id=hosted_context.correlation_id if hosted_context is not None else None,
     )
     emit_structured_log(
         LOGGER,
@@ -207,7 +290,7 @@ def _run_logged_paper_command(
                 phase=command_name,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"command": command_name},
+                details=hosted_execution_details(hosted_context, {"command": command_name}),
             ),
             exc_info=exc,
         )
@@ -222,7 +305,7 @@ def _run_logged_paper_command(
             phase=command_name,
             outcome=outcome or "success",
             duration_ms=duration_ms_since(start_time),
-            details={"command": command_name},
+            details=hosted_execution_details(hosted_context, {"command": command_name}),
         ),
     )
     return exit_code
@@ -232,8 +315,13 @@ def _run_paper_decision_command(
     config,
     *,
     execution_context: ExecutionContext,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> tuple[int, str | None]:
-    result = run_paper_decision(config, execution_context=execution_context)
+    result = run_paper_decision(
+        config,
+        execution_context=execution_context,
+        hosted_context=hosted_context,
+    )
     print(result.get("proposal_path", result["status_path"]))
     return 0, str(result.get("status", {}).get("status", "success"))
 
@@ -242,8 +330,13 @@ def _run_paper_submit_command(
     config,
     *,
     execution_context: ExecutionContext,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> tuple[int, str | None]:
-    result = run_paper_submit(config, execution_context=execution_context)
+    result = run_paper_submit(
+        config,
+        execution_context=execution_context,
+        hosted_context=hosted_context,
+    )
     print(result.get("submission_path", result["status_path"]))
     return 0, str(result.get("status", {}).get("status", "success"))
 
@@ -255,6 +348,7 @@ def _run_paper_approve_command(
     decision: str,
     actor: str,
     execution_context: ExecutionContext,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> tuple[int, str | None]:
     result = decide_paper_proposal(
         config,
@@ -262,6 +356,7 @@ def _run_paper_approve_command(
         decision=decision,
         actor=actor,
         execution_context=execution_context,
+        hosted_context=hosted_context,
     )
     print(result["approval_path"])
     return 0, str(result.get("status", {}).get("status", "success"))
@@ -282,9 +377,10 @@ def _run_paper_agent_approve_command(
     *,
     once: bool,
     execution_context: ExecutionContext,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> tuple[int, str | None]:
     del execution_context
-    run_agent_approval_loop(config, once=once)
+    run_agent_approval_loop(config, once=once, hosted_context=hosted_context)
     return 0, "success"
 
 
@@ -293,9 +389,10 @@ def _run_paper_scheduler_command(
     *,
     once: bool,
     execution_context: ExecutionContext,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> tuple[int, str | None]:
     del execution_context
-    run_scheduler_loop(config, once=once)
+    run_scheduler_loop(config, once=once, hosted_context=hosted_context)
     return 0, "success"
 
 
@@ -433,23 +530,35 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     load_env_file()
+    hosted_context = None
+    if args.command in HOSTED_COMMAND_PHASES:
+        hosted_context = _resolve_hosted_execution_context(
+            args,
+            parser,
+            phase=HOSTED_COMMAND_PHASES[args.command],
+            allow_env_phase=args.command == "paper-scheduler",
+        )
     config = load_config(args.config)
 
     if args.command == "paper-decision":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_decision_command(
                 config,
                 execution_context=execution_context,
+                hosted_context=hosted_context,
             ),
         )
 
     if args.command == "paper-submit":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_submit_command(
                 config,
                 execution_context=execution_context,
+                hosted_context=hosted_context,
             ),
         )
 
@@ -457,18 +566,21 @@ def main(argv: list[str] | None = None) -> int:
         return _run_logged_paper_command(
             args.command,
             proposal_id=args.proposal_id,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_approve_command(
                 config,
                 proposal_id=args.proposal_id,
                 decision=args.decision,
                 actor=args.actor,
                 execution_context=execution_context,
+                hosted_context=hosted_context,
             ),
         )
 
     if args.command == "paper-status":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_status_command(
                 config,
                 execution_context=execution_context,
@@ -478,26 +590,31 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "paper-agent-approve":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_agent_approve_command(
                 config,
                 once=args.once,
                 execution_context=execution_context,
+                hosted_context=hosted_context,
             ),
         )
 
     if args.command == "paper-scheduler":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_scheduler_command(
                 config,
                 once=args.once,
                 execution_context=execution_context,
+                hosted_context=hosted_context,
             ),
         )
 
     if args.command == "paper-report":
         return _run_logged_paper_command(
             args.command,
+            hosted_context=hosted_context,
             action=lambda execution_context: _run_paper_report_command(
                 config,
                 start_date=args.start,

--- a/src/marketlab/paper/agent.py
+++ b/src/marketlab/paper/agent.py
@@ -21,6 +21,7 @@ from marketlab.paper.contracts import (
     PaperApprovalEvaluationRequest,
     PaperApprovalResult,
     PaperBroker,
+    PaperHostedExecutionContext,
     PaperNotificationSink,
 )
 from marketlab.paper.notifications import (
@@ -28,7 +29,11 @@ from marketlab.paper.notifications import (
     build_error_fingerprint,
     build_telegram_paper_notification_sink,
 )
-from marketlab.paper.observability import paper_execution_context
+from marketlab.paper.observability import (
+    hosted_execution_details,
+    hosted_root_execution_context,
+    paper_execution_context,
+)
 from marketlab.paper.service import (
     APPROVAL_PENDING,
     _now_utc,
@@ -82,6 +87,19 @@ def _paper_notification_sink(config: ExperimentConfig) -> PaperNotificationSink:
 
 def _paper_approval_client(config: ExperimentConfig) -> PaperApprovalClient:
     return build_default_paper_approval_client(config)
+
+
+def _derive_agent_approval_context(
+    hosted_context: PaperHostedExecutionContext | None,
+    *,
+    proposal_id: str,
+) -> PaperHostedExecutionContext | None:
+    if hosted_context is None:
+        return None
+    return hosted_context.derive(
+        phase="agent_approve",
+        suffix=f"agent_approve:{proposal_id}",
+    )
 
 
 def _notify_worker_error(
@@ -156,13 +174,26 @@ def run_agent_approval_iteration(
     notification_sink: PaperNotificationSink | None = None,
     approval_client: PaperApprovalClient | None = None,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any]:
+    iteration_details = hosted_execution_details(
+        hosted_context,
+        {"component": "agent_iteration"},
+    )
     iteration_context = paper_execution_context(
-        execution_context,
+        (
+            hosted_root_execution_context(
+                hosted_context,
+                phase="paper-approve",
+                details=iteration_details,
+            )
+            if hosted_context is not None
+            else execution_context
+        ),
         phase="paper-approve",
-        deployment="paper_agent",
-        refresh_execution_id=True,
-        details={"component": "agent_iteration"},
+        deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
+        refresh_execution_id=hosted_context is None,
+        details=iteration_details,
     )
     emit_structured_log(
         LOGGER,
@@ -181,8 +212,8 @@ def run_agent_approval_iteration(
             paper_execution_context(
                 iteration_context,
                 phase="paper-approve",
-                deployment="paper_agent",
-                details={"component": "agent_iteration"},
+                deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
+                details=iteration_details,
             )
         ):
             if config.paper.execution_mode != "agent_approval":
@@ -229,12 +260,20 @@ def run_agent_approval_iteration(
                             fallback_reason=str(exc),
                             now=now,
                             notification_sink=notification_sink,
+                            hosted_context=_derive_agent_approval_context(
+                                hosted_context,
+                                proposal_id=str(proposal["proposal_id"]),
+                            ),
                             execution_context=paper_execution_context(
                                 iteration_context,
                                 phase="paper-approve",
-                                deployment="paper_agent",
+                                deployment=(
+                                    hosted_context.deployment_id
+                                    if hosted_context is not None
+                                    else "paper_agent"
+                                ),
                                 proposal=proposal,
-                                refresh_execution_id=True,
+                                refresh_execution_id=hosted_context is None,
                             ),
                         )
                         approval_result = PaperApprovalResult.from_legacy(result)
@@ -271,13 +310,21 @@ def run_agent_approval_iteration(
                             fallback_reason=decision.fallback_reason,
                             now=now,
                             notification_sink=notification_sink,
+                            hosted_context=_derive_agent_approval_context(
+                                hosted_context,
+                                proposal_id=str(proposal["proposal_id"]),
+                            ),
                             execution_context=paper_execution_context(
                                 iteration_context,
                                 phase="paper-approve",
-                                deployment="paper_agent",
+                                deployment=(
+                                    hosted_context.deployment_id
+                                    if hosted_context is not None
+                                    else "paper_agent"
+                                ),
                                 proposal=proposal,
                                 provider=decision.provider,
-                                refresh_execution_id=True,
+                                refresh_execution_id=hosted_context is None,
                             ),
                         )
                         approval_result = PaperApprovalResult.from_legacy(result)
@@ -320,10 +367,10 @@ def run_agent_approval_iteration(
             execution_context=paper_execution_context(
                 iteration_context,
                 phase="paper-approve",
-                deployment="paper_agent",
+                deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "agent_iteration"},
+                details=iteration_details,
             ),
             exc_info=exc,
         )
@@ -336,14 +383,17 @@ def run_agent_approval_iteration(
         execution_context=paper_execution_context(
             iteration_context,
             phase="paper-approve",
-            deployment="paper_agent",
+            deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
             outcome="processed" if summary["processed_count"] > 0 else state.get("last_result", "idle"),
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "agent_iteration",
-                "agent_state_path": summary["agent_state_path"],
-                "processed_count": summary["processed_count"],
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "agent_iteration",
+                    "agent_state_path": summary["agent_state_path"],
+                    "processed_count": summary["processed_count"],
+                },
+            ),
         ),
     )
     return summary
@@ -355,13 +405,27 @@ def run_agent_approval_loop(
     once: bool = False,
     notification_sink: PaperNotificationSink | None = None,
     approval_client: PaperApprovalClient | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> None:
     while True:
+        loop_details = hosted_execution_details(
+            hosted_context,
+            {"component": "agent_loop", "once": once},
+        )
         loop_context = paper_execution_context(
+            (
+                hosted_root_execution_context(
+                    hosted_context,
+                    phase="paper-approve",
+                    details=loop_details,
+                )
+                if hosted_context is not None
+                else None
+            ),
             phase="paper-approve",
-            deployment="paper_agent",
-            refresh_execution_id=True,
-            details={"component": "agent_loop", "once": once},
+            deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
+            refresh_execution_id=hosted_context is None,
+            details=loop_details,
         )
         emit_structured_log(
             LOGGER,
@@ -379,6 +443,7 @@ def run_agent_approval_loop(
                     notification_sink=notification_sink,
                     approval_client=approval_client,
                     execution_context=loop_context,
+                    hosted_context=hosted_context,
                 )
         except Exception as exc:
             loop_error = exc
@@ -409,14 +474,17 @@ def run_agent_approval_loop(
                 execution_context=paper_execution_context(
                     loop_context,
                     phase="paper-approve",
-                    deployment="paper_agent",
+                    deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
                     outcome="error",
                     duration_ms=duration_ms_since(start_time),
-                    details={
-                        "component": "agent_loop",
-                        "agent_state_path": summary["agent_state_path"],
-                        "duplicate_suppressed": notification_path is None,
-                    },
+                    details=hosted_execution_details(
+                        hosted_context,
+                        {
+                            "component": "agent_loop",
+                            "agent_state_path": summary["agent_state_path"],
+                            "duplicate_suppressed": notification_path is None,
+                        },
+                    ),
                 ),
                 exc_info=exc,
             )
@@ -429,14 +497,17 @@ def run_agent_approval_loop(
                 execution_context=paper_execution_context(
                     loop_context,
                     phase="paper-approve",
-                    deployment="paper_agent",
+                    deployment=hosted_context.deployment_id if hosted_context is not None else "paper_agent",
                     outcome="processed" if summary["processed_count"] > 0 else "idle",
                     duration_ms=duration_ms_since(start_time),
-                    details={
-                        "component": "agent_loop",
-                        "agent_state_path": summary["agent_state_path"],
-                        "processed_count": summary["processed_count"],
-                    },
+                    details=hosted_execution_details(
+                        hosted_context,
+                        {
+                            "component": "agent_loop",
+                            "agent_state_path": summary["agent_state_path"],
+                            "processed_count": summary["processed_count"],
+                        },
+                    ),
                 ),
             )
         print(json.dumps(summary, indent=2, sort_keys=True))

--- a/src/marketlab/paper/contracts.py
+++ b/src/marketlab/paper/contracts.py
@@ -4,10 +4,254 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, runtime_checkable
+from typing import Any, Literal, cast, runtime_checkable
 
 import pandas as pd
 from typing_extensions import Protocol
+
+PaperHostedEnvironment = Literal["dev", "uat", "paper-prod"]
+PaperHostedPhase = Literal["decision", "agent_approve", "submit", "reconcile"]
+
+PAPER_HOSTED_ENVIRONMENTS: frozenset[PaperHostedEnvironment] = frozenset(
+    ("dev", "uat", "paper-prod")
+)
+PAPER_HOSTED_PHASES: frozenset[PaperHostedPhase] = frozenset(
+    ("decision", "agent_approve", "submit", "reconcile")
+)
+PAPER_HOSTED_METADATA_FIELDS = (
+    "deployment_id",
+    "environment",
+    "phase",
+    "execution_id",
+    "correlation_id",
+    "idempotency_key",
+    "trigger_source",
+    "requested_at",
+    "config_version",
+    "image_digest",
+)
+
+
+class PaperDeploymentRegistryConflictError(RuntimeError):
+    """Raised when a hosted idempotency key is replayed with different metadata."""
+
+
+def _validated_hosted_metadata(payload: Mapping[str, Any]) -> dict[str, str]:
+    extra_keys = sorted(set(payload) - set(PAPER_HOSTED_METADATA_FIELDS))
+    if extra_keys:
+        joined = ", ".join(extra_keys)
+        raise ValueError(f"Paper hosted execution metadata contains unsupported fields: {joined}")
+    missing = [
+        key
+        for key in PAPER_HOSTED_METADATA_FIELDS
+        if str(payload.get(key, "")).strip() == ""
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(f"Paper hosted execution metadata is missing required fields: {joined}")
+    metadata = {key: str(payload[key]).strip() for key in PAPER_HOSTED_METADATA_FIELDS}
+    environment = metadata["environment"]
+    if environment not in PAPER_HOSTED_ENVIRONMENTS:
+        allowed = ", ".join(PAPER_HOSTED_ENVIRONMENTS)
+        raise ValueError(f"Unsupported paper hosted environment: {environment}. Expected one of: {allowed}")
+    phase = metadata["phase"]
+    if phase not in PAPER_HOSTED_PHASES:
+        allowed = ", ".join(PAPER_HOSTED_PHASES)
+        raise ValueError(f"Unsupported paper hosted phase: {phase}. Expected one of: {allowed}")
+    try:
+        datetime.fromisoformat(metadata["requested_at"].replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("Paper hosted requested_at must be an ISO-8601 datetime.") from exc
+    return metadata
+
+
+def _derive_hosted_value(value: str, *, suffix: str) -> str:
+    suffix_value = suffix.strip()
+    if suffix_value == "":
+        return value
+    return f"{value}:{suffix_value}"
+
+
+@dataclass(slots=True, frozen=True)
+class PaperHostedExecutionContext:
+    deployment_id: str
+    environment: PaperHostedEnvironment
+    phase: PaperHostedPhase
+    execution_id: str
+    correlation_id: str
+    idempotency_key: str
+    trigger_source: str
+    requested_at: str
+    config_version: str
+    image_digest: str
+
+    def __post_init__(self) -> None:
+        _validated_hosted_metadata(self.as_metadata())
+
+    @classmethod
+    def from_metadata(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> PaperHostedExecutionContext:
+        metadata = _validated_hosted_metadata(payload)
+        return cls(
+            deployment_id=metadata["deployment_id"],
+            environment=cast(PaperHostedEnvironment, metadata["environment"]),
+            phase=cast(PaperHostedPhase, metadata["phase"]),
+            execution_id=metadata["execution_id"],
+            correlation_id=metadata["correlation_id"],
+            idempotency_key=metadata["idempotency_key"],
+            trigger_source=metadata["trigger_source"],
+            requested_at=metadata["requested_at"],
+            config_version=metadata["config_version"],
+            image_digest=metadata["image_digest"],
+        )
+
+    def as_metadata(self) -> dict[str, str]:
+        return {
+            "deployment_id": self.deployment_id,
+            "environment": self.environment,
+            "phase": self.phase,
+            "execution_id": self.execution_id,
+            "correlation_id": self.correlation_id,
+            "idempotency_key": self.idempotency_key,
+            "trigger_source": self.trigger_source,
+            "requested_at": self.requested_at,
+            "config_version": self.config_version,
+            "image_digest": self.image_digest,
+        }
+
+    def derive(
+        self,
+        *,
+        phase: PaperHostedPhase,
+        suffix: str = "",
+    ) -> PaperHostedExecutionContext:
+        if self.phase == phase and suffix.strip() == "":
+            return self
+        return PaperHostedExecutionContext(
+            deployment_id=self.deployment_id,
+            environment=self.environment,
+            phase=phase,
+            execution_id=_derive_hosted_value(self.execution_id, suffix=phase if suffix == "" else suffix),
+            correlation_id=self.correlation_id,
+            idempotency_key=_derive_hosted_value(
+                self.idempotency_key,
+                suffix=phase if suffix == "" else suffix,
+            ),
+            trigger_source=self.trigger_source,
+            requested_at=self.requested_at,
+            config_version=self.config_version,
+            image_digest=self.image_digest,
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class PaperDeploymentRecord:
+    deployment_id: str
+    environment: PaperHostedEnvironment
+    phase: PaperHostedPhase
+    execution_id: str
+    correlation_id: str
+    idempotency_key: str
+    trigger_source: str
+    requested_at: str
+    config_version: str
+    image_digest: str
+
+    @classmethod
+    def from_context(
+        cls,
+        context: PaperHostedExecutionContext,
+    ) -> PaperDeploymentRecord:
+        return cls(
+            deployment_id=context.deployment_id,
+            environment=context.environment,
+            phase=context.phase,
+            execution_id=context.execution_id,
+            correlation_id=context.correlation_id,
+            idempotency_key=context.idempotency_key,
+            trigger_source=context.trigger_source,
+            requested_at=context.requested_at,
+            config_version=context.config_version,
+            image_digest=context.image_digest,
+        )
+
+    @classmethod
+    def from_metadata(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> PaperDeploymentRecord:
+        context = PaperHostedExecutionContext.from_metadata(payload)
+        return cls.from_context(context)
+
+    def as_metadata(self) -> dict[str, str]:
+        return {
+            "deployment_id": self.deployment_id,
+            "environment": self.environment,
+            "phase": self.phase,
+            "execution_id": self.execution_id,
+            "correlation_id": self.correlation_id,
+            "idempotency_key": self.idempotency_key,
+            "trigger_source": self.trigger_source,
+            "requested_at": self.requested_at,
+            "config_version": self.config_version,
+            "image_digest": self.image_digest,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class PaperPhaseRunRecord:
+    deployment_id: str
+    environment: PaperHostedEnvironment
+    phase: PaperHostedPhase
+    execution_id: str
+    correlation_id: str
+    idempotency_key: str
+    trigger_source: str
+    requested_at: str
+    config_version: str
+    image_digest: str
+
+    @classmethod
+    def from_context(
+        cls,
+        context: PaperHostedExecutionContext,
+    ) -> PaperPhaseRunRecord:
+        return cls(
+            deployment_id=context.deployment_id,
+            environment=context.environment,
+            phase=context.phase,
+            execution_id=context.execution_id,
+            correlation_id=context.correlation_id,
+            idempotency_key=context.idempotency_key,
+            trigger_source=context.trigger_source,
+            requested_at=context.requested_at,
+            config_version=context.config_version,
+            image_digest=context.image_digest,
+        )
+
+    @classmethod
+    def from_metadata(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> PaperPhaseRunRecord:
+        context = PaperHostedExecutionContext.from_metadata(payload)
+        return cls.from_context(context)
+
+    def as_metadata(self) -> dict[str, str]:
+        return {
+            "deployment_id": self.deployment_id,
+            "environment": self.environment,
+            "phase": self.phase,
+            "execution_id": self.execution_id,
+            "correlation_id": self.correlation_id,
+            "idempotency_key": self.idempotency_key,
+            "trigger_source": self.trigger_source,
+            "requested_at": self.requested_at,
+            "config_version": self.config_version,
+            "image_digest": self.image_digest,
+        }
 
 
 def _string_field(payload: dict[str, Any], key: str) -> str:
@@ -158,6 +402,19 @@ class PaperUnitOfWork(Protocol):
 @runtime_checkable
 class PaperUnitOfWorkFactory(Protocol):
     def __call__(self) -> PaperUnitOfWork: ...
+
+
+@runtime_checkable
+class PaperDeploymentRegistry(Protocol):
+    def record_deployment(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperDeploymentRecord: ...
+
+    def record_phase_run(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperPhaseRunRecord: ...
 
 
 @runtime_checkable

--- a/src/marketlab/paper/observability.py
+++ b/src/marketlab/paper/observability.py
@@ -9,6 +9,7 @@ from marketlab.log import (
     create_execution_context,
     current_execution_context,
 )
+from marketlab.paper.contracts import PaperHostedExecutionContext
 
 
 def _first_non_empty(*values: object) -> str | None:
@@ -27,6 +28,8 @@ def root_execution_context(
     trade_date: str | None = None,
     provider: str | None = None,
     details: Mapping[str, Any] | None = None,
+    execution_id: str | None = None,
+    correlation_id: str | None = None,
 ) -> ExecutionContext:
     return create_execution_context(
         deployment=deployment,
@@ -35,6 +38,46 @@ def root_execution_context(
         trade_date=trade_date,
         provider=provider,
         details=details,
+        execution_id=execution_id,
+        correlation_id=correlation_id,
+    )
+
+
+def hosted_execution_details(
+    hosted_context: PaperHostedExecutionContext | None,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    merged = {str(key): value for key, value in (details or {}).items()}
+    if hosted_context is None:
+        return merged
+    merged.update(
+        {
+            "hosted_environment": hosted_context.environment,
+            "hosted_phase": hosted_context.phase,
+            "idempotency_key": hosted_context.idempotency_key,
+            "trigger_source": hosted_context.trigger_source,
+            "requested_at": hosted_context.requested_at,
+            "config_version": hosted_context.config_version,
+            "image_digest": hosted_context.image_digest,
+        }
+    )
+    return merged
+
+
+def hosted_root_execution_context(
+    hosted_context: PaperHostedExecutionContext,
+    *,
+    phase: str,
+    provider: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> ExecutionContext:
+    return root_execution_context(
+        deployment=hosted_context.deployment_id,
+        phase=phase,
+        provider=provider,
+        execution_id=hosted_context.execution_id,
+        correlation_id=hosted_context.correlation_id,
+        details=hosted_execution_details(hosted_context, details),
     )
 
 

--- a/src/marketlab/paper/persistence/__init__.py
+++ b/src/marketlab/paper/persistence/__init__.py
@@ -1,23 +1,31 @@
 from .filesystem import (
     FilesystemPaperArtifactStore,
+    FilesystemPaperDeploymentRegistry,
     FilesystemPaperUnitOfWork,
     FilesystemPaperUnitOfWorkFactory,
     build_filesystem_paper_artifact_store,
+    build_filesystem_paper_deployment_registry,
     build_filesystem_paper_uow_factory,
 )
 from .sqlite import (
+    SQLitePaperDeploymentRegistry,
     SQLitePaperUnitOfWork,
     SQLitePaperUnitOfWorkFactory,
+    build_sqlite_paper_deployment_registry,
     build_sqlite_paper_uow_factory,
 )
 
 __all__ = [
+    "FilesystemPaperDeploymentRegistry",
     "FilesystemPaperArtifactStore",
     "FilesystemPaperUnitOfWork",
     "FilesystemPaperUnitOfWorkFactory",
+    "SQLitePaperDeploymentRegistry",
     "SQLitePaperUnitOfWork",
     "SQLitePaperUnitOfWorkFactory",
+    "build_filesystem_paper_deployment_registry",
     "build_filesystem_paper_artifact_store",
     "build_filesystem_paper_uow_factory",
+    "build_sqlite_paper_deployment_registry",
     "build_sqlite_paper_uow_factory",
 ]

--- a/src/marketlab/paper/persistence/filesystem.py
+++ b/src/marketlab/paper/persistence/filesystem.py
@@ -27,18 +27,19 @@ def _path_token(value: str) -> str:
     return quote(value, safe="")
 
 
-def _write_idempotent_metadata(path: Path, payload: dict[str, str]) -> None:
+def _write_idempotent_metadata(path: Path, payload: dict[str, str]) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with path.open("x", encoding="utf-8") as handle:
             handle.write(f"{json.dumps(payload, indent=2, sort_keys=True)}\n")
-        return
+        return True
     except FileExistsError:
         existing = _json_load(path)
     if existing != payload:
         raise PaperDeploymentRegistryConflictError(
             f"Hosted execution idempotency conflict at {path}."
         )
+    return False
 
 
 class FilesystemPaperTradeRepository(PaperTradeRepository):
@@ -215,8 +216,14 @@ class FilesystemPaperDeploymentRegistry(PaperDeploymentRegistry):
         self,
         context: PaperHostedExecutionContext,
     ) -> PaperPhaseRunRecord:
-        _write_idempotent_metadata(self._phase_run_path(context), context.as_metadata())
-        self.record_deployment(context)
+        phase_run_path = self._phase_run_path(context)
+        phase_run_created = _write_idempotent_metadata(phase_run_path, context.as_metadata())
+        try:
+            self.record_deployment(context)
+        except Exception:
+            if phase_run_created:
+                phase_run_path.unlink(missing_ok=True)
+            raise
         return PaperPhaseRunRecord.from_context(context)
 
 

--- a/src/marketlab/paper/persistence/filesystem.py
+++ b/src/marketlab/paper/persistence/filesystem.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from marketlab.config import ExperimentConfig
 from marketlab.paper.contracts import (
     PaperArtifactStore,
+    PaperDeploymentRecord,
+    PaperDeploymentRegistry,
+    PaperDeploymentRegistryConflictError,
+    PaperHostedExecutionContext,
+    PaperPhaseRunRecord,
     PaperStatusRepository,
     PaperTradeRepository,
     PaperUnitOfWork,
@@ -14,6 +21,24 @@ from marketlab.paper.contracts import (
 )
 from marketlab.paper.core import _now_utc
 from marketlab.paper.state import PaperStateStore, _json_dump, _json_load
+
+
+def _path_token(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _write_idempotent_metadata(path: Path, payload: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8") as handle:
+            handle.write(f"{json.dumps(payload, indent=2, sort_keys=True)}\n")
+        return
+    except FileExistsError:
+        existing = _json_load(path)
+    if existing != payload:
+        raise PaperDeploymentRegistryConflictError(
+            f"Hosted execution idempotency conflict at {path}."
+        )
 
 
 class FilesystemPaperTradeRepository(PaperTradeRepository):
@@ -158,6 +183,43 @@ class FilesystemPaperStatusRepository(PaperStatusRepository):
         return self.status_path
 
 
+class FilesystemPaperDeploymentRegistry(PaperDeploymentRegistry):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._store = PaperStateStore(config)
+
+    def _deployment_path(self, context: PaperHostedExecutionContext) -> Path:
+        return (
+            self._store.state_root
+            / "deployments"
+            / context.environment
+            / _path_token(context.deployment_id)
+            / context.phase
+            / f"{_path_token(context.execution_id)}.json"
+        )
+
+    def _phase_run_path(self, context: PaperHostedExecutionContext) -> Path:
+        return (
+            self._store.state_root
+            / "phase-runs"
+            / f"{_path_token(context.idempotency_key)}.json"
+        )
+
+    def record_deployment(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperDeploymentRecord:
+        _write_idempotent_metadata(self._deployment_path(context), context.as_metadata())
+        return PaperDeploymentRecord.from_context(context)
+
+    def record_phase_run(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperPhaseRunRecord:
+        _write_idempotent_metadata(self._phase_run_path(context), context.as_metadata())
+        self.record_deployment(context)
+        return PaperPhaseRunRecord.from_context(context)
+
+
 class FilesystemPaperUnitOfWork(PaperUnitOfWork):
     def __init__(self, config: ExperimentConfig) -> None:
         self._store = PaperStateStore(config)
@@ -201,6 +263,12 @@ class FilesystemPaperUnitOfWorkFactory(PaperUnitOfWorkFactory):
 
 def build_filesystem_paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
     return FilesystemPaperUnitOfWorkFactory(config)
+
+
+def build_filesystem_paper_deployment_registry(
+    config: ExperimentConfig,
+) -> PaperDeploymentRegistry:
+    return FilesystemPaperDeploymentRegistry(config)
 
 
 class FilesystemPaperArtifactStore(PaperArtifactStore):

--- a/src/marketlab/paper/persistence/sqlite.py
+++ b/src/marketlab/paper/persistence/sqlite.py
@@ -8,6 +8,11 @@ from typing import Any
 
 from marketlab.config import ExperimentConfig
 from marketlab.paper.contracts import (
+    PaperDeploymentRecord,
+    PaperDeploymentRegistry,
+    PaperDeploymentRegistryConflictError,
+    PaperHostedExecutionContext,
+    PaperPhaseRunRecord,
     PaperStatusRepository,
     PaperTradeRepository,
     PaperUnitOfWork,
@@ -58,6 +63,24 @@ _SCHEMA_STATEMENTS = (
         payload_json TEXT NOT NULL
     )
     """,
+    """
+    CREATE TABLE IF NOT EXISTS paper_deployment_records (
+        environment TEXT NOT NULL,
+        deployment_id TEXT NOT NULL,
+        phase TEXT NOT NULL,
+        execution_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        PRIMARY KEY (environment, deployment_id, phase, execution_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS paper_phase_run_records (
+        idempotency_key TEXT PRIMARY KEY,
+        phase TEXT NOT NULL,
+        payload_json TEXT NOT NULL
+    )
+    """,
 )
 
 
@@ -74,6 +97,26 @@ def _row_payload(row: sqlite3.Row | None) -> dict[str, Any] | None:
 def _ensure_schema(connection: sqlite3.Connection) -> None:
     for statement in _SCHEMA_STATEMENTS:
         connection.execute(statement)
+
+
+def _metadata_json(payload: dict[str, str]) -> str:
+    return json.dumps(payload, sort_keys=True)
+
+
+def _ensure_identical_payload(
+    *,
+    row: sqlite3.Row | None,
+    payload: dict[str, str],
+    conflict_target: str,
+) -> bool:
+    if row is None:
+        return False
+    existing = json.loads(str(row["payload_json"]))
+    if existing != payload:
+        raise PaperDeploymentRegistryConflictError(
+            f"Hosted execution idempotency conflict for {conflict_target}."
+        )
+    return True
 
 
 def _snapshot_artifacts(paths: list[Path]) -> dict[Path, bytes | None]:
@@ -320,6 +363,162 @@ class SQLitePaperStatusRepository(PaperStatusRepository):
         return self.status_path
 
 
+class SQLitePaperDeploymentRegistry(PaperDeploymentRegistry):
+    def __init__(self, config: ExperimentConfig) -> None:
+        self._db_path = config.paper_sqlite_db_path
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._db_path)
+        connection.row_factory = sqlite3.Row
+        _ensure_schema(connection)
+        return connection
+
+    def record_deployment(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperDeploymentRecord:
+        payload = context.as_metadata()
+        payload_json = _metadata_json(payload)
+        connection = self._connect()
+        try:
+            with connection:
+                row = connection.execute(
+                    """
+                    SELECT payload_json
+                    FROM paper_deployment_records
+                    WHERE environment = ?
+                      AND deployment_id = ?
+                      AND phase = ?
+                      AND execution_id = ?
+                    """,
+                    (
+                        context.environment,
+                        context.deployment_id,
+                        context.phase,
+                        context.execution_id,
+                    ),
+                ).fetchone()
+                if not _ensure_identical_payload(
+                    row=row,
+                    payload=payload,
+                    conflict_target=(
+                        f"deployment {context.environment}/{context.deployment_id}/"
+                        f"{context.phase}/{context.execution_id}"
+                    ),
+                ):
+                    connection.execute(
+                        """
+                        INSERT INTO paper_deployment_records (
+                            environment,
+                            deployment_id,
+                            phase,
+                            execution_id,
+                            idempotency_key,
+                            payload_json
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            context.environment,
+                            context.deployment_id,
+                            context.phase,
+                            context.execution_id,
+                            context.idempotency_key,
+                            payload_json,
+                        ),
+                    )
+        finally:
+            connection.close()
+        return PaperDeploymentRecord.from_context(context)
+
+    def record_phase_run(
+        self,
+        context: PaperHostedExecutionContext,
+    ) -> PaperPhaseRunRecord:
+        payload = context.as_metadata()
+        payload_json = _metadata_json(payload)
+        connection = self._connect()
+        try:
+            with connection:
+                row = connection.execute(
+                    """
+                    SELECT payload_json
+                    FROM paper_phase_run_records
+                    WHERE idempotency_key = ?
+                    """,
+                    (context.idempotency_key,),
+                ).fetchone()
+                if not _ensure_identical_payload(
+                    row=row,
+                    payload=payload,
+                    conflict_target=f"idempotency key {context.idempotency_key}",
+                ):
+                    connection.execute(
+                        """
+                        INSERT INTO paper_phase_run_records (
+                            idempotency_key,
+                            phase,
+                            payload_json
+                        )
+                        VALUES (?, ?, ?)
+                        """,
+                        (
+                            context.idempotency_key,
+                            context.phase,
+                            payload_json,
+                        ),
+                    )
+                row = connection.execute(
+                    """
+                    SELECT payload_json
+                    FROM paper_deployment_records
+                    WHERE environment = ?
+                      AND deployment_id = ?
+                      AND phase = ?
+                      AND execution_id = ?
+                    """,
+                    (
+                        context.environment,
+                        context.deployment_id,
+                        context.phase,
+                        context.execution_id,
+                    ),
+                ).fetchone()
+                if not _ensure_identical_payload(
+                    row=row,
+                    payload=payload,
+                    conflict_target=(
+                        f"deployment {context.environment}/{context.deployment_id}/"
+                        f"{context.phase}/{context.execution_id}"
+                    ),
+                ):
+                    connection.execute(
+                        """
+                        INSERT INTO paper_deployment_records (
+                            environment,
+                            deployment_id,
+                            phase,
+                            execution_id,
+                            idempotency_key,
+                            payload_json
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            context.environment,
+                            context.deployment_id,
+                            context.phase,
+                            context.execution_id,
+                            context.idempotency_key,
+                            payload_json,
+                        ),
+                    )
+        finally:
+            connection.close()
+        return PaperPhaseRunRecord.from_context(context)
+
+
 class SQLitePaperUnitOfWork(PaperUnitOfWork):
     def __init__(self, config: ExperimentConfig) -> None:
         self._store = PaperStateStore(config)
@@ -392,3 +591,7 @@ class SQLitePaperUnitOfWorkFactory(PaperUnitOfWorkFactory):
 
 def build_sqlite_paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
     return SQLitePaperUnitOfWorkFactory(config)
+
+
+def build_sqlite_paper_deployment_registry(config: ExperimentConfig) -> PaperDeploymentRegistry:
+    return SQLitePaperDeploymentRegistry(config)

--- a/src/marketlab/paper/scheduler.py
+++ b/src/marketlab/paper/scheduler.py
@@ -17,6 +17,8 @@ from marketlab.log import (
 )
 from marketlab.paper.contracts import (
     PaperDecisionResult,
+    PaperHostedExecutionContext,
+    PaperHostedPhase,
     PaperNotificationSink,
     PaperReconciliationResult,
     PaperSubmissionResult,
@@ -26,7 +28,11 @@ from marketlab.paper.notifications import (
     build_error_fingerprint,
     build_telegram_paper_notification_sink,
 )
-from marketlab.paper.observability import paper_execution_context
+from marketlab.paper.observability import (
+    hosted_execution_details,
+    hosted_root_execution_context,
+    paper_execution_context,
+)
 from marketlab.paper.service import (
     PaperStateStore,
     _clock_value,
@@ -73,6 +79,17 @@ def _clear_scheduler_error_state(state: dict[str, Any]) -> None:
 
 def _paper_notification_sink(config: ExperimentConfig) -> PaperNotificationSink:
     return build_telegram_paper_notification_sink(config)
+
+
+def _derive_hosted_phase_context(
+    hosted_context: PaperHostedExecutionContext | None,
+    *,
+    phase: PaperHostedPhase,
+    suffix: str,
+) -> PaperHostedExecutionContext | None:
+    if hosted_context is None:
+        return None
+    return hosted_context.derive(phase=phase, suffix=f"{phase}:{suffix}")
 
 
 def _notify_scheduler_error(
@@ -129,13 +146,26 @@ def run_scheduler_iteration(
     now: datetime | None = None,
     notification_sink: PaperNotificationSink | None = None,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any]:
+    iteration_details = hosted_execution_details(
+        hosted_context,
+        {"component": "scheduler_iteration"},
+    )
     iteration_context = paper_execution_context(
-        execution_context,
+        (
+            hosted_root_execution_context(
+                hosted_context,
+                phase="paper-scheduler",
+                details=iteration_details,
+            )
+            if hosted_context is not None
+            else execution_context
+        ),
         phase="paper-scheduler",
-        deployment="paper_scheduler",
-        refresh_execution_id=True,
-        details={"component": "scheduler_iteration"},
+        deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
+        refresh_execution_id=hosted_context is None,
+        details=iteration_details,
     )
     emit_structured_log(
         LOGGER,
@@ -156,24 +186,34 @@ def run_scheduler_iteration(
             paper_execution_context(
                 iteration_context,
                 phase="paper-scheduler",
-                deployment="paper_scheduler",
+                deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
                 trade_date=market_date,
-                details={"component": "scheduler_iteration"},
+                details=iteration_details,
             )
         ):
             if local_now.time() >= decision_clock and state.get("last_decision_market_date") != market_date:
                 try:
+                    phase_hosted_context = _derive_hosted_phase_context(
+                        hosted_context,
+                        phase="decision",
+                        suffix=market_date,
+                    )
                     result = run_paper_decision(
                         config,
                         now=now,
                         notification_sink=notification_sink,
+                        hosted_context=phase_hosted_context,
                         execution_context=paper_execution_context(
                             iteration_context,
                             phase="paper-decision",
-                            deployment="paper_scheduler",
+                            deployment=(
+                                hosted_context.deployment_id
+                                if hosted_context is not None
+                                else "paper_scheduler"
+                            ),
                             trade_date=market_date,
                             provider=config.paper.data_provider,
-                            refresh_execution_id=True,
+                            refresh_execution_id=phase_hosted_context is None,
                         ),
                     )
                     decision_result = PaperDecisionResult.from_legacy(result)
@@ -189,17 +229,27 @@ def run_scheduler_iteration(
 
             if local_now.time() >= submission_clock and state.get("last_submission_market_date") != market_date:
                 try:
+                    phase_hosted_context = _derive_hosted_phase_context(
+                        hosted_context,
+                        phase="submit",
+                        suffix=market_date,
+                    )
                     result = run_paper_submit(
                         config,
                         now=now,
                         notification_sink=notification_sink,
+                        hosted_context=phase_hosted_context,
                         execution_context=paper_execution_context(
                             iteration_context,
                             phase="paper-submit",
-                            deployment="paper_scheduler",
+                            deployment=(
+                                hosted_context.deployment_id
+                                if hosted_context is not None
+                                else "paper_scheduler"
+                            ),
                             trade_date=market_date,
                             provider=config.paper.broker,
-                            refresh_execution_id=True,
+                            refresh_execution_id=phase_hosted_context is None,
                         ),
                     )
                     submission_result = PaperSubmissionResult.from_legacy(result)
@@ -217,16 +267,26 @@ def run_scheduler_iteration(
                 state["last_submission_at"] = _now_utc(now).isoformat()
 
             try:
+                phase_hosted_context = _derive_hosted_phase_context(
+                    hosted_context,
+                    phase="reconcile",
+                    suffix=market_date,
+                )
                 reconciliation = reconcile_latest_submission_status(
                     config,
                     now=now,
+                    hosted_context=phase_hosted_context,
                     execution_context=paper_execution_context(
                         iteration_context,
                         phase="paper-submit-reconcile",
-                        deployment="paper_scheduler",
+                        deployment=(
+                            hosted_context.deployment_id
+                            if hosted_context is not None
+                            else "paper_scheduler"
+                        ),
                         trade_date=market_date,
                         provider=config.paper.broker,
-                        refresh_execution_id=True,
+                        refresh_execution_id=phase_hosted_context is None,
                     ),
                 )
             except Exception as exc:
@@ -260,11 +320,11 @@ def run_scheduler_iteration(
             execution_context=paper_execution_context(
                 iteration_context,
                 phase="paper-scheduler",
-                deployment="paper_scheduler",
+                deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
                 trade_date=market_date,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "scheduler_iteration"},
+                details=iteration_details,
             ),
             exc_info=exc,
         )
@@ -277,15 +337,18 @@ def run_scheduler_iteration(
         execution_context=paper_execution_context(
             iteration_context,
             phase="paper-scheduler",
-            deployment="paper_scheduler",
+            deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
             trade_date=market_date,
             outcome="events_recorded" if events else "idle",
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "scheduler_iteration",
-                "event_count": len(events),
-                "scheduler_state_path": summary["scheduler_state_path"],
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "scheduler_iteration",
+                    "event_count": len(events),
+                    "scheduler_state_path": summary["scheduler_state_path"],
+                },
+            ),
         ),
     )
     return summary
@@ -296,13 +359,27 @@ def run_scheduler_loop(
     *,
     once: bool = False,
     notification_sink: PaperNotificationSink | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> None:
     while True:
+        loop_details = hosted_execution_details(
+            hosted_context,
+            {"component": "scheduler_loop", "once": once},
+        )
         loop_context = paper_execution_context(
+            (
+                hosted_root_execution_context(
+                    hosted_context,
+                    phase="paper-scheduler",
+                    details=loop_details,
+                )
+                if hosted_context is not None
+                else None
+            ),
             phase="paper-scheduler",
-            deployment="paper_scheduler",
-            refresh_execution_id=True,
-            details={"component": "scheduler_loop", "once": once},
+            deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
+            refresh_execution_id=hosted_context is None,
+            details=loop_details,
         )
         emit_structured_log(
             LOGGER,
@@ -319,6 +396,7 @@ def run_scheduler_loop(
                     config,
                     notification_sink=notification_sink,
                     execution_context=loop_context,
+                    hosted_context=hosted_context,
                 )
         except Exception as exc:
             loop_error = exc
@@ -348,14 +426,17 @@ def run_scheduler_loop(
                 execution_context=paper_execution_context(
                     loop_context,
                     phase="paper-scheduler",
-                    deployment="paper_scheduler",
+                    deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
                     outcome="error",
                     duration_ms=duration_ms_since(start_time),
-                    details={
-                        "component": "scheduler_loop",
-                        "scheduler_state_path": summary["scheduler_state_path"],
-                        "duplicate_suppressed": notification_path is None,
-                    },
+                    details=hosted_execution_details(
+                        hosted_context,
+                        {
+                            "component": "scheduler_loop",
+                            "scheduler_state_path": summary["scheduler_state_path"],
+                            "duplicate_suppressed": notification_path is None,
+                        },
+                    ),
                 ),
                 exc_info=exc,
             )
@@ -368,14 +449,17 @@ def run_scheduler_loop(
                 execution_context=paper_execution_context(
                     loop_context,
                     phase="paper-scheduler",
-                    deployment="paper_scheduler",
+                    deployment=hosted_context.deployment_id if hosted_context is not None else "paper_scheduler",
                     outcome="events_recorded" if summary["events"] else "idle",
                     duration_ms=duration_ms_since(start_time),
-                    details={
-                        "component": "scheduler_loop",
-                        "scheduler_state_path": summary["scheduler_state_path"],
-                        "event_count": len(summary["events"]),
-                    },
+                    details=hosted_execution_details(
+                        hosted_context,
+                        {
+                            "component": "scheduler_loop",
+                            "scheduler_state_path": summary["scheduler_state_path"],
+                            "event_count": len(summary["events"]),
+                        },
+                    ),
                 ),
             )
         print(json.dumps(summary, indent=2, sort_keys=True))

--- a/src/marketlab/paper/service.py
+++ b/src/marketlab/paper/service.py
@@ -25,8 +25,11 @@ from marketlab.paper.contracts import (
     PaperBroker,
     PaperBrokerFactory,
     PaperDecisionRequest,
+    PaperDeploymentRegistry,
     PaperHistoryProvider,
     PaperHistoryProviderFactory,
+    PaperHostedExecutionContext,
+    PaperHostedPhase,
     PaperNotificationSink,
     PaperReconciliationRequest,
     PaperSubmissionRequest,
@@ -54,10 +57,16 @@ from marketlab.paper.core import (
     validate_paper_trading_config,
 )
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
-from marketlab.paper.observability import paper_execution_context
+from marketlab.paper.observability import (
+    hosted_execution_details,
+    hosted_root_execution_context,
+    paper_execution_context,
+)
 from marketlab.paper.persistence import (
     build_filesystem_paper_artifact_store,
+    build_filesystem_paper_deployment_registry,
     build_filesystem_paper_uow_factory,
+    build_sqlite_paper_deployment_registry,
     build_sqlite_paper_uow_factory,
 )
 from marketlab.paper.state import PaperStateStore
@@ -76,6 +85,14 @@ def _paper_uow_factory(config: ExperimentConfig) -> PaperUnitOfWorkFactory:
         return build_filesystem_paper_uow_factory(config)
     if config.paper.persistence_backend == "sqlite":
         return build_sqlite_paper_uow_factory(config)
+    raise ValueError(f"Unsupported paper persistence backend: {config.paper.persistence_backend}")
+
+
+def _paper_deployment_registry(config: ExperimentConfig) -> PaperDeploymentRegistry:
+    if config.paper.persistence_backend == "filesystem":
+        return build_filesystem_paper_deployment_registry(config)
+    if config.paper.persistence_backend == "sqlite":
+        return build_sqlite_paper_deployment_registry(config)
     raise ValueError(f"Unsupported paper persistence backend: {config.paper.persistence_backend}")
 
 
@@ -103,6 +120,40 @@ def _paper_state_store(config: ExperimentConfig) -> PaperStateStore:
     return PaperStateStore(config)
 
 
+def _ensure_hosted_phase(
+    config: ExperimentConfig,
+    hosted_context: PaperHostedExecutionContext | None,
+    *,
+    expected_phase: PaperHostedPhase,
+) -> None:
+    if hosted_context is None:
+        return
+    if hosted_context.phase != expected_phase:
+        raise ValueError(
+            "Hosted paper execution metadata phase mismatch: "
+            f"expected {expected_phase}, got {hosted_context.phase}."
+        )
+    _paper_deployment_registry(config).record_phase_run(hosted_context)
+
+
+def _paper_phase_context(
+    execution_context: ExecutionContext | None,
+    hosted_context: PaperHostedExecutionContext | None,
+    *,
+    phase: str,
+    provider: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> ExecutionContext | None:
+    if hosted_context is None:
+        return execution_context
+    return hosted_root_execution_context(
+        hosted_context,
+        phase=phase,
+        provider=provider,
+        details=details,
+    )
+
+
 def _decision_notification_outcome(status: dict[str, Any]) -> str:
     outcome = str(status.get("status", ""))
     if outcome == SUBMISSION_SKIPPED:
@@ -120,13 +171,23 @@ def run_paper_decision(
     broker: PaperBroker | None = None,
     notification_sink: PaperNotificationSink | None = None,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any]:
+    _ensure_hosted_phase(config, hosted_context, expected_phase="decision")
+    context_details = hosted_execution_details(hosted_context, {"component": "paper_service"})
     decision_context = paper_execution_context(
-        execution_context,
+        _paper_phase_context(
+            execution_context,
+            hosted_context,
+            phase="paper-decision",
+            provider=config.paper.data_provider,
+            details=context_details,
+        ),
         phase="paper-decision",
+        deployment=hosted_context.deployment_id if hosted_context is not None else None,
         provider=config.paper.data_provider,
-        refresh_execution_id=True,
-        details={"component": "paper_service"},
+        refresh_execution_id=hosted_context is None,
+        details=context_details,
     )
     emit_structured_log(
         LOGGER,
@@ -169,7 +230,7 @@ def run_paper_decision(
                 provider=config.paper.data_provider,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "paper_service"},
+                details=context_details,
             ),
             exc_info=exc,
         )
@@ -187,13 +248,16 @@ def run_paper_decision(
             provider=config.paper.data_provider,
             outcome=_decision_notification_outcome(result.status),
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "paper_service",
-                "status_path": result.status_path,
-                "proposal_path": result.proposal_path,
-                "evidence_path": result.evidence_path,
-                "notification_path": str(notification_path),
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "paper_service",
+                    "status_path": result.status_path,
+                    "proposal_path": result.proposal_path,
+                    "evidence_path": result.evidence_path,
+                    "notification_path": str(notification_path),
+                },
+            ),
         ),
     )
     return result.as_legacy_payload()
@@ -248,14 +312,27 @@ def decide_paper_proposal(
     now: datetime | None = None,
     notification_sink: PaperNotificationSink | None = None,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any]:
+    _ensure_hosted_phase(config, hosted_context, expected_phase="agent_approve")
+    context_details = hosted_execution_details(
+        hosted_context,
+        {"component": "paper_service", "actor": actor, "decision": decision},
+    )
     approval_context = paper_execution_context(
-        execution_context,
+        _paper_phase_context(
+            execution_context,
+            hosted_context,
+            phase="paper-approve",
+            provider=provider,
+            details=context_details,
+        ),
         phase="paper-approve",
+        deployment=hosted_context.deployment_id if hosted_context is not None else None,
         proposal={"proposal_id": proposal_id},
         provider=provider,
-        refresh_execution_id=True,
-        details={"component": "paper_service", "actor": actor, "decision": decision},
+        refresh_execution_id=hosted_context is None,
+        details=context_details,
     )
     emit_structured_log(
         LOGGER,
@@ -303,7 +380,7 @@ def decide_paper_proposal(
                 provider=provider,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "paper_service", "actor": actor, "decision": decision},
+                details=context_details,
             ),
             exc_info=exc,
         )
@@ -321,13 +398,16 @@ def decide_paper_proposal(
             approval=result.approval,
             provider=provider,
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "paper_service",
-                "status_path": result.status_path,
-                "proposal_path": result.proposal_path,
-                "approval_path": result.approval_path,
-                "notification_path": notification_path,
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "paper_service",
+                    "status_path": result.status_path,
+                    "proposal_path": result.proposal_path,
+                    "approval_path": result.approval_path,
+                    "notification_path": notification_path,
+                },
+            ),
         ),
     )
     return result.as_legacy_payload()
@@ -339,13 +419,23 @@ def reconcile_latest_submission_status(
     now: datetime | None = None,
     broker: PaperBroker | None = None,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any] | None:
+    _ensure_hosted_phase(config, hosted_context, expected_phase="reconcile")
+    context_details = hosted_execution_details(hosted_context, {"component": "paper_service"})
     reconciliation_context = paper_execution_context(
-        execution_context,
+        _paper_phase_context(
+            execution_context,
+            hosted_context,
+            phase="paper-submit-reconcile",
+            provider=config.paper.broker,
+            details=context_details,
+        ),
         phase="paper-submit-reconcile",
+        deployment=hosted_context.deployment_id if hosted_context is not None else None,
         provider=config.paper.broker,
-        refresh_execution_id=True,
-        details={"component": "paper_service"},
+        refresh_execution_id=hosted_context is None,
+        details=context_details,
     )
     emit_structured_log(
         LOGGER,
@@ -379,7 +469,7 @@ def reconcile_latest_submission_status(
                 provider=config.paper.broker,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "paper_service"},
+                details=context_details,
             ),
             exc_info=exc,
         )
@@ -396,7 +486,7 @@ def reconcile_latest_submission_status(
                 provider=config.paper.broker,
                 outcome="no_reconciliation_update",
                 duration_ms=duration_ms_since(start_time),
-                details={"component": "paper_service"},
+                details=context_details,
             ),
         )
         return None
@@ -412,11 +502,14 @@ def reconcile_latest_submission_status(
             provider=config.paper.broker,
             outcome=result.poll_status or result.order_status,
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "paper_service",
-                "submission_path": result.submission_path,
-                "order_status_path": result.order_status_path,
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "paper_service",
+                    "submission_path": result.submission_path,
+                    "order_status_path": result.order_status_path,
+                },
+            ),
         ),
     )
     return result.as_legacy_payload()
@@ -430,13 +523,26 @@ def run_paper_submit(
     notification_sink: PaperNotificationSink | None = None,
     retry_failed_submission: bool = False,
     execution_context: ExecutionContext | None = None,
+    hosted_context: PaperHostedExecutionContext | None = None,
 ) -> dict[str, Any]:
+    _ensure_hosted_phase(config, hosted_context, expected_phase="submit")
+    context_details = hosted_execution_details(
+        hosted_context,
+        {"component": "paper_service", "retry_failed_submission": retry_failed_submission},
+    )
     submission_context = paper_execution_context(
-        execution_context,
+        _paper_phase_context(
+            execution_context,
+            hosted_context,
+            phase="paper-submit",
+            provider=config.paper.broker,
+            details=context_details,
+        ),
         phase="paper-submit",
+        deployment=hosted_context.deployment_id if hosted_context is not None else None,
         provider=config.paper.broker,
-        refresh_execution_id=True,
-        details={"component": "paper_service", "retry_failed_submission": retry_failed_submission},
+        refresh_execution_id=hosted_context is None,
+        details=context_details,
     )
     emit_structured_log(
         LOGGER,
@@ -480,10 +586,7 @@ def run_paper_submit(
                 provider=config.paper.broker,
                 outcome="error",
                 duration_ms=duration_ms_since(start_time),
-                details={
-                    "component": "paper_service",
-                    "retry_failed_submission": retry_failed_submission,
-                },
+                details=context_details,
             ),
             exc_info=exc,
         )
@@ -501,12 +604,15 @@ def run_paper_submit(
             submission=result.submission,
             provider=config.paper.broker,
             duration_ms=duration_ms_since(start_time),
-            details={
-                "component": "paper_service",
-                "status_path": result.status_path,
-                "submission_path": result.submission_path,
-                "notification_path": str(notification_path),
-            },
+            details=hosted_execution_details(
+                hosted_context,
+                {
+                    "component": "paper_service",
+                    "status_path": result.status_path,
+                    "submission_path": result.submission_path,
+                    "notification_path": str(notification_path),
+                },
+            ),
         ),
     )
     legacy = result.as_legacy_payload()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,8 +6,13 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from tests._paper_fakes import write_phase7_paper_config
 
 from marketlab import cli
+from marketlab.paper.contracts import (
+    PaperDeploymentRegistryConflictError,
+    PaperHostedExecutionContext,
+)
 from marketlab.resources.templates import get_config_template_text
 
 
@@ -211,3 +216,105 @@ def test_paper_decision_keeps_path_stdout_and_structured_logs_on_stderr(
         "paper.command.finish",
     ]
     assert records[-1]["outcome"] == "proposal_created"
+
+
+def test_paper_decision_hosted_flags_override_environment_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured_contexts: list[PaperHostedExecutionContext | None] = []
+    monkeypatch.setattr(cli, "load_config", lambda path: object())
+    monkeypatch.setenv("MARKETLAB_DEPLOYMENT_ID", "env-deployment")
+    monkeypatch.setenv("MARKETLAB_ENVIRONMENT", "dev")
+    monkeypatch.setenv("MARKETLAB_EXECUTION_ID", "env-exec")
+    monkeypatch.setenv("MARKETLAB_CORRELATION_ID", "env-corr")
+    monkeypatch.setenv("MARKETLAB_IDEMPOTENCY_KEY", "env-idem")
+    monkeypatch.setenv("MARKETLAB_TRIGGER_SOURCE", "env")
+    monkeypatch.setenv("MARKETLAB_REQUESTED_AT", "2026-06-19T12:00:00+00:00")
+    monkeypatch.setenv("MARKETLAB_CONFIG_VERSION", "env-config")
+    monkeypatch.setenv("MARKETLAB_IMAGE_DIGEST", "sha256:env")
+
+    def _fake_decision(config, **kwargs):
+        captured_contexts.append(kwargs["hosted_context"])
+        return {
+            "proposal_path": "proposal.json",
+            "status_path": "status.json",
+            "status": {"status": "proposal_created"},
+        }
+
+    monkeypatch.setattr(cli, "run_paper_decision", _fake_decision)
+
+    exit_code = cli.main(
+        [
+            "paper-decision",
+            "--config",
+            "dummy.yaml",
+            "--deployment-id",
+            "flag-deployment",
+            "--execution-id",
+            "flag-exec",
+            "--idempotency-key",
+            "flag-idem",
+        ]
+    )
+
+    records = _stderr_records(capsys.readouterr().err)
+    assert exit_code == 0
+    assert len(captured_contexts) == 1
+    assert captured_contexts[0] is not None
+    assert captured_contexts[0].deployment_id == "flag-deployment"
+    assert captured_contexts[0].execution_id == "flag-exec"
+    assert captured_contexts[0].idempotency_key == "flag-idem"
+    assert captured_contexts[0].correlation_id == "env-corr"
+    assert captured_contexts[0].phase == "decision"
+    assert records[0]["deployment"] == "flag-deployment"
+    assert records[0]["execution_id"] == "flag-exec"
+    assert records[0]["correlation_id"] == "env-corr"
+
+
+def test_paper_decision_rejects_partial_hosted_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    load_calls: list[str] = []
+    monkeypatch.setenv("MARKETLAB_DEPLOYMENT_ID", "partial-deployment")
+    monkeypatch.setattr(cli, "load_config", lambda path: load_calls.append(path))
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["paper-decision", "--config", "dummy.yaml"])
+
+    assert excinfo.value.code == 2
+    assert load_calls == []
+
+
+def test_paper_submit_cli_surfaces_duplicate_hosted_idempotency_conflict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with repo_scratch_dir("hosted_duplicate_idempotency") as root:
+        config_path = write_phase7_paper_config(root / "config.yaml")
+        base_args = [
+            "paper-submit",
+            "--config",
+            str(config_path),
+            "--deployment-id",
+            "qqq-paper-dev",
+            "--environment",
+            "dev",
+            "--execution-id",
+            "exec-1",
+            "--correlation-id",
+            "corr-1",
+            "--idempotency-key",
+            "idem-1",
+            "--trigger-source",
+            "cli",
+            "--requested-at",
+            "2026-06-19T12:00:00+00:00",
+            "--config-version",
+            "config-v1",
+        ]
+
+        assert cli.main([*base_args, "--image-digest", "sha256:first"]) == 0
+        capsys.readouterr()
+
+        with pytest.raises(PaperDeploymentRegistryConflictError):
+            cli.main([*base_args, "--image-digest", "sha256:second"])

--- a/tests/unit/test_paper_agent.py
+++ b/tests/unit/test_paper_agent.py
@@ -22,6 +22,7 @@ from marketlab.paper.approval_clients import build_default_paper_approval_client
 from marketlab.paper.contracts import (
     PaperApprovalClientDecision,
     PaperApprovalEvaluationRequest,
+    PaperHostedExecutionContext,
 )
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.service import PaperStateStore, run_paper_decision
@@ -52,6 +53,23 @@ def _stderr_records(stderr: str) -> list[dict[str, object]]:
         for line in stderr.splitlines()
         if line.strip() != ""
     ]
+
+
+def _hosted_context(**overrides: str) -> PaperHostedExecutionContext:
+    payload = {
+        "deployment_id": "qqq-paper-dev",
+        "environment": "dev",
+        "phase": "agent_approve",
+        "execution_id": "agent-exec",
+        "correlation_id": "agent-corr",
+        "idempotency_key": "agent-idem",
+        "trigger_source": "service-bus",
+        "requested_at": "2026-06-19T12:00:00+00:00",
+        "config_version": "config-v1",
+        "image_digest": "sha256:abc123",
+    }
+    payload.update(overrides)
+    return PaperHostedExecutionContext.from_metadata(payload)
 
 
 def test_agent_worker_approves_with_openai_backend(monkeypatch, tmp_path: Path) -> None:
@@ -234,6 +252,50 @@ def test_agent_worker_supports_injected_approval_client_and_notification_sink(
     assert proposal["approval_backend"] == "fake"
     assert proposal["approval_model"] == "fake-model"
     assert proposal["approval_fallback_used"] is True
+
+
+def test_agent_worker_derives_hosted_context_per_proposal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    run_paper_decision(
+        config,
+        now=datetime(2026, 4, 10, 20, 10, tzinfo=UTC),
+        provider=FakeAlpacaProvider(symbol="QQQ"),
+        broker=FakeAlpacaBroker(symbol="QQQ"),
+    )
+    proposal = PaperStateStore(config).latest_proposal()
+    assert proposal is not None
+    captured: list[PaperHostedExecutionContext | None] = []
+
+    def _fake_decide(*args, **kwargs):
+        captured.append(kwargs["hosted_context"])
+        proposal_id = kwargs["proposal_id"]
+        return {
+            "proposal_id": proposal_id,
+            "proposal_path": "proposal.json",
+            "approval_path": "approval.json",
+            "status_path": "status.json",
+            "status": {"event": "paper-approve", "status": "approved"},
+        }
+
+    monkeypatch.setattr(agent_module, "decide_paper_proposal", _fake_decide)
+
+    result = run_agent_approval_iteration(
+        config,
+        now=datetime(2026, 4, 10, 20, 30, tzinfo=UTC),
+        broker=FakeAlpacaBroker(symbol="QQQ"),
+        approval_client=FakePaperApprovalClient(),
+        hosted_context=_hosted_context(),
+    )
+
+    assert result["processed_count"] == 1
+    assert len(captured) == 1
+    assert captured[0] is not None
+    assert captured[0].phase == "agent_approve"
+    assert captured[0].idempotency_key == f"agent-idem:agent_approve:{proposal['proposal_id']}"
+    assert captured[0].correlation_id == "agent-corr"
 
 
 def test_agent_worker_overrides_primary_rejection_when_evidence_requires_approval(

--- a/tests/unit/test_paper_contracts.py
+++ b/tests/unit/test_paper_contracts.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import fields
+
+import pytest
 from tests._paper_fakes import (
     FakeAlpacaBroker,
     FakeAlpacaProvider,
@@ -8,6 +11,7 @@ from tests._paper_fakes import (
 )
 
 from marketlab.paper.contracts import (
+    PAPER_HOSTED_METADATA_FIELDS,
     PaperApprovalClient,
     PaperApprovalClientDecision,
     PaperApprovalRequest,
@@ -15,8 +19,12 @@ from marketlab.paper.contracts import (
     PaperBroker,
     PaperDecisionRequest,
     PaperDecisionResult,
+    PaperDeploymentRecord,
+    PaperDeploymentRegistry,
     PaperHistoryProvider,
+    PaperHostedExecutionContext,
     PaperNotificationSink,
+    PaperPhaseRunRecord,
     PaperReconciliationRequest,
     PaperReconciliationResult,
     PaperSubmissionRequest,
@@ -29,6 +37,94 @@ def test_paper_protocols_match_existing_fake_adapters() -> None:
     assert isinstance(FakeAlpacaBroker(), PaperBroker)
     assert isinstance(FakePaperNotificationSink(), PaperNotificationSink)
     assert isinstance(FakePaperApprovalClient(), PaperApprovalClient)
+
+
+def _hosted_metadata(**overrides: str) -> dict[str, str]:
+    payload = {
+        "deployment_id": "qqq-paper-dev",
+        "environment": "dev",
+        "phase": "decision",
+        "execution_id": "exec-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
+        "trigger_source": "cli",
+        "requested_at": "2026-06-19T12:00:00+00:00",
+        "config_version": "config-v1",
+        "image_digest": "sha256:abc123",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_hosted_execution_contracts_use_exact_metadata_fields() -> None:
+    expected = list(PAPER_HOSTED_METADATA_FIELDS)
+
+    assert [field.name for field in fields(PaperHostedExecutionContext)] == expected
+    assert [field.name for field in fields(PaperDeploymentRecord)] == expected
+    assert [field.name for field in fields(PaperPhaseRunRecord)] == expected
+
+
+def test_hosted_execution_context_round_trips_metadata() -> None:
+    metadata = _hosted_metadata(phase="submit", idempotency_key="submit-1")
+
+    context = PaperHostedExecutionContext.from_metadata(metadata)
+    deployment = PaperDeploymentRecord.from_context(context)
+    phase_run = PaperPhaseRunRecord.from_metadata(metadata)
+
+    assert context.as_metadata() == metadata
+    assert deployment.as_metadata() == metadata
+    assert phase_run.as_metadata() == metadata
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "match"),
+    [
+        ("environment", "prod", "Unsupported paper hosted environment"),
+        ("phase", "scheduler", "Unsupported paper hosted phase"),
+        ("requested_at", "not-a-date", "requested_at must be an ISO-8601"),
+    ],
+)
+def test_hosted_execution_context_rejects_invalid_metadata(
+    field_name: str,
+    value: str,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        PaperHostedExecutionContext.from_metadata(_hosted_metadata(**{field_name: value}))
+
+
+def test_hosted_execution_context_rejects_missing_and_extra_metadata() -> None:
+    missing = _hosted_metadata()
+    missing.pop("image_digest")
+    with pytest.raises(ValueError, match="missing required fields: image_digest"):
+        PaperHostedExecutionContext.from_metadata(missing)
+
+    extra = _hosted_metadata(extra="not-supported")
+    with pytest.raises(ValueError, match="unsupported fields: extra"):
+        PaperHostedExecutionContext.from_metadata(extra)
+
+
+def test_hosted_execution_context_derives_child_phase_identity() -> None:
+    context = PaperHostedExecutionContext.from_metadata(_hosted_metadata())
+
+    child = context.derive(phase="reconcile", suffix="reconcile:2026-06-19")
+
+    assert child.phase == "reconcile"
+    assert child.correlation_id == context.correlation_id
+    assert child.execution_id == "exec-1:reconcile:2026-06-19"
+    assert child.idempotency_key == "idem-1:reconcile:2026-06-19"
+
+
+class _FakeRegistry:
+    def record_deployment(self, context: PaperHostedExecutionContext) -> PaperDeploymentRecord:
+        return PaperDeploymentRecord.from_context(context)
+
+    def record_phase_run(self, context: PaperHostedExecutionContext) -> PaperPhaseRunRecord:
+        return PaperPhaseRunRecord.from_context(context)
+
+
+def test_deployment_registry_protocol_matches_fake_adapter() -> None:
+    assert isinstance(_FakeRegistry(), PaperDeploymentRegistry)
 
 
 def test_paper_decision_result_round_trips_legacy_payload() -> None:

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import json
+import sqlite3
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -16,6 +18,9 @@ from tests._paper_fakes import (
 import marketlab.paper.service as service_module
 from marketlab.paper.application import ReconciliationService
 from marketlab.paper.contracts import (
+    PaperDeploymentRegistry,
+    PaperDeploymentRegistryConflictError,
+    PaperHostedExecutionContext,
     PaperReconciliationRequest,
     PaperStatusRepository,
     PaperTradeRepository,
@@ -24,7 +29,9 @@ from marketlab.paper.contracts import (
 )
 from marketlab.paper.persistence import (
     build_filesystem_paper_artifact_store,
+    build_filesystem_paper_deployment_registry,
     build_filesystem_paper_uow_factory,
+    build_sqlite_paper_deployment_registry,
     build_sqlite_paper_uow_factory,
 )
 from marketlab.paper.persistence import (
@@ -343,6 +350,142 @@ def _build_factory(
     if adapter_kind == "memory":
         return InMemoryPaperUnitOfWorkFactory(tmp_path / "memory-root")
     raise ValueError(f"Unknown adapter kind: {adapter_kind}")
+
+
+def _build_registry(*, adapter_kind: str, config) -> PaperDeploymentRegistry:
+    if adapter_kind == "filesystem":
+        return build_filesystem_paper_deployment_registry(config)
+    if adapter_kind == "sqlite":
+        return build_sqlite_paper_deployment_registry(config)
+    raise ValueError(f"Unknown adapter kind: {adapter_kind}")
+
+
+def _hosted_context(**overrides: str) -> PaperHostedExecutionContext:
+    payload = {
+        "deployment_id": "qqq-paper-dev",
+        "environment": "dev",
+        "phase": "decision",
+        "execution_id": "exec-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
+        "trigger_source": "scheduler",
+        "requested_at": "2026-06-19T12:00:00+00:00",
+        "config_version": "config-v1",
+        "image_digest": "sha256:abc123",
+    }
+    payload.update(overrides)
+    return PaperHostedExecutionContext.from_metadata(payload)
+
+
+@pytest.mark.parametrize("adapter_kind", ["filesystem", "sqlite"])
+def test_deployment_registry_accepts_identical_idempotency_replays(
+    adapter_kind: str,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path / f"{adapter_kind}-registry",
+        symbol="QQQ",
+        persistence_backend=adapter_kind,
+    )
+    registry = _build_registry(adapter_kind=adapter_kind, config=config)
+    context = _hosted_context()
+
+    first = registry.record_phase_run(context)
+    second = registry.record_phase_run(context)
+
+    assert first.as_metadata() == context.as_metadata()
+    assert second.as_metadata() == context.as_metadata()
+
+
+@pytest.mark.parametrize("adapter_kind", ["filesystem", "sqlite"])
+def test_deployment_registry_rejects_conflicting_idempotency_replays(
+    adapter_kind: str,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path / f"{adapter_kind}-registry-conflict",
+        symbol="QQQ",
+        persistence_backend=adapter_kind,
+    )
+    registry = _build_registry(adapter_kind=adapter_kind, config=config)
+    registry.record_phase_run(_hosted_context())
+
+    with pytest.raises(PaperDeploymentRegistryConflictError):
+        registry.record_phase_run(_hosted_context(image_digest="sha256:changed"))
+
+
+@pytest.mark.parametrize("adapter_kind", ["filesystem", "sqlite"])
+def test_deployment_registry_rejects_idempotency_replays_in_a_different_phase(
+    adapter_kind: str,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path / f"{adapter_kind}-registry-cross-phase-conflict",
+        symbol="QQQ",
+        persistence_backend=adapter_kind,
+    )
+    registry = _build_registry(adapter_kind=adapter_kind, config=config)
+    registry.record_phase_run(_hosted_context())
+
+    with pytest.raises(PaperDeploymentRegistryConflictError):
+        registry.record_phase_run(
+            _hosted_context(
+                phase="submit",
+                execution_id="submit-exec-1",
+            )
+        )
+
+
+def test_filesystem_deployment_registry_writes_stable_layout(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(tmp_path / "filesystem-registry-layout", symbol="QQQ")
+    registry = build_filesystem_paper_deployment_registry(config)
+    context = _hosted_context(
+        phase="submit",
+        execution_id="exec/submit",
+        idempotency_key="idem/submit",
+    )
+
+    registry.record_phase_run(context)
+
+    phase_run_path = (
+        config.paper_state_dir
+        / "phase-runs"
+        / "idem%2Fsubmit.json"
+    )
+    deployment_path = (
+        config.paper_state_dir
+        / "deployments"
+        / "dev"
+        / "qqq-paper-dev"
+        / "submit"
+        / "exec%2Fsubmit.json"
+    )
+    assert json.loads(phase_run_path.read_text(encoding="utf-8")) == context.as_metadata()
+    assert json.loads(deployment_path.read_text(encoding="utf-8")) == context.as_metadata()
+
+
+def test_sqlite_deployment_registry_uses_local_tables_only(tmp_path: Path) -> None:
+    config = build_phase7_paper_config(
+        tmp_path / "sqlite-registry-layout",
+        symbol="QQQ",
+        persistence_backend="sqlite",
+    )
+    registry = build_sqlite_paper_deployment_registry(config)
+    context = _hosted_context(phase="reconcile", idempotency_key="idem-reconcile")
+
+    registry.record_phase_run(context)
+
+    with sqlite3.connect(config.paper_sqlite_db_path) as connection:
+        phase_rows = connection.execute(
+            "SELECT payload_json FROM paper_phase_run_records"
+        ).fetchall()
+        deployment_rows = connection.execute(
+            "SELECT payload_json FROM paper_deployment_records"
+        ).fetchall()
+    assert [json.loads(row[0]) for row in phase_rows] == [context.as_metadata()]
+    assert [json.loads(row[0]) for row in deployment_rows] == [context.as_metadata()]
+    assert not (config.paper_state_dir / "phase-runs").exists()
+    assert not (config.paper_state_dir / "deployments").exists()
 
 
 @pytest.mark.parametrize("adapter_kind", ["filesystem", "sqlite"])

--- a/tests/unit/test_paper_persistence.py
+++ b/tests/unit/test_paper_persistence.py
@@ -436,6 +436,27 @@ def test_deployment_registry_rejects_idempotency_replays_in_a_different_phase(
         )
 
 
+def test_filesystem_deployment_registry_rolls_back_phase_run_on_deployment_conflict(
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(
+        tmp_path / "filesystem-registry-deployment-conflict",
+        symbol="QQQ",
+    )
+    registry = build_filesystem_paper_deployment_registry(config)
+    registry.record_deployment(_hosted_context(idempotency_key="existing-deployment-key"))
+    conflicting_context = _hosted_context(idempotency_key="rolled-back-phase-run-key")
+
+    with pytest.raises(PaperDeploymentRegistryConflictError):
+        registry.record_phase_run(conflicting_context)
+
+    assert not (
+        config.paper_state_dir
+        / "phase-runs"
+        / "rolled-back-phase-run-key.json"
+    ).exists()
+
+
 def test_filesystem_deployment_registry_writes_stable_layout(tmp_path: Path) -> None:
     config = build_phase7_paper_config(tmp_path / "filesystem-registry-layout", symbol="QQQ")
     registry = build_filesystem_paper_deployment_registry(config)

--- a/tests/unit/test_paper_scheduler.py
+++ b/tests/unit/test_paper_scheduler.py
@@ -9,6 +9,7 @@ from tests._paper_fakes import FakePaperNotificationSink, build_phase7_paper_con
 
 from marketlab.log import configure_logging
 from marketlab.paper import scheduler
+from marketlab.paper.contracts import PaperHostedExecutionContext
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
 
 
@@ -37,6 +38,23 @@ def _stderr_records(stderr: str) -> list[dict[str, object]]:
         for line in stderr.splitlines()
         if line.strip() != ""
     ]
+
+
+def _hosted_context(**overrides: str) -> PaperHostedExecutionContext:
+    payload = {
+        "deployment_id": "qqq-paper-dev",
+        "environment": "dev",
+        "phase": "decision",
+        "execution_id": "scheduler-exec",
+        "correlation_id": "scheduler-corr",
+        "idempotency_key": "scheduler-idem",
+        "trigger_source": "container-app-job",
+        "requested_at": "2026-06-19T12:00:00+00:00",
+        "config_version": "config-v1",
+        "image_digest": "sha256:abc123",
+    }
+    payload.update(overrides)
+    return PaperHostedExecutionContext.from_metadata(payload)
 
 
 def test_scheduler_iteration_runs_each_phase_once_per_market_date(
@@ -102,6 +120,48 @@ def test_scheduler_iteration_forwards_injected_notification_sink(
     )
 
     assert forwarded_sinks == [sink, sink]
+
+
+def test_scheduler_iteration_derives_hosted_contexts_for_due_phases(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path)
+    captured: list[PaperHostedExecutionContext | None] = []
+
+    def _fake_decision(*args, **kwargs):
+        captured.append(kwargs["hosted_context"])
+        return {"proposal_path": "proposal.json", "status_path": "status.json", "status": {}}
+
+    def _fake_submit(*args, **kwargs):
+        captured.append(kwargs["hosted_context"])
+        return {"submission_path": "submission.json", "status_path": "status.json", "status": {}}
+
+    def _fake_reconcile(*args, **kwargs):
+        captured.append(kwargs["hosted_context"])
+        return None
+
+    monkeypatch.setattr(scheduler, "run_paper_decision", _fake_decision)
+    monkeypatch.setattr(scheduler, "run_paper_submit", _fake_submit)
+    monkeypatch.setattr(scheduler, "reconcile_latest_submission_status", _fake_reconcile)
+
+    scheduler.run_scheduler_iteration(
+        config,
+        now=datetime(2026, 4, 10, 23, 10, tzinfo=UTC),
+        hosted_context=_hosted_context(),
+    )
+
+    assert [context.phase if context is not None else "" for context in captured] == [
+        "decision",
+        "submit",
+        "reconcile",
+    ]
+    assert [context.idempotency_key if context is not None else "" for context in captured] == [
+        "scheduler-idem:decision:2026-04-10",
+        "scheduler-idem:submit:2026-04-10",
+        "scheduler-idem:reconcile:2026-04-10",
+    ]
+    assert all(context.correlation_id == "scheduler-corr" for context in captured if context is not None)
 
 
 def test_scheduler_iteration_appends_submission_reconciliation_events(

--- a/tests/unit/test_paper_service.py
+++ b/tests/unit/test_paper_service.py
@@ -12,7 +12,12 @@ from tests._paper_fakes import (
     build_phase7_paper_config,
 )
 
+import marketlab.paper.service as service_module
 from marketlab.log import configure_logging
+from marketlab.paper.contracts import (
+    PaperDeploymentRegistryConflictError,
+    PaperHostedExecutionContext,
+)
 from marketlab.paper.notifications import build_telegram_paper_notification_sink
 from marketlab.paper.persistence import build_sqlite_paper_uow_factory
 from marketlab.paper.service import (
@@ -59,6 +64,23 @@ def _stderr_records(stderr: str) -> list[dict[str, object]]:
         for line in stderr.splitlines()
         if line.strip().startswith("{")
     ]
+
+
+def _hosted_context(**overrides: str) -> PaperHostedExecutionContext:
+    payload = {
+        "deployment_id": "qqq-paper-dev",
+        "environment": "dev",
+        "phase": "submit",
+        "execution_id": "exec-1",
+        "correlation_id": "corr-1",
+        "idempotency_key": "idem-1",
+        "trigger_source": "cli",
+        "requested_at": "2026-06-19T12:00:00+00:00",
+        "config_version": "config-v1",
+        "image_digest": "sha256:abc123",
+    }
+    payload.update(overrides)
+    return PaperHostedExecutionContext.from_metadata(payload)
 
 
 def test_paper_service_logs_include_phase_ids_provider_and_duration(
@@ -131,6 +153,38 @@ def test_paper_service_logs_include_phase_ids_provider_and_duration(
     assert finish_records["paper.reconcile.finish"]["proposal_id"] == decision["proposal_id"]
     assert finish_records["paper.reconcile.finish"]["provider"] == "alpaca"
     assert finish_records["paper.reconcile.finish"]["outcome"] == "observed"
+
+
+def test_hosted_registry_conflict_stops_submit_before_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = build_phase7_paper_config(tmp_path, execution_mode="agent_approval", symbol="QQQ")
+    broker = FakeAlpacaBroker(symbol="QQQ")
+    sink = FakePaperNotificationSink()
+
+    class _ConflictingRegistry:
+        def record_phase_run(self, context: PaperHostedExecutionContext):
+            raise PaperDeploymentRegistryConflictError("conflicting idempotency")
+
+    monkeypatch.setattr(
+        service_module,
+        "_paper_deployment_registry",
+        lambda _config: _ConflictingRegistry(),
+    )
+
+    with pytest.raises(PaperDeploymentRegistryConflictError, match="conflicting idempotency"):
+        run_paper_submit(
+            config,
+            now=datetime(2026, 4, 10, 23, 5, tzinfo=UTC),
+            broker=broker,
+            notification_sink=sink,
+            hosted_context=_hosted_context(),
+        )
+
+    assert broker.submitted_orders == []
+    assert sink.submission_calls == []
+    assert not PaperStateStore(config).status_path.exists()
 
 
 def test_run_paper_decision_writes_latest_daily_proposal(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_phase9_plan_docs.py
+++ b/tests/unit/test_phase9_plan_docs.py
@@ -10,6 +10,7 @@ P9_03_PLAN = ROOT / "docs" / "phase9" / "P9-03-WORKER-PLAN.md"
 P9_04_PLAN = ROOT / "docs" / "phase9" / "P9-04-WORKER-PLAN.md"
 P9_05_PLAN = ROOT / "docs" / "phase9" / "P9-05-WORKER-PLAN.md"
 P9_06_PLAN = ROOT / "docs" / "phase9" / "P9-06-WORKER-PLAN.md"
+P9_07_PLAN = ROOT / "docs" / "phase9" / "P9-07-WORKER-PLAN.md"
 
 
 def test_phase9_plan_replaces_obsolete_cloud_plan() -> None:
@@ -262,3 +263,38 @@ def test_p9_06_plan_is_linked_from_docs() -> None:
     assert "phase9/P9-06-WORKER-PLAN.md" in roadmap
     assert "Phase 9 P9-06 Worker Plan: phase9/P9-06-WORKER-PLAN.md" in nav
     assert "phase9/P9-06-WORKER-PLAN.md" in index
+
+
+def test_p9_07_plan_locks_hosted_execution_registry_scope() -> None:
+    content = P9_07_PLAN.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    required = [
+        "feature/phase-9-hosted-execution-registry",
+        "feat(phase9): add hosted paper execution registry",
+        "deployment_id environment phase execution_id correlation_id idempotency_key trigger_source requested_at config_version image_digest",
+        "Supported environments are `dev`, `uat`, and `paper-prod`",
+        "Supported phases are `decision`, `agent_approve`, `submit`, and `reconcile`",
+        "PaperHostedExecutionContext",
+        "PaperDeploymentRegistry",
+        "artifacts/paper/state/deployments/",
+        "artifacts/paper/state/phase-runs/",
+        "Duplicate `idempotency_key` values with identical metadata are accepted",
+        "conflicting metadata raise before a paper phase creates providers, calls brokers, sends notifications",
+        "does not add PostgreSQL, Blob Storage, Service Bus, QQQ Terraform, Azure SDK calls",
+        "scheduler derives child phase contexts for `decision`, `submit`, and `reconcile`",
+        "agent approval worker derives one `agent_approve` context per proposal",
+        "Explicit flags win over environment values",
+    ]
+
+    assert all(term in normalized for term in required)
+
+
+def test_p9_07_plan_is_linked_from_docs() -> None:
+    roadmap = PLAN.read_text(encoding="utf-8")
+    nav = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "phase9/P9-07-WORKER-PLAN.md" in roadmap
+    assert "Phase 9 P9-07 Worker Plan: phase9/P9-07-WORKER-PLAN.md" in nav
+    assert "phase9/P9-07-WORKER-PLAN.md" in index


### PR DESCRIPTION
## Summary
- define and document the P9-07 hosted execution registry contract
- add filesystem and SQLite registry adapters with global idempotency conflict handling
- wire hosted metadata through paper services, scheduler, agent, observability, and CLI

## Validation
- 687 unit tests passed on Python 3.14 and Python 3.12
- tox integration: 50 passed, 2 deselected
- Ruff, targeted mypy, MkDocs strict, whitespace, build, and installed-wheel smoke passed

Note: tox preflight could not bootstrap isolated dependencies because package-index access returned WinError 10013; the equivalent available checks above passed.