### PR TITLE
feat(phase9): add QQQ paper-prod cutover gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 *.tfstate
 *.tfstate.*
 **/backend.hcl
+**/backend.paper-prod.hcl
 **/*.backend.hcl
 **/backend-*.hcl
 **/*.tfbackend

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -328,7 +328,7 @@ working alerts, and a rehearsed rollback.
 | [P9-10](phase9/P9-10-WORKER-PLAN.md) | QQQ Azure Terraform and deployment pipeline | P9-02, P9-09 | Dev environment deploys disabled-by-default jobs using managed identity |
 | [P9-11](phase9/P9-11-WORKER-PLAN.md) | QQQ state importer and operational runbooks | P9-08, P9-09 | Repeatable import, checksum report, backup, restore, and rollback documented |
 | [P9-12](phase9/P9-12-WORKER-PLAN.md) | QQQ dev and UAT shadow validation | P9-10, P9-11 | Ten-trading-day parity report and failure drills accepted |
-| P9-13 | QQQ paper-prod cutover | P9-12 | Local scheduler stopped; final delta imported; Azure jobs enabled safely |
+| [P9-13](phase9/P9-13-WORKER-PLAN.md) | QQQ paper-prod cutover | P9-12 | Local scheduler stopped; final delta imported; Azure jobs enabled safely |
 | P9-14 | QQQ post-cutover closeout | P9-13 | Ten-trading-day observation passes; rollback remains rehearsed |
 | P9-15 | BTC final evidence decision | P9-06 and maturity window | Final report records continue, restart, or stop |
 
@@ -374,7 +374,9 @@ Terraform and deployment-pipeline details are frozen in
 import and operations runbook details are frozen in
 [the QQQ import worker plan](phase9/P9-11-WORKER-PLAN.md). P9-12 QQQ UAT
 parity evidence details are frozen in
-[the QQQ UAT worker plan](phase9/P9-12-WORKER-PLAN.md).
+[the QQQ UAT worker plan](phase9/P9-12-WORKER-PLAN.md). P9-13 QQQ
+paper-prod cutover gates and operator runbook details are frozen in
+[the QQQ paper-prod worker plan](phase9/P9-13-WORKER-PLAN.md).
 - QQQ paper decision, approval, submission, reconciliation, notifications, and
   reporting run from Azure
 - PostgreSQL is canonical QQQ workflow state and Blob Storage contains the

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,6 @@ This site is the canonical home for MarketLab's public documentation.
 - [Phase 9 P9-10 Worker Plan](phase9/P9-10-WORKER-PLAN.md)
 - [Phase 9 P9-11 Worker Plan](phase9/P9-11-WORKER-PLAN.md)
 - [Phase 9 P9-12 Worker Plan](phase9/P9-12-WORKER-PLAN.md)
+- [Phase 9 P9-13 Worker Plan](phase9/P9-13-WORKER-PLAN.md)
 
 The root `README.md` remains the repository-facing entrypoint, while the deeper public docs live here.

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -419,6 +419,143 @@ acceptance requires reviewed evidence for:
 Do not use live Azure resource names, DSNs, tfvars, backend files, Terraform
 state, Terraform plans, or secret values in tracked documentation.
 
+## P9-13 QQQ Paper-Prod Cutover Runbooks
+
+P9-13 prepares the paper-prod cutover after P9-12 parity and failure-drill
+evidence has been accepted. It does not authorize a live cutover by itself.
+Stopping the local scheduler, importing the final state delta, applying
+Terraform, changing secrets, enabling Azure triggers, and running the first
+paper-prod cycle require a separate supervised operator session.
+
+### Pre-Cutover Checklist
+
+- confirm the accepted P9-12 parity report and failure-drill evidence are
+  recorded outside tracked files
+- confirm `configs/experiment.qqq_paper_daily.yaml` has not changed strategy,
+  model, schedule, approval, or broker semantics
+- confirm paper-prod Terraform uses `qqq-paper-prod.tfstate` from an untracked
+  backend file
+- confirm the immutable image digest, Key Vault secret IDs, PostgreSQL DSN,
+  operator-approved firewall rules, and paper-prod tfvars are retained outside
+  the repository
+- confirm Alpaca endpoints are paper-only before any broker-facing Azure job is
+  smoke-tested
+- record operator, commit SHA, P9-12 evidence URI, final import evidence URI,
+  backup/restore evidence URI, rollback evidence URI, and alert evidence URI
+  outside tracked files
+
+### Stop Local Authority
+
+Stop the local QQQ scheduler and agent before enabling any paper-prod Azure
+trigger:
+
+```bash
+docker compose --env-file .env -f docker/compose.paper.yml stop marketlab-paper-scheduler marketlab-paper-agent
+```
+
+Verify local containers did not leave an unresolved proposal, missing approval,
+duplicate submission, or non-terminal order. Use the normal status and artifact
+review surfaces:
+
+```bash
+python scripts/run_marketlab.py paper-status --config configs/experiment.qqq_paper_daily.yaml
+```
+
+Do not continue if an order is still open, pending, partially filled without an
+accepted operator note, or otherwise non-terminal.
+
+### Final State Delta Import
+
+Run a final dry-run import from the local QQQ artifact root:
+
+```bash
+python scripts/run_marketlab.py paper-state-import \
+  --config configs/local.qqq-postgres.yaml \
+  --source-state-dir artifacts/paper/state \
+  --source-inbox-dir artifacts/paper/inbox \
+  --dry-run \
+  --report-path artifacts/paper/state/imports/qqq-paper-prod-final-dry-run.json
+```
+
+Apply only after the dry-run, backup, restore, and rollback evidence are
+accepted:
+
+```bash
+python scripts/run_marketlab.py paper-state-import \
+  --config configs/local.qqq-postgres.yaml \
+  --source-state-dir artifacts/paper/state \
+  --source-inbox-dir artifacts/paper/inbox \
+  --apply \
+  --report-path artifacts/paper/state/imports/qqq-paper-prod-final-apply.json
+```
+
+Synchronize review artifacts after the accepted import:
+
+```bash
+python scripts/run_marketlab.py paper-blob-sync \
+  --config configs/local.qqq-postgres-azure-blob.yaml
+```
+
+### Paper-Prod Azure Smoke Test
+
+Create paper-prod jobs with schedules and Service Bus approval triggering still
+disabled first. Manually invoke the reviewed jobs in this order:
+
+1. `paper-db-migrate`
+2. `paper-blob-sync`
+3. `paper-outbox-deliver`
+4. `paper-service-bus-receive`
+5. `paper-notifications-deliver`
+6. `paper-scheduler --once`
+7. `paper-agent-approve --once`
+
+Review PostgreSQL, Blob, Service Bus, notification audit, alert, and paper
+broker evidence after each job. Do not enable triggers until the smoke test is
+accepted.
+
+### Enable Paper-Prod Triggers
+
+Only after the smoke test passes, a supervised apply may set:
+
+```hcl
+environment                         = "paper-prod"
+create_jobs                         = true
+enable_broker_secret_refs           = true
+enable_scheduler_schedule           = true
+enable_service_bus_approval_trigger = true
+```
+
+The paper-prod Terraform gate also requires a non-placeholder immutable image
+digest and reviewed HTTPS evidence URIs for P9-12 parity, final import,
+backup/restore, rollback, and alerts.
+
+### First Production-Paper Cycle
+
+For the first scheduled paper-prod cycle, verify:
+
+- scheduler due-time enforcement still follows `America/New_York`
+- one proposal is written for the expected QQQ trade date
+- approval remains approve/reject only
+- no duplicate broker submission is created
+- Blob artifacts mirror PostgreSQL state
+- Service Bus messages are settled or dead-lettered according to the reviewed
+  failure-drill contract
+- alert evidence shows both job failure and missing-evidence checks are active
+
+### Rollback
+
+If any cutover gate fails, disable Azure scheduler and Service Bus triggers,
+restore PostgreSQL from the accepted backup, restore Blob artifacts from the
+reviewed snapshot or versioned prefix, and keep the local QQQ scheduler disabled
+until the operator explicitly chooses the recovery authority. Restart the local
+runner only after the restored state is reviewed:
+
+```bash
+docker compose --env-file .env -f docker/compose.paper.yml up -d --build marketlab-paper-scheduler marketlab-paper-agent
+```
+
+P9-14 owns the ten-trading-day post-cutover observation window and closeout.
+
 ## Alpaca Environment
 
 Keep credentials in environment variables, not YAML. For local runs, copy `.env.example` to `.env` in the repo root and fill in the paper credentials:

--- a/docs/phase9/P9-13-WORKER-PLAN.md
+++ b/docs/phase9/P9-13-WORKER-PLAN.md
@@ -1,0 +1,88 @@
+# Phase 9 P9-13 Worker Plan: QQQ Paper-Prod Cutover
+
+## Summary
+
+P9-13 prepares the guarded QQQ paper-prod cutover after P9-12 UAT parity and
+failure-drill evidence has been accepted. It converts the QQQ Azure root from a
+dev-only source contract into an explicit `dev` and `paper-prod` contract with
+production launch gates.
+
+P9-13 does not stop the local scheduler, run a final import, apply Terraform,
+change secrets, enable Azure jobs, submit broker orders, or perform the live
+cutover by itself. Those actions require a separate supervised operator
+session after this source packet is reviewed and merged.
+
+- Branch: `feature/phase-9-qqq-paper-prod-cutover`
+- PR title: `feat(phase9): add QQQ paper-prod cutover gates`
+- Dependencies: accepted P9-12 QQQ UAT parity and failure-drill evidence
+- Canonical config remains `configs/experiment.qqq_paper_daily.yaml`
+
+## Key Changes
+
+- Extend `infra/azure/qqq-paper` to support only `dev` and `paper-prod`.
+- Keep dev defaults disabled while allowing paper-prod trigger enablement only
+  when production evidence URIs, non-placeholder image digest, secret refs,
+  broker secret refs, and job creation are all explicitly configured.
+- Add the paper-prod backend example using `qqq-paper-prod.tfstate`; keep real
+  backend files, tfvars, plans, state, DSNs, and Key Vault secret IDs untracked.
+- Document the paper-prod cutover runbook in `docs/paper-trading.md`.
+- Link this worker plan from the Phase 9 roadmap, docs index, and MkDocs nav.
+
+Production launch gates require:
+
+- `environment = "paper-prod"`
+- `create_jobs = true`
+- a non-placeholder immutable `marketlab_image_digest`
+- `enable_broker_secret_refs = true`
+- populated Key Vault secret IDs for Alpaca, Anthropic, and Telegram runtime
+  secrets
+- reviewed HTTPS evidence URIs for P9-12 parity, final import, backup/restore,
+  rollback, and alert checks
+
+## Cutover Runbook Contract
+
+The P9-13 runbook must require operators to:
+
+- confirm P9-12 parity and failure-drill acceptance
+- stop the local QQQ scheduler and agent before paper-prod trigger enablement
+- verify there is no unresolved proposal or non-terminal order
+- run final `paper-state-import --dry-run`, then approved `--apply`
+- run `paper-blob-sync`
+- manually smoke-test Azure jobs while schedules remain disabled
+- enable the paper-prod scheduler and Service Bus approval trigger only after
+  the smoke test passes
+- verify the first production-paper cycle from PostgreSQL, Blob, Service Bus,
+  alerts, and paper broker evidence
+- roll back by disabling Azure jobs and restoring PostgreSQL/Blob state if a
+  gate fails
+
+P9-14 owns the ten-trading-day post-cutover observation window and closeout.
+
+## Tests And Validation
+
+- Add docs tests for P9-13 links, boundaries, branch metadata, cutover gates,
+  rollback language, and the P9-14 handoff.
+- Add Terraform static tests for the `dev`/`paper-prod` environment set,
+  production-only trigger gates, evidence URI requirements, non-placeholder
+  image digest requirement, secret-reference requirements, and paper-prod
+  backend key.
+
+Validation commands:
+
+```bash
+py -3.14 -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_phase9_azure_bootstrap.py
+python -m ruff check .
+python -m mkdocs build --strict
+git diff --check
+```
+
+Run `py -3.14 -m tox -e preflight` before publication when the local Windows
+workspace is free of generated artifact file locks.
+
+## Assumptions And Boundaries
+
+- P9-13 prepares source gates and operator documentation only.
+- Live Azure apply, local scheduler shutdown, final import, secret changes, and
+  trigger enablement require explicit supervised approval after merge.
+- QQQ strategy, approval semantics, Alpaca paper-only endpoint checks, VOO, BTC,
+  and live-money support remain out of scope.

--- a/infra/azure/qqq-paper/README.md
+++ b/infra/azure/qqq-paper/README.md
@@ -1,10 +1,10 @@
 # Phase 9 QQQ Paper Azure Root
 
-This Terraform root defines the source contract for P9-10: a QQQ paper dev
-control plane with disabled-by-default Container Apps Jobs. It validates the
-shape of the Azure resources and deployment wiring, but it does not authorize
+This Terraform root defines the source contract for the Phase 9 QQQ paper
+control plane. P9-10 introduced the disabled-by-default dev shape. P9-13 adds
+explicit `paper-prod` launch gates, but this root still does not authorize
 Azure apply, job activation, state import, UAT shadow validation, or broker
-submission.
+submission by itself.
 
 ## Local Validation
 
@@ -25,13 +25,14 @@ CI must remain validation-only. It must not run `az login`, provider
 registration, `terraform plan`, `terraform apply`, `terraform destroy`,
 `terraform import`, or refresh-only planning.
 
-## Supervised Dev Deployment Gate
+## Supervised Deployment Gates
 
 A separate supervised deployment session must review exact costs, names, image
 digest, secret IDs, PostgreSQL firewall rules, backend settings, and Terraform
 plan output before any apply. Keep these defaults for the first reviewed apply:
 
 ```hcl
+environment                         = "dev"
 create_jobs                         = false
 enable_scheduler_schedule           = false
 enable_service_bus_approval_trigger = false
@@ -46,6 +47,32 @@ When `create_jobs = true`, `postgres_firewall_rules` must contain the
 operator-approved egress IPs that are allowed to reach the PostgreSQL Flexible
 Server. Do not use a broad public range. Capture the source of each IP in the
 supervised deployment notes before applying.
+
+Paper-prod uses the separate backend key documented in
+`backend.paper-prod.hcl.example`:
+
+```hcl
+key = "qqq-paper-prod.tfstate"
+```
+
+Do not commit the real backend file, tfvars, Terraform plan, Terraform state,
+DSN, Key Vault secret IDs, or live Azure identifiers.
+
+Before enabling `enable_scheduler_schedule` or
+`enable_service_bus_approval_trigger`, the reviewed apply must set:
+
+```hcl
+environment                         = "paper-prod"
+create_jobs                         = true
+enable_broker_secret_refs           = true
+enable_scheduler_schedule           = true
+enable_service_bus_approval_trigger = true
+```
+
+The launch gate rejects trigger enablement unless the image digest is a
+non-placeholder immutable SHA-256 digest, broker/provider/notification Key
+Vault secret references are populated, and reviewed HTTPS evidence URIs are
+provided for P9-12 parity, final import, backup/restore, rollback, and alerts.
 
 ## Runtime Configuration
 
@@ -94,8 +121,10 @@ Do not enable broker-facing secret references until a reviewed change sets
 `enable_broker_secret_refs = true`. Do not enable the scheduler trigger until
 P9-11 import and P9-12 dev/UAT parity gates are accepted.
 
-## P9-10 Boundary
+## Phase 9 Boundary
 
 This root must not import QQQ state, define VOO or BTC resources, enable live
 money, or change the QQQ strategy. P9-11 owns import, backup, restore, and
-rollback runbooks. P9-12 owns parity and failure drills.
+rollback runbooks. P9-12 owns parity and failure drills. P9-13 owns
+paper-prod cutover gates and the operator runbook; the actual cutover remains a
+separately supervised operation.

--- a/infra/azure/qqq-paper/backend.paper-prod.hcl.example
+++ b/infra/azure/qqq-paper/backend.paper-prod.hcl.example
@@ -1,0 +1,4 @@
+resource_group_name  = "<bootstrap-resource-group>"
+storage_account_name = "<bootstrap-storage-account>"
+container_name       = "tfstate"
+key                  = "qqq-paper-prod.tfstate"

--- a/infra/azure/qqq-paper/main.tf
+++ b/infra/azure/qqq-paper/main.tf
@@ -1,7 +1,10 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  deployment_id = "qqq-paper-${var.environment}"
+  deployment_id       = "qqq-paper-${var.environment}"
+  resource_name_env   = var.environment == "paper-prod" ? "prod" : var.environment
+  key_vault_name      = "kv-ml-qqq-${local.resource_name_env}-${var.resource_suffix}"
+  key_vault_name_safe = length(local.key_vault_name) <= 24
 
   required_tags = {
     "cost-center" = var.cost_center
@@ -327,7 +330,7 @@ resource "azurerm_servicebus_queue" "paper_events" {
 }
 
 resource "azurerm_key_vault" "qqq" {
-  name                          = "kv-ml-qqq-${var.environment}-${var.resource_suffix}"
+  name                          = local.key_vault_name
   resource_group_name           = azurerm_resource_group.qqq.name
   location                      = azurerm_resource_group.qqq.location
   tenant_id                     = data.azurerm_client_config.current.tenant_id
@@ -337,6 +340,13 @@ resource "azurerm_key_vault" "qqq" {
   soft_delete_retention_days    = 30
   public_network_access_enabled = true
   tags                          = local.tags
+
+  lifecycle {
+    precondition {
+      condition     = local.key_vault_name_safe
+      error_message = "QQQ paper Key Vault name must be 24 characters or fewer."
+    }
+  }
 }
 
 resource "azurerm_postgresql_flexible_server" "qqq" {

--- a/infra/azure/qqq-paper/main.tf
+++ b/infra/azure/qqq-paper/main.tf
@@ -437,7 +437,10 @@ resource "azurerm_container_app_job" "qqq" {
   }
 
   dynamic "manual_trigger_config" {
-    for_each = each.key == "paper-scheduler" && var.enable_scheduler_schedule ? [] : [1]
+    for_each = (
+      (each.key == "paper-scheduler" && var.enable_scheduler_schedule)
+      || (each.key == "paper-service-bus-receive" && var.enable_service_bus_approval_trigger)
+    ) ? [] : [1]
 
     content {
       parallelism              = 1
@@ -452,6 +455,32 @@ resource "azurerm_container_app_job" "qqq" {
       cron_expression          = var.scheduler_cron_expression
       parallelism              = 1
       replica_completion_count = 1
+    }
+  }
+
+  dynamic "event_trigger_config" {
+    for_each = each.key == "paper-service-bus-receive" && var.enable_service_bus_approval_trigger ? [1] : []
+
+    content {
+      parallelism              = 1
+      replica_completion_count = 1
+
+      scale {
+        min_executions              = 0
+        max_executions              = 1
+        polling_interval_in_seconds = 30
+
+        rules {
+          name             = "qqq-paper-approval-queue"
+          custom_rule_type = "azure-servicebus"
+          identity_id      = azurerm_user_assigned_identity.qqq.id
+          metadata = {
+            messageCount = "1"
+            namespace    = azurerm_servicebus_namespace.qqq.name
+            queueName    = azurerm_servicebus_queue.paper_events.name
+          }
+        }
+      }
     }
   }
 

--- a/infra/azure/qqq-paper/terraform.tfvars.example
+++ b/infra/azure/qqq-paper/terraform.tfvars.example
@@ -1,4 +1,5 @@
 resource_suffix = "qqqdev01"
+environment     = "dev"
 owner           = "marketlab-operator"
 cost_center     = "marketlab-phase9"
 alert_email     = "operator@example.com"
@@ -23,3 +24,10 @@ postgres_firewall_rules = {
 }
 
 paper_state_share_quota_gb = 10
+
+# Required before enabling paper-prod scheduler or Service Bus approval triggers.
+p9_12_parity_evidence_uri   = ""
+final_import_evidence_uri   = ""
+backup_restore_evidence_uri = ""
+rollback_evidence_uri       = ""
+alert_evidence_uri          = ""

--- a/infra/azure/qqq-paper/variables.tf
+++ b/infra/azure/qqq-paper/variables.tf
@@ -9,13 +9,13 @@ variable "resource_suffix" {
 }
 
 variable "environment" {
-  description = "Phase 9 QQQ paper environment. P9-10 creates only the dev source contract."
+  description = "Phase 9 QQQ paper environment. P9-13 supports dev and paper-prod only."
   type        = string
   default     = "dev"
 
   validation {
-    condition     = var.environment == "dev"
-    error_message = "P9-10 only supports the dev QQQ paper environment."
+    condition     = contains(["dev", "paper-prod"], var.environment)
+    error_message = "environment must be either dev or paper-prod for Phase 9 QQQ paper."
   }
 }
 
@@ -72,6 +72,14 @@ variable "marketlab_image_digest" {
     )
     error_message = "marketlab_image_digest must be an immutable sha256 digest when create_jobs is true."
   }
+
+  validation {
+    condition = (
+      !var.create_jobs
+      || var.marketlab_image_digest != "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    error_message = "marketlab_image_digest must not be the placeholder digest when create_jobs is true."
+  }
 }
 
 variable "container_repository" {
@@ -122,16 +130,48 @@ variable "enable_scheduler_schedule" {
     condition     = !var.enable_scheduler_schedule || var.create_jobs
     error_message = "enable_scheduler_schedule requires create_jobs because the scheduled trigger belongs to the Container Apps Job."
   }
+
+  validation {
+    condition = (
+      !var.enable_scheduler_schedule
+      || (
+        var.environment == "paper-prod"
+        && var.enable_broker_secret_refs
+        && can(regex("^https://", var.p9_12_parity_evidence_uri))
+        && can(regex("^https://", var.final_import_evidence_uri))
+        && can(regex("^https://", var.backup_restore_evidence_uri))
+        && can(regex("^https://", var.rollback_evidence_uri))
+        && can(regex("^https://", var.alert_evidence_uri))
+      )
+    )
+    error_message = "enable_scheduler_schedule is allowed only for paper-prod after broker secret refs and all P9-13 evidence URIs are configured."
+  }
 }
 
 variable "enable_service_bus_approval_trigger" {
-  description = "Reserved approval-trigger switch. P9-10 keeps Service Bus-triggered jobs disabled."
+  description = "Explicit paper-prod launch-gate switch for Service Bus approval triggering."
   type        = bool
   default     = false
 
   validation {
-    condition     = !var.enable_service_bus_approval_trigger
-    error_message = "enable_service_bus_approval_trigger remains false in P9-10; P9-12 owns trigger activation evidence."
+    condition     = !var.enable_service_bus_approval_trigger || var.create_jobs
+    error_message = "enable_service_bus_approval_trigger requires create_jobs because the approval receiver belongs to the Container Apps Job set."
+  }
+
+  validation {
+    condition = (
+      !var.enable_service_bus_approval_trigger
+      || (
+        var.environment == "paper-prod"
+        && var.enable_broker_secret_refs
+        && can(regex("^https://", var.p9_12_parity_evidence_uri))
+        && can(regex("^https://", var.final_import_evidence_uri))
+        && can(regex("^https://", var.backup_restore_evidence_uri))
+        && can(regex("^https://", var.rollback_evidence_uri))
+        && can(regex("^https://", var.alert_evidence_uri))
+      )
+    )
+    error_message = "enable_service_bus_approval_trigger is allowed only for paper-prod after broker secret refs and all P9-13 evidence URIs are configured."
   }
 }
 
@@ -172,6 +212,11 @@ variable "alpaca_key_id_secret_id" {
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = !var.enable_broker_secret_refs || can(regex("^https://", var.alpaca_key_id_secret_id))
+    error_message = "alpaca_key_id_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true."
+  }
 }
 
 variable "alpaca_secret_key_secret_id" {
@@ -179,6 +224,11 @@ variable "alpaca_secret_key_secret_id" {
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = !var.enable_broker_secret_refs || can(regex("^https://", var.alpaca_secret_key_secret_id))
+    error_message = "alpaca_secret_key_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true."
+  }
 }
 
 variable "anthropic_api_key_secret_id" {
@@ -186,6 +236,11 @@ variable "anthropic_api_key_secret_id" {
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = !var.enable_broker_secret_refs || can(regex("^https://", var.anthropic_api_key_secret_id))
+    error_message = "anthropic_api_key_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true."
+  }
 }
 
 variable "telegram_bot_token_secret_id" {
@@ -193,6 +248,11 @@ variable "telegram_bot_token_secret_id" {
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = !var.enable_broker_secret_refs || can(regex("^https://", var.telegram_bot_token_secret_id))
+    error_message = "telegram_bot_token_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true."
+  }
 }
 
 variable "telegram_chat_id_secret_id" {
@@ -200,6 +260,81 @@ variable "telegram_chat_id_secret_id" {
   type        = string
   default     = ""
   sensitive   = true
+
+  validation {
+    condition     = !var.enable_broker_secret_refs || can(regex("^https://", var.telegram_chat_id_secret_id))
+    error_message = "telegram_chat_id_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true."
+  }
+}
+
+variable "p9_12_parity_evidence_uri" {
+  description = "Reviewed HTTPS URI for the accepted P9-12 parity and failure-drill evidence."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.p9_12_parity_evidence_uri == ""
+      || can(regex("^https://", var.p9_12_parity_evidence_uri))
+    )
+    error_message = "p9_12_parity_evidence_uri must be empty or an https URI."
+  }
+}
+
+variable "final_import_evidence_uri" {
+  description = "Reviewed HTTPS URI for the P9-13 final dry-run and apply import evidence."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.final_import_evidence_uri == ""
+      || can(regex("^https://", var.final_import_evidence_uri))
+    )
+    error_message = "final_import_evidence_uri must be empty or an https URI."
+  }
+}
+
+variable "backup_restore_evidence_uri" {
+  description = "Reviewed HTTPS URI for the accepted PostgreSQL and Blob backup/restore evidence."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.backup_restore_evidence_uri == ""
+      || can(regex("^https://", var.backup_restore_evidence_uri))
+    )
+    error_message = "backup_restore_evidence_uri must be empty or an https URI."
+  }
+}
+
+variable "rollback_evidence_uri" {
+  description = "Reviewed HTTPS URI for the accepted paper-prod rollback rehearsal evidence."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.rollback_evidence_uri == ""
+      || can(regex("^https://", var.rollback_evidence_uri))
+    )
+    error_message = "rollback_evidence_uri must be empty or an https URI."
+  }
+}
+
+variable "alert_evidence_uri" {
+  description = "Reviewed HTTPS URI for paper-prod alert evidence before trigger enablement."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.alert_evidence_uri == ""
+      || can(regex("^https://", var.alert_evidence_uri))
+    )
+    error_message = "alert_evidence_uri must be empty or an https URI."
+  }
 }
 
 variable "postgres_admin_login" {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Phase 9 P9-10 Worker Plan: phase9/P9-10-WORKER-PLAN.md
   - Phase 9 P9-11 Worker Plan: phase9/P9-11-WORKER-PLAN.md
   - Phase 9 P9-12 Worker Plan: phase9/P9-12-WORKER-PLAN.md
+  - Phase 9 P9-13 Worker Plan: phase9/P9-13-WORKER-PLAN.md
 plugins:
   - search
 extra_javascript:

--- a/tests/unit/test_phase9_azure_bootstrap.py
+++ b/tests/unit/test_phase9_azure_bootstrap.py
@@ -138,6 +138,7 @@ def test_operator_values_and_terraform_state_are_ignored() -> None:
     assert "*.tfstate" in ignored
     assert "*.tfstate.*" in ignored
     assert "**/backend.hcl" in ignored
+    assert "**/backend.paper-prod.hcl" in ignored
     assert "**/*.backend.hcl" in ignored
     assert "**/backend-*.hcl" in ignored
     assert "**/*.tfbackend" in ignored
@@ -413,6 +414,9 @@ def test_qqq_paper_azure_security_and_runtime_seams_are_locked() -> None:
         "dead_lettering_on_message_expiration = true",
         "configs/experiment.qqq_paper_daily.yaml",
         "passwordless PostgreSQL managed-identity authentication",
+        'key_vault_name = "kv-ml-qqq-${local.resource_name_env}-${var.resource_suffix}"',
+        "resource_name_env = var.environment == \"paper-prod\" ? \"prod\" : var.environment",
+        "QQQ paper Key Vault name must be 24 characters or fewer.",
     ]
     forbidden = [
         'resource "azurerm_container_app"',
@@ -454,6 +458,7 @@ def test_qqq_paper_prod_cutover_gates_are_locked() -> None:
     variables = _normalized(QQQ_PAPER / "variables.tf")
     tfvars = _normalized(QQQ_PAPER / "terraform.tfvars.example")
     runbook = _normalized(QQQ_PAPER / "README.md")
+    ignored = _normalized(ROOT / ".gitignore")
 
     required = [
         'contains(["dev", "paper-prod"], var.environment)',
@@ -475,3 +480,4 @@ def test_qqq_paper_prod_cutover_gates_are_locked() -> None:
     ]
 
     assert all(clause in variables or clause in tfvars or clause in runbook for clause in required)
+    assert "**/backend.paper-prod.hcl" in ignored

--- a/tests/unit/test_phase9_azure_bootstrap.py
+++ b/tests/unit/test_phase9_azure_bootstrap.py
@@ -158,6 +158,7 @@ def test_operator_values_and_terraform_state_are_ignored() -> None:
     assert (PHASE9_SHADOW / "terraform.tfvars.example").exists()
     assert (QQQ_PAPER / "backend.tf.example").exists()
     assert (QQQ_PAPER / "backend.hcl.example").exists()
+    assert (QQQ_PAPER / "backend.paper-prod.hcl.example").exists()
     assert (QQQ_PAPER / "terraform.tfvars.example").exists()
 
 
@@ -368,7 +369,10 @@ def test_qqq_paper_azure_jobs_and_triggers_default_disabled() -> None:
         "MARKETLAB_PAPER_RUNTIME_ENV_OVERRIDES",
         "MARKETLAB_PAPER_POSTGRES_DSN",
         "enable_scheduler_schedule requires create_jobs",
-        "enable_service_bus_approval_trigger remains false in P9-10",
+        "enable_service_bus_approval_trigger requires create_jobs",
+        "event_trigger_config",
+        'custom_rule_type = "azure-servicebus"',
+        "paper-service-bus-receive",
         "enable_broker_secret_refs",
         "postgres_firewall_rules",
         "create_jobs requires at least one operator-approved PostgreSQL firewall rule",
@@ -428,6 +432,7 @@ def test_qqq_paper_azure_security_and_runtime_seams_are_locked() -> None:
 def test_qqq_paper_backend_provider_and_tox_validation_are_locked() -> None:
     backend = _normalized(QQQ_PAPER / "backend.tf.example")
     backend_hcl = _normalized(QQQ_PAPER / "backend.hcl.example")
+    backend_prod_hcl = _normalized(QQQ_PAPER / "backend.paper-prod.hcl.example")
     versions = _normalized(QQQ_PAPER / "versions.tf")
     lock = _normalized(QQQ_PAPER / ".terraform.lock.hcl")
     tox = _normalized(ROOT / "tox.ini")
@@ -435,6 +440,7 @@ def test_qqq_paper_backend_provider_and_tox_validation_are_locked() -> None:
 
     assert 'backend "azurerm" { use_azuread_auth = true use_cli = true }' in backend
     assert "key = \"qqq-paper-dev.tfstate\"" in backend_hcl
+    assert "key = \"qqq-paper-prod.tfstate\"" in backend_prod_hcl
     assert 'required_version = "= 1.15.5"' in versions
     assert 'version = "~> 4.74.0"' in versions
     assert 'resource_provider_registrations = "none"' in versions
@@ -442,3 +448,30 @@ def test_qqq_paper_backend_provider_and_tox_validation_are_locked() -> None:
     assert "qqq-paper init -backend=false -lockfile=readonly -input=false" in tox
     assert "qqq-paper validate -no-color" in tox
     assert "infra/azure/qqq-paper/.terraform.lock.hcl" in workflow
+
+
+def test_qqq_paper_prod_cutover_gates_are_locked() -> None:
+    variables = _normalized(QQQ_PAPER / "variables.tf")
+    tfvars = _normalized(QQQ_PAPER / "terraform.tfvars.example")
+    runbook = _normalized(QQQ_PAPER / "README.md")
+
+    required = [
+        'contains(["dev", "paper-prod"], var.environment)',
+        "environment must be either dev or paper-prod",
+        "marketlab_image_digest must not be the placeholder digest when create_jobs is true",
+        "enable_scheduler_schedule is allowed only for paper-prod after broker secret refs and all P9-13 evidence URIs are configured",
+        "enable_service_bus_approval_trigger is allowed only for paper-prod after broker secret refs and all P9-13 evidence URIs are configured",
+        "p9_12_parity_evidence_uri",
+        "final_import_evidence_uri",
+        "backup_restore_evidence_uri",
+        "rollback_evidence_uri",
+        "alert_evidence_uri",
+        "alpaca_key_id_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true",
+        "anthropic_api_key_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true",
+        "telegram_bot_token_secret_id must be an https Key Vault secret ID when enable_broker_secret_refs is true",
+        "environment = \"paper-prod\"",
+        "qqq-paper-prod.tfstate",
+        "Do not commit the real backend file, tfvars, Terraform plan, Terraform state, DSN, Key Vault secret IDs, or live Azure identifiers.",
+    ]
+
+    assert all(clause in variables or clause in tfvars or clause in runbook for clause in required)

--- a/tests/unit/test_phase9_plan_docs.py
+++ b/tests/unit/test_phase9_plan_docs.py
@@ -16,6 +16,7 @@ P9_09_PLAN = ROOT / "docs" / "phase9" / "P9-09-WORKER-PLAN.md"
 P9_10_PLAN = ROOT / "docs" / "phase9" / "P9-10-WORKER-PLAN.md"
 P9_11_PLAN = ROOT / "docs" / "phase9" / "P9-11-WORKER-PLAN.md"
 P9_12_PLAN = ROOT / "docs" / "phase9" / "P9-12-WORKER-PLAN.md"
+P9_13_PLAN = ROOT / "docs" / "phase9" / "P9-13-WORKER-PLAN.md"
 
 
 def test_phase9_plan_replaces_obsolete_cloud_plan() -> None:
@@ -508,3 +509,48 @@ def test_p9_12_plan_is_linked_from_docs() -> None:
     assert "phase9/P9-12-WORKER-PLAN.md" in roadmap
     assert "Phase 9 P9-12 Worker Plan: phase9/P9-12-WORKER-PLAN.md" in nav
     assert "phase9/P9-12-WORKER-PLAN.md" in index
+
+
+def test_p9_13_plan_locks_paper_prod_cutover_scope() -> None:
+    content = P9_13_PLAN.read_text(encoding="utf-8")
+    paper_trading = (ROOT / "docs" / "paper-trading.md").read_text(encoding="utf-8")
+    normalized = " ".join(f"{content}\n{paper_trading}".split())
+
+    required = [
+        "feature/phase-9-qqq-paper-prod-cutover",
+        "feat(phase9): add QQQ paper-prod cutover gates",
+        "accepted P9-12 QQQ UAT parity and failure-drill evidence",
+        "does not stop the local scheduler",
+        "apply Terraform",
+        "enable Azure jobs",
+        "environment = \"paper-prod\"",
+        "create_jobs = true",
+        "enable_broker_secret_refs = true",
+        "enable_scheduler_schedule = true",
+        "enable_service_bus_approval_trigger = true",
+        "non-placeholder immutable image digest",
+        "P9-12 parity",
+        "final import",
+        "backup/restore",
+        "rollback",
+        "alert evidence",
+        "qqq-paper-prod.tfstate",
+        "paper-state-import --dry-run",
+        "paper-blob-sync",
+        "Service Bus approval trigger",
+        "no unresolved proposal or non-terminal order",
+        "P9-14 owns the ten-trading-day post-cutover observation window",
+        "QQQ strategy, approval semantics, Alpaca paper-only endpoint checks, VOO, BTC",
+    ]
+
+    assert all(term in normalized for term in required)
+
+
+def test_p9_13_plan_is_linked_from_docs() -> None:
+    roadmap = PLAN.read_text(encoding="utf-8")
+    nav = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "phase9/P9-13-WORKER-PLAN.md" in roadmap
+    assert "Phase 9 P9-13 Worker Plan: phase9/P9-13-WORKER-PLAN.md" in nav
+    assert "phase9/P9-13-WORKER-PLAN.md" in index


### PR DESCRIPTION
## Summary
- add the P9-13 worker plan and docs links for QQQ paper-prod cutover
- extend the QQQ Azure Terraform root with paper-prod launch gates and Service Bus event-trigger wiring
- document the operator cutover, smoke-test, first-cycle, and rollback runbooks
- add static docs and Terraform tests for the P9-13 contract

## Validation
- `py -3.14 -m pytest -q tests/unit/test_phase9_plan_docs.py tests/unit/test_phase9_azure_bootstrap.py --basetemp C:\Users\ricar\AppData\Local\Temp\marketlab_p9_13_pytest2` passed: 47 passed
- `python -m tox -e terraform` passed
- `python -m ruff check .` passed
- `python -m mkdocs build --strict` passed
- `git diff --check` passed with CRLF warnings only
- direct package build to fresh temp output passed

`py -3.14 -m tox -e preflight` passed lint, docs, typecheck, and unit tests, then hit Windows host locks in ignored generated paths (`dist/marketlab-0.2.0.tar.gz`, `artifacts/tmp/pytest-integration`).